### PR TITLE
[examples/demo] Fix bug in list_directory with non-root path

### DIFF
--- a/examples/demo.rs
+++ b/examples/demo.rs
@@ -168,9 +168,15 @@ fn list_directory<'a>(client: &'a dyn HttpClient, path: &str, recursive: bool)
     -> dropbox_sdk::Result<Result<DirectoryIterator<'a>, files::ListFolderError>>
 {
     assert!(path.starts_with('/'), "path needs to be absolute (start with a '/')");
+    let requested_path = if path == "/" {
+        // Root folder should be requested as empty string
+        String::new()
+    } else {
+        (&path[1..]).to_owned()
+    };
     match files::list_folder(
         client,
-        &files::ListFolderArg::new((&path[1..]).to_owned())
+        &files::ListFolderArg::new(requested_path)
             .with_recursive(recursive))
     {
         Ok(Ok(result)) => {


### PR DESCRIPTION
As written, the list_directories function in demo.rs could not be used
to list anything but the root directory. I stumpled upon this while
doing my own experimentation and copy & pasting code together from the
demo.

The fix is easy: if '/' is requested, query the empty string, otherwise
query the string as passed by the caller.