### PR TITLE
Avoid unnecessary roundtrip in list_directory.

### DIFF
--- a/examples/demo.rs
+++ b/examples/demo.rs
@@ -174,10 +174,16 @@ fn list_directory<'a>(client: &'a dyn HttpClient, path: &str, recursive: bool)
             .with_recursive(recursive))
     {
         Ok(Ok(result)) => {
+            let cursor = if result.has_more {
+                Some(result.cursor)
+            } else {
+                None;
+            };
+
             Ok(Ok(DirectoryIterator {
                 client,
+                cursor,
                 buffer: result.entries.into(),
-                cursor: Some(result.cursor),
             }))
         },
         Ok(Err(e)) => Ok(Err(e)),


### PR DESCRIPTION
If the first request for `list_folder` returned all entries, the `demo.rs` program will still do another request since it does not check `has_more` in the initial reply. This fixes this.