### PR TITLE
some documentation formatting fixes

### DIFF
--- a/src/generated/file_properties.rs
+++ b/src/generated/file_properties.rs
@@ -11,17 +11,18 @@
 //!
 //! These endpoints enable you to tag arbitrary key/value data to Dropbox files.
 //!
-//! The most basic unit in this namespace is the [`PropertyField`](PropertyField). These fields
-//! encapsulate the actual key/value data.
+//! The most basic unit in this namespace is the [`PropertyField`](file_properties::PropertyField).
+//! These fields encapsulate the actual key/value data.
 //!
-//! Fields are added to a Dropbox file using a [`PropertyGroup`](PropertyGroup). Property groups
-//! contain a reference to a Dropbox file and a [`PropertyGroupTemplate`](PropertyGroupTemplate).
-//! Property groups are uniquely identified by the combination of their associated Dropbox file and
-//! template.
+//! Fields are added to a Dropbox file using a [`PropertyGroup`](file_properties::PropertyGroup).
+//! Property groups contain a reference to a Dropbox file and a
+//! [`PropertyGroupTemplate`](file_properties::PropertyGroupTemplate). Property groups are uniquely
+//! identified by the combination of their associated Dropbox file and template.
 //!
-//! The [`PropertyGroupTemplate`](PropertyGroupTemplate) is a way of restricting the possible key
-//! names and value types of the data within a property group. The possible key names and value
-//! types are explicitly enumerated using [`PropertyFieldTemplate`](PropertyFieldTemplate) objects.
+//! The [`PropertyGroupTemplate`](file_properties::PropertyGroupTemplate) is a way of restricting
+//! the possible key names and value types of the data within a property group. The possible key
+//! names and value types are explicitly enumerated using
+//! [`PropertyFieldTemplate`](file_properties::PropertyFieldTemplate) objects.
 //!
 //! You can think of a property group template as a class definition for a particular key/value
 //! metadata object, and the property groups themselves as the instantiations of these objects.

--- a/src/generated/files.rs
+++ b/src/generated/files.rs
@@ -525,11 +525,11 @@ pub fn get_thumbnail_batch(
 /// [`FolderSharingInfo::read_only`](FolderSharingInfo) and set all its children's read-only
 /// statuses to match. For each [`DeletedMetadata`](DeletedMetadata), if your local state has
 /// something at the given path, remove it and all its children. If there's nothing at the given
-/// path, ignore this entry. Note:
-/// [`auth::super::auth::RateLimitError`](super::auth::super::auth::RateLimitError) may be returned
-/// if multiple [`list_folder()`](list_folder) or [`list_folder_continue()`](list_folder_continue)
-/// calls with same parameters are made simultaneously by same API app for same user. If your app
-/// implements retry logic, please hold off the retry until the previous request finishes.
+/// path, ignore this entry. Note: [`auth::RateLimitError`](super::auth::RateLimitError) may be
+/// returned if multiple [`list_folder()`](list_folder) or
+/// [`list_folder_continue()`](list_folder_continue) calls with same parameters are made
+/// simultaneously by same API app for same user. If your app implements retry logic, please hold
+/// off the retry until the previous request finishes.
 pub fn list_folder(
     client: &dyn crate::client_trait::HttpClient,
     arg: &ListFolderArg,


### PR DESCRIPTION
1. File-scope doc comments (those starting with "//!") that refer to
types defined in the module need to have the link include the name of
the module, or rustdoc can't resolve the reference.
2. References to routes in another namespace were being generated with
multiple "super::" components in their path; instead, the human-visible
name should just be "namespace::route", and the link path needs to be
fixed to just "super::namespace::route".