### PR TITLE
a couple small fixes to examples/demo

### DIFF
--- a/examples/demo.rs
+++ b/examples/demo.rs
@@ -129,6 +129,7 @@ fn main() {
                     eprintln!("Error: {}", request_error);
                 }
             }
+            break 'download;
         }
     } else {
         eprintln!("listing all files");


### PR DESCRIPTION
1. somehow the buffering inside a loop appears to cause a stack overflow on Windows. Replacing this with a call to `std::io::copy` fixes the issue (maybe by moving the buffer to another stack frame?), and is IMO more readable anyway.

2. having demo download a file that's not there will cause it to loop forever. The retry loop should default to breaking out at the end unless there's a read error.