### PR TITLE
Bring rust SDK more in line with recent SDK quality improvements

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,31 @@
+---
+name: "\U0001F41B Bug report"
+about: Create a report to help us improve the SDK
+title: ''
+labels: bug
+assignees: ''
+
+---
+
+**Describe the bug**
+A clear and concise description of the bug.
+
+**To Reproduce**
+The steps to reproduce the behavior
+
+**Expected Behavior**
+A clear description of what you expected to happen.
+
+**Actual Behavior**
+A clear description of what actually happened
+
+**Screenshots**
+If applicable, add screenshots to help explain your problem.
+
+**Versions**
+* What version of the SDK are you using?
+* What version of the language are you using?
+* What platform are you using? (if applicable)
+
+**Additional context**
+Add any other context about the problem here.

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,1 @@
+blank_issues_enabled: false

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,20 @@
+---
+name: "\U0001F680 Feature Request"
+about: Suggest an idea for this SDK
+title: ''
+labels: enhancement
+assignees: ''
+
+---
+
+**Why is this feature valuable to you? Does it solve a problem you're having?**
+A clear and concise description of why this feature is valuable. Ex. I'm always frustrated when [...]
+
+**Describe the solution you'd like**
+A clear and concise description of what you want to happen.
+
+**Describe alternatives you've considered**
+A clear and concise description of any alternative solutions or features you've considered. (if applicable)
+
+**Additional context**
+Add any other context or screenshots about the feature request here.

--- a/.github/ISSUE_TEMPLATE/question_help.md
+++ b/.github/ISSUE_TEMPLATE/question_help.md
@@ -1,0 +1,25 @@
+---
+name: "\U0001F4AC Questions / Help"
+about: Get help with issues you are experiencing
+title: ''
+labels: help-wanted, question
+assignees: ''
+
+---
+
+**Before you start**
+Have you checked StackOverflow, previous issues, and Dropbox Developer Forums for help?
+
+**What is your question?**
+A clear and concise description the question.
+
+**Screenshots**
+If applicable, add screenshots to help explain your question.
+
+**Versions**
+* What version of the SDK are you using?
+* What version of the language are you using?
+* What platform are you using? (if applicable)
+
+**Additional context**
+Add any other context about the question here.

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,16 @@
+# To get started with Dependabot version updates, you'll need to specify which
+# package ecosystems to update and where the package manifests are located.
+# Please see the documentation for all configuration options:
+# https://help.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
+
+version: 2
+updates:
+  - package-ecosystem: "cargo" # See documentation for possible values
+    directory: "/" # Location of package manifests
+    schedule:
+      interval: "daily"
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "daily"

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,17 @@
+<!--
+Thank you for your pull request. Please provide a description below.
+-->
+
+## **Checklist**
+<!-- For completed items, change [ ] to [x]. -->
+
+**General Contributing**
+- [ ] Have you read the Code of Conduct and signed the [CLA](https://opensource.dropbox.com/cla/)?
+
+**Is This a Code Change?**
+- [ ] Non-code related change (markdown/git settings etc)
+- [ ] SDK Code Change
+- [ ] Example/Test Code Change
+
+**Validation**
+{Add language specific validation steps i.e. how to build/test/documentation/etc}

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,5 @@
+# Dropbox Code Of Conduct
+
+*Dropbox believes that an inclusive development environment fosters greater technical achievement. To encourage a diverse group of contributors we've adopted this code of conduct.*
+
+Please read the Official Dropbox [Code of Conduct](https://opensource.dropbox.com/coc/) before contributing.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,25 @@
+# Contributing to the Dropbox SDK for Rust
+We value and rely on the feedback from our community. This comes in the form of bug reports, feature requests, and general guidance. We welcome your issues and pull requests and try our hardest to be timely in both response and resolution. Please read through this document before submitting issues or pull requests to ensure we have the necessary information to help you resolve your issue.
+
+## Filing Bug Reports
+You can file a bug report on the [GitHub Issues][issues] page.
+
+1. Search through existing issues to ensure that your issue has not been reported. If it is a common issue, there is likely already an issue.
+
+2. Please ensure you are using the latest version of the SDK. While this may be a valid issue, we only will fix bugs affecting the latest version and your bug may have been fixed in a newer version.
+
+3. Provide as much information as you can regarding the language version, SDK version, and any other relevant information about your environment so we can help resolve the issue as quickly as possible.
+
+## Submitting Pull Requests
+
+We are more than happy to recieve pull requests helping us improve the state of our SDK. You can open a new pull request on the [GitHub Pull Requests][pr] page.
+
+1. Please ensure that you have read the [License][license], [Code of Conduct][coc] and have signed the [Contributing License Agreement (CLA)][cla].
+
+2. Please add tests confirming the new functionality works. Pull requests will not be merged without passing continuous integration tests unless the pull requests aims to fix existing issues with these tests.
+
+[issues]: https://github.com/dropbox/dropbox-sdk-rust/issues
+[pr]: https://github.com/dropbox/dropbox-sdk-rust/pulls
+[coc]: https://github.com/dropbox/dropbox-sdk-rust/blob/master/CODE_OF_CONDUCT.md
+[license]: https://github.com/dropbox/dropbox-sdk-rust/blob/master/LICENSE
+[cla]: https://opensource.dropbox.com/cla/

--- a/README.md
+++ b/README.md
@@ -20,7 +20,8 @@ This SDK is not yet official. What does this mean?
 
 However, that said,
 * The SDK is usable!
-* We are happy to get feedback and/or pull requests from the community!
+* We are happy to get feedback and/or pull requests from the community! See..
+[CONTRIBUTING.md][contributing] for more information.
 
 ## A Note on Semver
 

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ This SDK is not yet official. What does this mean?
 
 However, that said,
 * The SDK is usable!
-* We are happy to get feedback and/or pull requests from the community! See..
+* We are happy to get feedback and/or pull requests from the community! See
 [CONTRIBUTING.md][contributing] for more information.
 
 ## A Note on Semver
@@ -124,3 +124,5 @@ Some implementation notes, limitations, and TODOs:
    tests for all variants.
 
 ## Happy Dropboxing!
+
+[contributing]: https://github.com/dropbox/dropbox-sdk-rust/blob/master/CONTRIBUTING.md


### PR DESCRIPTION
This makes the SDK look at bit more like the official SDK-related repos. See
* https://github.com/dropbox/dropbox-sdk-python
* https://github.com/dropbox/dropbox-sdk-dotnet
* https://github.com/dropbox/stone

We can also set up a workflow to automatically update the spec / create PRs if someone is able to regularly merge them.