### PR TITLE
Implement authenticaiton types (User/Team/Noauth) and general overhaul of the HTTP client code.

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,32 +36,29 @@ version targeted, which is most easily done by looking at what revision the
 ## HTTP Client
 
 To actually use the API calls, you need a HTTP client -- all functions take a
-`&HttpClient` as their first argument.  This trait is located at
-`dropbox_sdk::client_trait::HttpClient`. Implement this trait and pass it as
-the client argument.
+type that implements `HttpClient` as their first argument.  This trait is
+located at `dropbox_sdk::client_trait::HttpClient`. Implement this trait and
+pass it as the client argument.
 
 If you don't want to implement your own, this SDK comes with an optional
 default client that uses Hyper and your system's native TLS library.  To use
 it, build with the `hyper_client` feature flag, and then there will be a
-`dropbox_sdk::hyper_client::HyperClient` type that you can use.  The default
-Hyper client needs a Dropbox API token; how you get one is up to you and your
-program.
+set of clents in the `dropbox_sdk::hyper_client` module that you can use,
+corresponding to each of the authentication types Dropbox uses (see below). The
+default Hyper client needs a Dropbox API token; how you get one is up to you
+and your program. See the programs under [examples/](examples/) for examples.
 
 ## Authentication Types
 
-The Dropbox API has a number of different [authentication types]. This SDK
-supports the User, Team, and No Authentication types, but does not yet
-support App Authentication.
+The Dropbox API has a number of different [authentication types]. Each route
+requires a HTTP client compatible with the specific authentication type needed.
+The authentication type is designated by implementing a marker trait in
+addition to the base `HttpClient` trait: one of `NoauthClient`,
+`UserAuthClient`, `TeamAuthClient`, or `AppAuthClient`.
 
-The default HTTP client currently makes no distinction between User and Team
-authentication, and for Team authentication, it does not support selection of
-an admin user, or team member impersonation. If you need this functionality,
-you could implement it with a custom HTTP client (so you can add the desired
-`Dropbox-API-Select-User` or `Dropbox-API-Select-Admin` header), or submit a
-feature request and we may implement support for it in the future.
-
-To switch between User and Team auth contexts, construct a separate HTTP client
-for each type of token, and switch which client is used with the function call.
+The default Hyper client has implementations of all of these (except for
+`AppAuthClient` currently). They all share a common implementation and differ
+only in which HTTP headers they add to the request.
 
 [authentication types]: https://www.dropbox.com/developers/reference/auth-types
 

--- a/README.md
+++ b/README.md
@@ -46,7 +46,8 @@ it, build with the `hyper_client` feature flag, and then there will be a
 set of clents in the `dropbox_sdk::hyper_client` module that you can use,
 corresponding to each of the authentication types Dropbox uses (see below). The
 default Hyper client needs a Dropbox API token; how you get one is up to you
-and your program. See the programs under [examples/](examples/) for examples.
+and your program. See the programs under [examples/](examples/) for examples,
+and see the helper code in the [oauth2](src/oauth2.rs) module.
 
 ## Authentication Types
 

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ This SDK is not yet official. What does this mean?
 However, that said,
 * The SDK is usable!
 * We are happy to get feedback and/or pull requests from the community! See
-[CONTRIBUTING.md][contributing] for more information.
+[contributing](CONTRIBUTING.md) for more information.
 
 ## A Note on Semver
 
@@ -46,6 +46,24 @@ it, build with the `hyper_client` feature flag, and then there will be a
 `dropbox_sdk::hyper_client::HyperClient` type that you can use.  The default
 Hyper client needs a Dropbox API token; how you get one is up to you and your
 program.
+
+## Authentication Types
+
+The Dropbox API has a number of different [authentication types]. This SDK
+supports the User, Team, and No Authentication types, but does not yet
+support App Authentication.
+
+The default HTTP client currently makes no distinction between User and Team
+authentication, and for Team authentication, it does not support selection of
+an admin user, or team member impersonation. If you need this functionality,
+you could implement it with a custom HTTP client (so you can add the desired
+`Dropbox-API-Select-User` or `Dropbox-API-Select-Admin` header), or submit a
+feature request and we may implement support for it in the future.
+
+To switch between User and Team auth contexts, construct a separate HTTP client
+for each type of token, and switch which client is used with the function call.
+
+[authentication types]: https://www.dropbox.com/developers/reference/auth-types
 
 ## Feature Flags
 
@@ -124,5 +142,3 @@ Some implementation notes, limitations, and TODOs:
    tests for all variants.
 
 ## Happy Dropboxing!
-
-[contributing]: https://github.com/dropbox/dropbox-sdk-rust/blob/master/CONTRIBUTING.md

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -4,6 +4,10 @@ yyyy-mm-dd
   * `HyperClient` is now `UserAuthHyperClient`.
   * API methods now take a different type of client for their first argument, depending on the auth
     type they require.
+* Moved OAuth2 helper code out of hyper_client and made it independent of the HTTP client used, so
+  users of custom HTTP clients don't have to reinvent the wheel for OAuth2.
+  * The `oauth2_token_from_authorization_code` now is in a different module, and takes a HTTP
+    client implementation as a new first argument.
 
 # v0.6.0
 2020-09-24

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,3 +1,10 @@
+# v0.7.0
+yyyy-mm-dd
+* Implemented support for different authentication types.
+  * `HyperClient` is now `UserAuthHyperClient`.
+  * API methods now take a different type of client for their first argument, depending on the auth
+    type they require.
+
 # v0.6.0
 2020-09-24
 * API update

--- a/examples/demo.rs
+++ b/examples/demo.rs
@@ -1,8 +1,9 @@
 #![deny(rust_2018_idioms)]
 
 use dropbox_sdk::{files, UserAuthClient};
-use dropbox_sdk::hyper_client::{oauth2_token_from_authorization_code, Oauth2AuthorizeUrlBuilder,
-    Oauth2Type, UserAuthHyperClient};
+use dropbox_sdk::oauth2::{oauth2_token_from_authorization_code, Oauth2AuthorizeUrlBuilder,
+    Oauth2Type};
+use dropbox_sdk::hyper_client::{NoauthHyperClient, UserAuthHyperClient};
 
 use std::collections::VecDeque;
 use std::env;
@@ -68,7 +69,7 @@ fn main() {
 
         eprintln!("requesting OAuth2 token");
         match oauth2_token_from_authorization_code(
-            &client_id, &client_secret, auth_code.trim(), None)
+            NoauthHyperClient::default(), &client_id, &client_secret, auth_code.trim(), None)
         {
             Ok(token) => {
                 eprintln!("got token: {}", token);

--- a/examples/large-file-upload.rs
+++ b/examples/large-file-upload.rs
@@ -1,8 +1,9 @@
 #![deny(rust_2018_idioms)]
 
-use dropbox_sdk::hyper_client::{oauth2_token_from_authorization_code, UserAuthHyperClient,
-    Oauth2AuthorizeUrlBuilder, Oauth2Type};
+use dropbox_sdk::oauth2::{oauth2_token_from_authorization_code, Oauth2AuthorizeUrlBuilder,
+    Oauth2Type};
 use dropbox_sdk::files;
+use dropbox_sdk::hyper_client::{NoauthHyperClient, UserAuthHyperClient};
 
 use std::fs::File;
 use std::path::PathBuf;
@@ -161,7 +162,7 @@ fn main() {
 
         eprintln!("requesting OAuth2 token");
         match oauth2_token_from_authorization_code(
-            &client_id, &client_secret, auth_code.trim(), None)
+            NoauthHyperClient::default(), &client_id, &client_secret, auth_code.trim(), None)
         {
             Ok(token) => {
                 eprintln!("got token: {}", token);

--- a/examples/large-file-upload.rs
+++ b/examples/large-file-upload.rs
@@ -1,6 +1,7 @@
 #![deny(rust_2018_idioms)]
 
-use dropbox_sdk::{HyperClient, Oauth2AuthorizeUrlBuilder, Oauth2Type};
+use dropbox_sdk::hyper_client::{oauth2_token_from_authorization_code, UserAuthHyperClient,
+    Oauth2AuthorizeUrlBuilder, Oauth2Type};
 use dropbox_sdk::files;
 
 use std::fs::File;
@@ -159,7 +160,7 @@ fn main() {
         let auth_code = prompt("Then paste the code here");
 
         eprintln!("requesting OAuth2 token");
-        match HyperClient::oauth2_token_from_authorization_code(
+        match oauth2_token_from_authorization_code(
             &client_id, &client_secret, auth_code.trim(), None)
         {
             Ok(token) => {
@@ -173,7 +174,7 @@ fn main() {
         }
     });
 
-    let client = HyperClient::new(token);
+    let client = UserAuthHyperClient::new(token);
 
     // Figure out if destination is a folder or not and change the destination path accordingly.
     let dest_path = match files::get_metadata(

--- a/src/client_helpers.rs
+++ b/src/client_helpers.rs
@@ -81,7 +81,8 @@ pub fn request_with_body<T: DeserializeOwned, E: DeserializeOwned + Debug, P: Se
     range_end: Option<u64>,
 ) -> crate::Result<Result<HttpRequestResult<T>, E>> {
     let params_json = serde_json::to_string(params)?;
-    let result = client.request(endpoint, style, function, params_json, body, range_start, range_end);
+    let result = client.request(endpoint, style, function, params_json, ParamsType::Json, body,
+        range_start, range_end);
     match result {
         Ok(HttpRequestResultRaw { result_json, content_length, body }) => {
             debug!("json: {}", result_json);

--- a/src/client_helpers.rs
+++ b/src/client_helpers.rs
@@ -71,10 +71,9 @@ impl<'de, T: DeserializeOwned> Deserialize<'de> for TopLevelError<T> {
 /// response and the body stream (if any).
 #[allow(clippy::too_many_arguments)]
 pub fn request_with_body<T: DeserializeOwned, E: DeserializeOwned + Debug, P: Serialize>(
-    client: &dyn HttpClient,
+    client: &impl HttpClient,
     endpoint: Endpoint,
     style: Style,
-    auth: Auth,
     function: &str,
     params: &P,
     body: Option<&[u8]>,
@@ -82,7 +81,7 @@ pub fn request_with_body<T: DeserializeOwned, E: DeserializeOwned + Debug, P: Se
     range_end: Option<u64>,
 ) -> crate::Result<Result<HttpRequestResult<T>, E>> {
     let params_json = serde_json::to_string(params)?;
-    let result = client.request(endpoint, style, auth, function, params_json, body, range_start, range_end);
+    let result = client.request(endpoint, style, function, params_json, body, range_start, range_end);
     match result {
         Ok(HttpRequestResultRaw { result_json, content_length, body }) => {
             debug!("json: {}", result_json);
@@ -146,14 +145,13 @@ pub fn request_with_body<T: DeserializeOwned, E: DeserializeOwned + Debug, P: Se
 }
 
 pub fn request<T: DeserializeOwned, E: DeserializeOwned + Debug, P: Serialize>(
-    client: &dyn HttpClient,
+    client: &impl HttpClient,
     endpoint: Endpoint,
     style: Style,
-    auth: Auth,
     function: &str,
     params: &P,
     body: Option<&[u8]>,
 ) -> crate::Result<Result<T, E>> {
-    request_with_body(client, endpoint, style, auth, function, params, body, None, None)
+    request_with_body(client, endpoint, style, function, params, body, None, None)
         .map(|result| result.map(|HttpRequestResult { result, .. }| result))
 }

--- a/src/client_helpers.rs
+++ b/src/client_helpers.rs
@@ -74,6 +74,7 @@ pub fn request_with_body<T: DeserializeOwned, E: DeserializeOwned + Debug, P: Se
     client: &dyn HttpClient,
     endpoint: Endpoint,
     style: Style,
+    auth: Auth,
     function: &str,
     params: &P,
     body: Option<&[u8]>,
@@ -81,7 +82,7 @@ pub fn request_with_body<T: DeserializeOwned, E: DeserializeOwned + Debug, P: Se
     range_end: Option<u64>,
 ) -> crate::Result<Result<HttpRequestResult<T>, E>> {
     let params_json = serde_json::to_string(params)?;
-    let result = client.request(endpoint, style, function, params_json, body, range_start, range_end);
+    let result = client.request(endpoint, style, auth, function, params_json, body, range_start, range_end);
     match result {
         Ok(HttpRequestResultRaw { result_json, content_length, body }) => {
             debug!("json: {}", result_json);
@@ -148,10 +149,11 @@ pub fn request<T: DeserializeOwned, E: DeserializeOwned + Debug, P: Serialize>(
     client: &dyn HttpClient,
     endpoint: Endpoint,
     style: Style,
+    auth: Auth,
     function: &str,
     params: &P,
     body: Option<&[u8]>,
 ) -> crate::Result<Result<T, E>> {
-    request_with_body(client, endpoint, style, function, params, body, None, None)
+    request_with_body(client, endpoint, style, auth, function, params, body, None, None)
         .map(|result| result.map(|HttpRequestResult { result, .. }| result))
 }

--- a/src/client_trait.rs
+++ b/src/client_trait.rs
@@ -10,7 +10,6 @@ pub trait HttpClient {
         &self,
         endpoint: Endpoint,
         style: Style,
-        auth: Auth,
         function: &str,
         params_json: String,
         body: Option<&[u8]>,
@@ -18,6 +17,23 @@ pub trait HttpClient {
         range_end: Option<u64>,
     ) -> crate::Result<HttpRequestResultRaw>;
 }
+
+/// Marker trait to indicate that a HTTP client supports unauthenticated routes.
+pub trait NoauthClient: HttpClient {}
+
+/// Marker trait to indicate that a HTTP client supports User authentication.
+/// Team authentication works by adding a `Authorization: Bearer <TOKEN>` header.
+pub trait UserAuthClient: HttpClient {}
+
+/// Marker trait to indicate that a HTTP client supports Team authentication.
+/// Team authentication works by adding a `Authorization: Bearer <TOKEN>` header, and optionally a
+/// `Dropbox-API-Select-Admin` or `Dropbox-API-Select-User` header.
+pub trait TeamAuthClient: HttpClient {}
+
+/// Marker trait to indicate that a HTTP client supports App authentication.
+/// App authentication works by adding a `Authorization: Basic <base64(APP_KEY:APP_SECRET)>` header
+/// to the HTTP request.
+pub trait AppAuthClient: HttpClient {}
 
 pub struct HttpRequestResultRaw {
     pub result_json: String,
@@ -43,23 +59,6 @@ pub enum Style {
     Rpc,
     Upload,
     Download,
-}
-
-#[derive(Debug, Copy, Clone, PartialEq)]
-pub enum Auth {
-    /// No authentication needed.
-    Noauth,
-
-    /// Either User or Team. Send a 'Authorization: Bearer <TOKEN>' header.
-    Token,
-
-    // TODO: not supported yet.
-    // At least one route exists that can be used with both user and app auth, so we'd need some
-    // way to let callers select between the two. See `files/get_thumbnail:2`.
-    /*
-    /// App authorization, Send a 'Authorization: Basic <base64(KEY:SECRET)>' header.
-    App,
-    */
 }
 
 impl Endpoint {

--- a/src/client_trait.rs
+++ b/src/client_trait.rs
@@ -10,6 +10,7 @@ pub trait HttpClient {
         &self,
         endpoint: Endpoint,
         style: Style,
+        auth: Auth,
         function: &str,
         params_json: String,
         body: Option<&[u8]>,
@@ -42,6 +43,23 @@ pub enum Style {
     Rpc,
     Upload,
     Download,
+}
+
+#[derive(Debug, Copy, Clone, PartialEq)]
+pub enum Auth {
+    /// No authentication needed.
+    Noauth,
+
+    /// Either User or Team. Send a 'Authorization: Bearer <TOKEN>' header.
+    Token,
+
+    // TODO: not supported yet.
+    // At least one route exists that can be used with both user and app auth, so we'd need some
+    // way to let callers select between the two. See `files/get_thumbnail:2`.
+    /*
+    /// App authorization, Send a 'Authorization: Basic <base64(KEY:SECRET)>' header.
+    App,
+    */
 }
 
 impl Endpoint {

--- a/src/client_trait.rs
+++ b/src/client_trait.rs
@@ -12,7 +12,8 @@ pub trait HttpClient {
         endpoint: Endpoint,
         style: Style,
         function: &str,
-        params_json: String,
+        params: String,
+        params_type: ParamsType,
         body: Option<&[u8]>,
         range_start: Option<u64>,
         range_end: Option<u64>,
@@ -58,6 +59,18 @@ pub enum Endpoint {
     Api,
     Content,
     Notify,
+    OAuth2,
+}
+
+impl Endpoint {
+    pub fn url(self) -> &'static str {
+        match self {
+            Endpoint::Api => "https://api.dropboxapi.com/2/",
+            Endpoint::Content => "https://content.dropboxapi.com/2/",
+            Endpoint::Notify => "https://notify.dropboxapi.com/2/",
+            Endpoint::OAuth2 => "https://api.dropboxapi.com/", // note no '2/'
+        }
+    }
 }
 
 /// The style of a request, which determines how arguments are passed, and whether there is a
@@ -77,12 +90,22 @@ pub enum Style {
     Download,
 }
 
-impl Endpoint {
-    pub fn url(self) -> &'static str {
+/// The format of arguments being sent in a request.
+#[derive(Debug, Copy, Clone, PartialEq)]
+pub enum ParamsType {
+    /// JSON.
+    Json,
+
+    /// WWW Form URL-encoded. Only used for OAuth2 requests.
+    Form,
+}
+
+impl ParamsType {
+    /// The value for the HTTP Content-Type header for the given params format.
+    pub fn content_type(self) -> &'static str {
         match self {
-            Endpoint::Api => "https://api.dropboxapi.com/2/",
-            Endpoint::Content => "https://content.dropboxapi.com/2/",
-            Endpoint::Notify => "https://notify.dropboxapi.com/2/",
+            ParamsType::Json => "text/json",
+            ParamsType::Form => "application/x-www-form-urlencoded",
         }
     }
 }

--- a/src/client_trait.rs
+++ b/src/client_trait.rs
@@ -1,9 +1,10 @@
-// Copyright (c) 2019 Dropbox, Inc.
+// Copyright (c) 2019-2020 Dropbox, Inc.
 
 //! Everything needed to implement your HTTP client.
 
 use std::io::Read;
 
+/// The base HTTP client trait.
 pub trait HttpClient {
     #[allow(clippy::too_many_arguments)]
     fn request(
@@ -35,18 +36,23 @@ pub trait TeamAuthClient: HttpClient {}
 /// to the HTTP request.
 pub trait AppAuthClient: HttpClient {}
 
+/// The raw response from the server, containing the result from either a header or the body, as
+/// appropriate to the request style, and a body stream if it is from a Download style request.
 pub struct HttpRequestResultRaw {
     pub result_json: String,
     pub content_length: Option<u64>,
     pub body: Option<Box<dyn Read>>,
 }
 
+/// The response from the server, parsed into a given type, including a body stream if it is from
+/// a Download style request.
 pub struct HttpRequestResult<T> {
     pub result: T,
     pub content_length: Option<u64>,
     pub body: Option<Box<dyn Read>>,
 }
 
+/// The API base endpoint for a request. Determines which hostname the request should go to.
 #[derive(Debug, Copy, Clone, PartialEq)]
 pub enum Endpoint {
     Api,
@@ -54,10 +60,20 @@ pub enum Endpoint {
     Notify,
 }
 
+/// The style of a request, which determines how arguments are passed, and whether there is a
+/// request and/or response body.
 #[derive(Debug, Copy, Clone, PartialEq)]
 pub enum Style {
+    /// Arguments are passed in the request body; response is in the body; no request or response
+    /// body content stream.
     Rpc,
+
+    /// Arguments are passed in a HTTP header; response is in the body; request body is the upload
+    /// content; no response body content stream.
     Upload,
+
+    /// Arguments are passed in a HTTP header; response is in a HTTP header; no request content
+    /// body; response body contains the content stream.
     Download,
 }
 

--- a/src/client_trait.rs
+++ b/src/client_trait.rs
@@ -86,3 +86,23 @@ impl Endpoint {
         }
     }
 }
+
+/// Used with Team Authentication to select a user context within that team.
+#[derive(Debug, Clone)]
+pub enum TeamSelect {
+    /// A team member's user ID.
+    User(String),
+
+    /// A team admin's user ID, which grants additional access.
+    Admin(String),
+}
+
+impl TeamSelect {
+    /// The name of the HTTP header that must be set.
+    pub fn header_name(&self) -> &'static str {
+        match self {
+            TeamSelect::User(_) => "Dropbox-API-Select-User",
+            TeamSelect::Admin(_) => "Dropbox-API-Select-Admin",
+        }
+    }
+}

--- a/src/generated/account.rs
+++ b/src/generated/account.rs
@@ -16,6 +16,7 @@ pub fn set_profile_photo(
         client,
         crate::client_trait::Endpoint::Api,
         crate::client_trait::Style::Rpc,
+        crate::client_trait::Auth::Token,
         "account/set_profile_photo",
         arg,
         None)

--- a/src/generated/account.rs
+++ b/src/generated/account.rs
@@ -9,14 +9,13 @@
 
 /// Sets a user's profile photo.
 pub fn set_profile_photo(
-    client: &dyn crate::client_trait::HttpClient,
+    client: &impl crate::client_trait::UserAuthClient,
     arg: &SetProfilePhotoArg,
 ) -> crate::Result<Result<SetProfilePhotoResult, SetProfilePhotoError>> {
     crate::client_helpers::request(
         client,
         crate::client_trait::Endpoint::Api,
         crate::client_trait::Style::Rpc,
-        crate::client_trait::Auth::Token,
         "account/set_profile_photo",
         arg,
         None)

--- a/src/generated/auth.rs
+++ b/src/generated/auth.rs
@@ -7,20 +7,6 @@
     clippy::doc_markdown,
 )]
 
-/// Creates an OAuth 2.0 access token from the supplied OAuth 1.0 access token.
-pub fn token_from_oauth1(
-    client: &dyn crate::client_trait::HttpClient,
-    arg: &TokenFromOAuth1Arg,
-) -> crate::Result<Result<TokenFromOAuth1Result, TokenFromOAuth1Error>> {
-    crate::client_helpers::request(
-        client,
-        crate::client_trait::Endpoint::Api,
-        crate::client_trait::Style::Rpc,
-        "auth/token/from_oauth1",
-        arg,
-        None)
-}
-
 /// Disables the access token used to authenticate the call.
 pub fn token_revoke(
     client: &dyn crate::client_trait::HttpClient,
@@ -29,6 +15,7 @@ pub fn token_revoke(
         client,
         crate::client_trait::Endpoint::Api,
         crate::client_trait::Style::Rpc,
+        crate::client_trait::Auth::Token,
         "auth/token/revoke",
         &(),
         None)

--- a/src/generated/auth.rs
+++ b/src/generated/auth.rs
@@ -7,15 +7,28 @@
     clippy::doc_markdown,
 )]
 
+/// Creates an OAuth 2.0 access token from the supplied OAuth 1.0 access token.
+pub fn token_from_oauth1(
+    client: &impl crate::client_trait::AppAuthClient,
+    arg: &TokenFromOAuth1Arg,
+) -> crate::Result<Result<TokenFromOAuth1Result, TokenFromOAuth1Error>> {
+    crate::client_helpers::request(
+        client,
+        crate::client_trait::Endpoint::Api,
+        crate::client_trait::Style::Rpc,
+        "auth/token/from_oauth1",
+        arg,
+        None)
+}
+
 /// Disables the access token used to authenticate the call.
 pub fn token_revoke(
-    client: &dyn crate::client_trait::HttpClient,
+    client: &impl crate::client_trait::UserAuthClient,
 ) -> crate::Result<Result<(), ()>> {
     crate::client_helpers::request(
         client,
         crate::client_trait::Endpoint::Api,
         crate::client_trait::Style::Rpc,
-        crate::client_trait::Auth::Token,
         "auth/token/revoke",
         &(),
         None)

--- a/src/generated/check.rs
+++ b/src/generated/check.rs
@@ -7,19 +7,36 @@
     clippy::doc_markdown,
 )]
 
-/// This endpoint performs User Authentication, validating the supplied access token, and returns
-/// the supplied string, to allow you to test your code and connection to the Dropbox API. It has no
-/// other effect. If you receive an HTTP 200 response with the supplied query, it indicates at least
-/// part of the Dropbox API infrastructure is working and that the access token is valid.
-pub fn user(
-    client: &dyn crate::client_trait::HttpClient,
+/// This endpoint performs App Authentication, validating the supplied app key and secret, and
+/// returns the supplied string, to allow you to test your code and connection to the Dropbox API.
+/// It has no other effect. If you receive an HTTP 200 response with the supplied query, it
+/// indicates at least part of the Dropbox API infrastructure is working and that the app key and
+/// secret valid.
+pub fn app(
+    client: &impl crate::client_trait::AppAuthClient,
     arg: &EchoArg,
 ) -> crate::Result<Result<EchoResult, ()>> {
     crate::client_helpers::request(
         client,
         crate::client_trait::Endpoint::Api,
         crate::client_trait::Style::Rpc,
-        crate::client_trait::Auth::Token,
+        "check/app",
+        arg,
+        None)
+}
+
+/// This endpoint performs User Authentication, validating the supplied access token, and returns
+/// the supplied string, to allow you to test your code and connection to the Dropbox API. It has no
+/// other effect. If you receive an HTTP 200 response with the supplied query, it indicates at least
+/// part of the Dropbox API infrastructure is working and that the access token is valid.
+pub fn user(
+    client: &impl crate::client_trait::UserAuthClient,
+    arg: &EchoArg,
+) -> crate::Result<Result<EchoResult, ()>> {
+    crate::client_helpers::request(
+        client,
+        crate::client_trait::Endpoint::Api,
+        crate::client_trait::Style::Rpc,
         "check/user",
         arg,
         None)

--- a/src/generated/check.rs
+++ b/src/generated/check.rs
@@ -7,24 +7,6 @@
     clippy::doc_markdown,
 )]
 
-/// This endpoint performs App Authentication, validating the supplied app key and secret, and
-/// returns the supplied string, to allow you to test your code and connection to the Dropbox API.
-/// It has no other effect. If you receive an HTTP 200 response with the supplied query, it
-/// indicates at least part of the Dropbox API infrastructure is working and that the app key and
-/// secret valid.
-pub fn app(
-    client: &dyn crate::client_trait::HttpClient,
-    arg: &EchoArg,
-) -> crate::Result<Result<EchoResult, ()>> {
-    crate::client_helpers::request(
-        client,
-        crate::client_trait::Endpoint::Api,
-        crate::client_trait::Style::Rpc,
-        "check/app",
-        arg,
-        None)
-}
-
 /// This endpoint performs User Authentication, validating the supplied access token, and returns
 /// the supplied string, to allow you to test your code and connection to the Dropbox API. It has no
 /// other effect. If you receive an HTTP 200 response with the supplied query, it indicates at least
@@ -37,6 +19,7 @@ pub fn user(
         client,
         crate::client_trait::Endpoint::Api,
         crate::client_trait::Style::Rpc,
+        crate::client_trait::Auth::Token,
         "check/user",
         arg,
         None)

--- a/src/generated/contacts.rs
+++ b/src/generated/contacts.rs
@@ -16,6 +16,7 @@ pub fn delete_manual_contacts(
         client,
         crate::client_trait::Endpoint::Api,
         crate::client_trait::Style::Rpc,
+        crate::client_trait::Auth::Token,
         "contacts/delete_manual_contacts",
         &(),
         None)
@@ -30,6 +31,7 @@ pub fn delete_manual_contacts_batch(
         client,
         crate::client_trait::Endpoint::Api,
         crate::client_trait::Style::Rpc,
+        crate::client_trait::Auth::Token,
         "contacts/delete_manual_contacts_batch",
         arg,
         None)

--- a/src/generated/contacts.rs
+++ b/src/generated/contacts.rs
@@ -10,13 +10,12 @@
 /// Removes all manually added contacts. You'll still keep contacts who are on your team or who you
 /// imported. New contacts will be added when you share.
 pub fn delete_manual_contacts(
-    client: &dyn crate::client_trait::HttpClient,
+    client: &impl crate::client_trait::UserAuthClient,
 ) -> crate::Result<Result<(), ()>> {
     crate::client_helpers::request(
         client,
         crate::client_trait::Endpoint::Api,
         crate::client_trait::Style::Rpc,
-        crate::client_trait::Auth::Token,
         "contacts/delete_manual_contacts",
         &(),
         None)
@@ -24,14 +23,13 @@ pub fn delete_manual_contacts(
 
 /// Removes manually added contacts from the given list.
 pub fn delete_manual_contacts_batch(
-    client: &dyn crate::client_trait::HttpClient,
+    client: &impl crate::client_trait::UserAuthClient,
     arg: &DeleteManualContactsArg,
 ) -> crate::Result<Result<(), DeleteManualContactsError>> {
     crate::client_helpers::request(
         client,
         crate::client_trait::Endpoint::Api,
         crate::client_trait::Style::Rpc,
-        crate::client_trait::Auth::Token,
         "contacts/delete_manual_contacts_batch",
         arg,
         None)

--- a/src/generated/file_properties.rs
+++ b/src/generated/file_properties.rs
@@ -55,6 +55,7 @@ pub fn properties_add(
         client,
         crate::client_trait::Endpoint::Api,
         crate::client_trait::Style::Rpc,
+        crate::client_trait::Auth::Token,
         "file_properties/properties/add",
         arg,
         None)
@@ -73,6 +74,7 @@ pub fn properties_overwrite(
         client,
         crate::client_trait::Endpoint::Api,
         crate::client_trait::Style::Rpc,
+        crate::client_trait::Auth::Token,
         "file_properties/properties/overwrite",
         arg,
         None)
@@ -92,6 +94,7 @@ pub fn properties_remove(
         client,
         crate::client_trait::Endpoint::Api,
         crate::client_trait::Style::Rpc,
+        crate::client_trait::Auth::Token,
         "file_properties/properties/remove",
         arg,
         None)
@@ -106,6 +109,7 @@ pub fn properties_search(
         client,
         crate::client_trait::Endpoint::Api,
         crate::client_trait::Style::Rpc,
+        crate::client_trait::Auth::Token,
         "file_properties/properties/search",
         arg,
         None)
@@ -121,6 +125,7 @@ pub fn properties_search_continue(
         client,
         crate::client_trait::Endpoint::Api,
         crate::client_trait::Style::Rpc,
+        crate::client_trait::Auth::Token,
         "file_properties/properties/search/continue",
         arg,
         None)
@@ -140,6 +145,7 @@ pub fn properties_update(
         client,
         crate::client_trait::Endpoint::Api,
         crate::client_trait::Style::Rpc,
+        crate::client_trait::Auth::Token,
         "file_properties/properties/update",
         arg,
         None)
@@ -155,6 +161,7 @@ pub fn templates_add_for_team(
         client,
         crate::client_trait::Endpoint::Api,
         crate::client_trait::Style::Rpc,
+        crate::client_trait::Auth::Token,
         "file_properties/templates/add_for_team",
         arg,
         None)
@@ -170,6 +177,7 @@ pub fn templates_add_for_user(
         client,
         crate::client_trait::Endpoint::Api,
         crate::client_trait::Style::Rpc,
+        crate::client_trait::Auth::Token,
         "file_properties/templates/add_for_user",
         arg,
         None)
@@ -184,6 +192,7 @@ pub fn templates_get_for_team(
         client,
         crate::client_trait::Endpoint::Api,
         crate::client_trait::Style::Rpc,
+        crate::client_trait::Auth::Token,
         "file_properties/templates/get_for_team",
         arg,
         None)
@@ -199,6 +208,7 @@ pub fn templates_get_for_user(
         client,
         crate::client_trait::Endpoint::Api,
         crate::client_trait::Style::Rpc,
+        crate::client_trait::Auth::Token,
         "file_properties/templates/get_for_user",
         arg,
         None)
@@ -213,6 +223,7 @@ pub fn templates_list_for_team(
         client,
         crate::client_trait::Endpoint::Api,
         crate::client_trait::Style::Rpc,
+        crate::client_trait::Auth::Token,
         "file_properties/templates/list_for_team",
         &(),
         None)
@@ -228,6 +239,7 @@ pub fn templates_list_for_user(
         client,
         crate::client_trait::Endpoint::Api,
         crate::client_trait::Style::Rpc,
+        crate::client_trait::Auth::Token,
         "file_properties/templates/list_for_user",
         &(),
         None)
@@ -244,6 +256,7 @@ pub fn templates_remove_for_team(
         client,
         crate::client_trait::Endpoint::Api,
         crate::client_trait::Style::Rpc,
+        crate::client_trait::Auth::Token,
         "file_properties/templates/remove_for_team",
         arg,
         None)
@@ -260,6 +273,7 @@ pub fn templates_remove_for_user(
         client,
         crate::client_trait::Endpoint::Api,
         crate::client_trait::Style::Rpc,
+        crate::client_trait::Auth::Token,
         "file_properties/templates/remove_for_user",
         arg,
         None)
@@ -275,6 +289,7 @@ pub fn templates_update_for_team(
         client,
         crate::client_trait::Endpoint::Api,
         crate::client_trait::Style::Rpc,
+        crate::client_trait::Auth::Token,
         "file_properties/templates/update_for_team",
         arg,
         None)
@@ -291,6 +306,7 @@ pub fn templates_update_for_user(
         client,
         crate::client_trait::Endpoint::Api,
         crate::client_trait::Style::Rpc,
+        crate::client_trait::Auth::Token,
         "file_properties/templates/update_for_user",
         arg,
         None)

--- a/src/generated/file_properties.rs
+++ b/src/generated/file_properties.rs
@@ -48,14 +48,13 @@ pub type TemplateId = String;
 /// Add property groups to a Dropbox file. See [`templates_add_for_user()`](templates_add_for_user)
 /// or [`templates_add_for_team()`](templates_add_for_team) to create new templates.
 pub fn properties_add(
-    client: &dyn crate::client_trait::HttpClient,
+    client: &impl crate::client_trait::UserAuthClient,
     arg: &AddPropertiesArg,
 ) -> crate::Result<Result<(), AddPropertiesError>> {
     crate::client_helpers::request(
         client,
         crate::client_trait::Endpoint::Api,
         crate::client_trait::Style::Rpc,
-        crate::client_trait::Auth::Token,
         "file_properties/properties/add",
         arg,
         None)
@@ -67,14 +66,13 @@ pub fn properties_add(
 /// fields from a property group, whereas [`properties_update()`](properties_update) will only
 /// delete fields that are explicitly marked for deletion.
 pub fn properties_overwrite(
-    client: &dyn crate::client_trait::HttpClient,
+    client: &impl crate::client_trait::UserAuthClient,
     arg: &OverwritePropertyGroupArg,
 ) -> crate::Result<Result<(), InvalidPropertyGroupError>> {
     crate::client_helpers::request(
         client,
         crate::client_trait::Endpoint::Api,
         crate::client_trait::Style::Rpc,
-        crate::client_trait::Auth::Token,
         "file_properties/properties/overwrite",
         arg,
         None)
@@ -87,14 +85,13 @@ pub fn properties_overwrite(
 /// [`templates_remove_for_user()`](templates_remove_for_user) or
 /// [`templates_remove_for_team()`](templates_remove_for_team).
 pub fn properties_remove(
-    client: &dyn crate::client_trait::HttpClient,
+    client: &impl crate::client_trait::UserAuthClient,
     arg: &RemovePropertiesArg,
 ) -> crate::Result<Result<(), RemovePropertiesError>> {
     crate::client_helpers::request(
         client,
         crate::client_trait::Endpoint::Api,
         crate::client_trait::Style::Rpc,
-        crate::client_trait::Auth::Token,
         "file_properties/properties/remove",
         arg,
         None)
@@ -102,14 +99,13 @@ pub fn properties_remove(
 
 /// Search across property templates for particular property field values.
 pub fn properties_search(
-    client: &dyn crate::client_trait::HttpClient,
+    client: &impl crate::client_trait::UserAuthClient,
     arg: &PropertiesSearchArg,
 ) -> crate::Result<Result<PropertiesSearchResult, PropertiesSearchError>> {
     crate::client_helpers::request(
         client,
         crate::client_trait::Endpoint::Api,
         crate::client_trait::Style::Rpc,
-        crate::client_trait::Auth::Token,
         "file_properties/properties/search",
         arg,
         None)
@@ -118,14 +114,13 @@ pub fn properties_search(
 /// Once a cursor has been retrieved from [`properties_search()`](properties_search), use this to
 /// paginate through all search results.
 pub fn properties_search_continue(
-    client: &dyn crate::client_trait::HttpClient,
+    client: &impl crate::client_trait::UserAuthClient,
     arg: &PropertiesSearchContinueArg,
 ) -> crate::Result<Result<PropertiesSearchResult, PropertiesSearchContinueError>> {
     crate::client_helpers::request(
         client,
         crate::client_trait::Endpoint::Api,
         crate::client_trait::Style::Rpc,
-        crate::client_trait::Auth::Token,
         "file_properties/properties/search/continue",
         arg,
         None)
@@ -138,14 +133,13 @@ pub fn properties_search_continue(
 /// [`properties_overwrite()`](properties_overwrite) will delete any fields that are omitted from a
 /// property group.
 pub fn properties_update(
-    client: &dyn crate::client_trait::HttpClient,
+    client: &impl crate::client_trait::UserAuthClient,
     arg: &UpdatePropertiesArg,
 ) -> crate::Result<Result<(), UpdatePropertiesError>> {
     crate::client_helpers::request(
         client,
         crate::client_trait::Endpoint::Api,
         crate::client_trait::Style::Rpc,
-        crate::client_trait::Auth::Token,
         "file_properties/properties/update",
         arg,
         None)
@@ -154,14 +148,13 @@ pub fn properties_update(
 /// Add a template associated with a team. See [`properties_add()`](properties_add) to add
 /// properties to a file or folder. Note: this endpoint will create team-owned templates.
 pub fn templates_add_for_team(
-    client: &dyn crate::client_trait::HttpClient,
+    client: &impl crate::client_trait::TeamAuthClient,
     arg: &AddTemplateArg,
 ) -> crate::Result<Result<AddTemplateResult, ModifyTemplateError>> {
     crate::client_helpers::request(
         client,
         crate::client_trait::Endpoint::Api,
         crate::client_trait::Style::Rpc,
-        crate::client_trait::Auth::Token,
         "file_properties/templates/add_for_team",
         arg,
         None)
@@ -170,14 +163,13 @@ pub fn templates_add_for_team(
 /// Add a template associated with a user. See [`properties_add()`](properties_add) to add
 /// properties to a file. This endpoint can't be called on a team member or admin's behalf.
 pub fn templates_add_for_user(
-    client: &dyn crate::client_trait::HttpClient,
+    client: &impl crate::client_trait::UserAuthClient,
     arg: &AddTemplateArg,
 ) -> crate::Result<Result<AddTemplateResult, ModifyTemplateError>> {
     crate::client_helpers::request(
         client,
         crate::client_trait::Endpoint::Api,
         crate::client_trait::Style::Rpc,
-        crate::client_trait::Auth::Token,
         "file_properties/templates/add_for_user",
         arg,
         None)
@@ -185,14 +177,13 @@ pub fn templates_add_for_user(
 
 /// Get the schema for a specified template.
 pub fn templates_get_for_team(
-    client: &dyn crate::client_trait::HttpClient,
+    client: &impl crate::client_trait::TeamAuthClient,
     arg: &GetTemplateArg,
 ) -> crate::Result<Result<GetTemplateResult, TemplateError>> {
     crate::client_helpers::request(
         client,
         crate::client_trait::Endpoint::Api,
         crate::client_trait::Style::Rpc,
-        crate::client_trait::Auth::Token,
         "file_properties/templates/get_for_team",
         arg,
         None)
@@ -201,14 +192,13 @@ pub fn templates_get_for_team(
 /// Get the schema for a specified template. This endpoint can't be called on a team member or
 /// admin's behalf.
 pub fn templates_get_for_user(
-    client: &dyn crate::client_trait::HttpClient,
+    client: &impl crate::client_trait::UserAuthClient,
     arg: &GetTemplateArg,
 ) -> crate::Result<Result<GetTemplateResult, TemplateError>> {
     crate::client_helpers::request(
         client,
         crate::client_trait::Endpoint::Api,
         crate::client_trait::Style::Rpc,
-        crate::client_trait::Auth::Token,
         "file_properties/templates/get_for_user",
         arg,
         None)
@@ -217,13 +207,12 @@ pub fn templates_get_for_user(
 /// Get the template identifiers for a team. To get the schema of each template use
 /// [`templates_get_for_team()`](templates_get_for_team).
 pub fn templates_list_for_team(
-    client: &dyn crate::client_trait::HttpClient,
+    client: &impl crate::client_trait::TeamAuthClient,
 ) -> crate::Result<Result<ListTemplateResult, TemplateError>> {
     crate::client_helpers::request(
         client,
         crate::client_trait::Endpoint::Api,
         crate::client_trait::Style::Rpc,
-        crate::client_trait::Auth::Token,
         "file_properties/templates/list_for_team",
         &(),
         None)
@@ -233,13 +222,12 @@ pub fn templates_list_for_team(
 /// [`templates_get_for_user()`](templates_get_for_user). This endpoint can't be called on a team
 /// member or admin's behalf.
 pub fn templates_list_for_user(
-    client: &dyn crate::client_trait::HttpClient,
+    client: &impl crate::client_trait::UserAuthClient,
 ) -> crate::Result<Result<ListTemplateResult, TemplateError>> {
     crate::client_helpers::request(
         client,
         crate::client_trait::Endpoint::Api,
         crate::client_trait::Style::Rpc,
-        crate::client_trait::Auth::Token,
         "file_properties/templates/list_for_user",
         &(),
         None)
@@ -249,14 +237,13 @@ pub fn templates_list_for_user(
 /// [`templates_add_for_user()`](templates_add_for_user). All properties associated with the
 /// template will also be removed. This action cannot be undone.
 pub fn templates_remove_for_team(
-    client: &dyn crate::client_trait::HttpClient,
+    client: &impl crate::client_trait::TeamAuthClient,
     arg: &RemoveTemplateArg,
 ) -> crate::Result<Result<(), TemplateError>> {
     crate::client_helpers::request(
         client,
         crate::client_trait::Endpoint::Api,
         crate::client_trait::Style::Rpc,
-        crate::client_trait::Auth::Token,
         "file_properties/templates/remove_for_team",
         arg,
         None)
@@ -266,14 +253,13 @@ pub fn templates_remove_for_team(
 /// [`templates_add_for_user()`](templates_add_for_user). All properties associated with the
 /// template will also be removed. This action cannot be undone.
 pub fn templates_remove_for_user(
-    client: &dyn crate::client_trait::HttpClient,
+    client: &impl crate::client_trait::UserAuthClient,
     arg: &RemoveTemplateArg,
 ) -> crate::Result<Result<(), TemplateError>> {
     crate::client_helpers::request(
         client,
         crate::client_trait::Endpoint::Api,
         crate::client_trait::Style::Rpc,
-        crate::client_trait::Auth::Token,
         "file_properties/templates/remove_for_user",
         arg,
         None)
@@ -282,14 +268,13 @@ pub fn templates_remove_for_user(
 /// Update a template associated with a team. This route can update the template name, the template
 /// description and add optional properties to templates.
 pub fn templates_update_for_team(
-    client: &dyn crate::client_trait::HttpClient,
+    client: &impl crate::client_trait::TeamAuthClient,
     arg: &UpdateTemplateArg,
 ) -> crate::Result<Result<UpdateTemplateResult, ModifyTemplateError>> {
     crate::client_helpers::request(
         client,
         crate::client_trait::Endpoint::Api,
         crate::client_trait::Style::Rpc,
-        crate::client_trait::Auth::Token,
         "file_properties/templates/update_for_team",
         arg,
         None)
@@ -299,14 +284,13 @@ pub fn templates_update_for_team(
 /// description and add optional properties to templates. This endpoint can't be called on a team
 /// member or admin's behalf.
 pub fn templates_update_for_user(
-    client: &dyn crate::client_trait::HttpClient,
+    client: &impl crate::client_trait::UserAuthClient,
     arg: &UpdateTemplateArg,
 ) -> crate::Result<Result<UpdateTemplateResult, ModifyTemplateError>> {
     crate::client_helpers::request(
         client,
         crate::client_trait::Endpoint::Api,
         crate::client_trait::Style::Rpc,
-        crate::client_trait::Auth::Token,
         "file_properties/templates/update_for_user",
         arg,
         None)

--- a/src/generated/file_requests.rs
+++ b/src/generated/file_requests.rs
@@ -21,6 +21,7 @@ pub fn count(
         client,
         crate::client_trait::Endpoint::Api,
         crate::client_trait::Style::Rpc,
+        crate::client_trait::Auth::Token,
         "file_requests/count",
         &(),
         None)
@@ -35,6 +36,7 @@ pub fn create(
         client,
         crate::client_trait::Endpoint::Api,
         crate::client_trait::Style::Rpc,
+        crate::client_trait::Auth::Token,
         "file_requests/create",
         arg,
         None)
@@ -49,6 +51,7 @@ pub fn delete(
         client,
         crate::client_trait::Endpoint::Api,
         crate::client_trait::Style::Rpc,
+        crate::client_trait::Auth::Token,
         "file_requests/delete",
         arg,
         None)
@@ -62,6 +65,7 @@ pub fn delete_all_closed(
         client,
         crate::client_trait::Endpoint::Api,
         crate::client_trait::Style::Rpc,
+        crate::client_trait::Auth::Token,
         "file_requests/delete_all_closed",
         &(),
         None)
@@ -76,6 +80,7 @@ pub fn get(
         client,
         crate::client_trait::Endpoint::Api,
         crate::client_trait::Style::Rpc,
+        crate::client_trait::Auth::Token,
         "file_requests/get",
         arg,
         None)
@@ -91,6 +96,7 @@ pub fn list_v2(
         client,
         crate::client_trait::Endpoint::Api,
         crate::client_trait::Style::Rpc,
+        crate::client_trait::Auth::Token,
         "file_requests/list_v2",
         arg,
         None)
@@ -105,6 +111,7 @@ pub fn list(
         client,
         crate::client_trait::Endpoint::Api,
         crate::client_trait::Style::Rpc,
+        crate::client_trait::Auth::Token,
         "file_requests/list",
         &(),
         None)
@@ -121,6 +128,7 @@ pub fn list_continue(
         client,
         crate::client_trait::Endpoint::Api,
         crate::client_trait::Style::Rpc,
+        crate::client_trait::Auth::Token,
         "file_requests/list/continue",
         arg,
         None)
@@ -135,6 +143,7 @@ pub fn update(
         client,
         crate::client_trait::Endpoint::Api,
         crate::client_trait::Style::Rpc,
+        crate::client_trait::Auth::Token,
         "file_requests/update",
         arg,
         None)

--- a/src/generated/file_requests.rs
+++ b/src/generated/file_requests.rs
@@ -15,13 +15,12 @@ pub type FileRequestValidationError = Option<String>;
 /// Returns the total number of file requests owned by this user. Includes both open and closed file
 /// requests.
 pub fn count(
-    client: &dyn crate::client_trait::HttpClient,
+    client: &impl crate::client_trait::UserAuthClient,
 ) -> crate::Result<Result<CountFileRequestsResult, CountFileRequestsError>> {
     crate::client_helpers::request(
         client,
         crate::client_trait::Endpoint::Api,
         crate::client_trait::Style::Rpc,
-        crate::client_trait::Auth::Token,
         "file_requests/count",
         &(),
         None)
@@ -29,14 +28,13 @@ pub fn count(
 
 /// Creates a file request for this user.
 pub fn create(
-    client: &dyn crate::client_trait::HttpClient,
+    client: &impl crate::client_trait::UserAuthClient,
     arg: &CreateFileRequestArgs,
 ) -> crate::Result<Result<FileRequest, CreateFileRequestError>> {
     crate::client_helpers::request(
         client,
         crate::client_trait::Endpoint::Api,
         crate::client_trait::Style::Rpc,
-        crate::client_trait::Auth::Token,
         "file_requests/create",
         arg,
         None)
@@ -44,14 +42,13 @@ pub fn create(
 
 /// Delete a batch of closed file requests.
 pub fn delete(
-    client: &dyn crate::client_trait::HttpClient,
+    client: &impl crate::client_trait::UserAuthClient,
     arg: &DeleteFileRequestArgs,
 ) -> crate::Result<Result<DeleteFileRequestsResult, DeleteFileRequestError>> {
     crate::client_helpers::request(
         client,
         crate::client_trait::Endpoint::Api,
         crate::client_trait::Style::Rpc,
-        crate::client_trait::Auth::Token,
         "file_requests/delete",
         arg,
         None)
@@ -59,13 +56,12 @@ pub fn delete(
 
 /// Delete all closed file requests owned by this user.
 pub fn delete_all_closed(
-    client: &dyn crate::client_trait::HttpClient,
+    client: &impl crate::client_trait::UserAuthClient,
 ) -> crate::Result<Result<DeleteAllClosedFileRequestsResult, DeleteAllClosedFileRequestsError>> {
     crate::client_helpers::request(
         client,
         crate::client_trait::Endpoint::Api,
         crate::client_trait::Style::Rpc,
-        crate::client_trait::Auth::Token,
         "file_requests/delete_all_closed",
         &(),
         None)
@@ -73,14 +69,13 @@ pub fn delete_all_closed(
 
 /// Returns the specified file request.
 pub fn get(
-    client: &dyn crate::client_trait::HttpClient,
+    client: &impl crate::client_trait::UserAuthClient,
     arg: &GetFileRequestArgs,
 ) -> crate::Result<Result<FileRequest, GetFileRequestError>> {
     crate::client_helpers::request(
         client,
         crate::client_trait::Endpoint::Api,
         crate::client_trait::Style::Rpc,
-        crate::client_trait::Auth::Token,
         "file_requests/get",
         arg,
         None)
@@ -89,14 +84,13 @@ pub fn get(
 /// Returns a list of file requests owned by this user. For apps with the app folder permission,
 /// this will only return file requests with destinations in the app folder.
 pub fn list_v2(
-    client: &dyn crate::client_trait::HttpClient,
+    client: &impl crate::client_trait::UserAuthClient,
     arg: &ListFileRequestsArg,
 ) -> crate::Result<Result<ListFileRequestsV2Result, ListFileRequestsError>> {
     crate::client_helpers::request(
         client,
         crate::client_trait::Endpoint::Api,
         crate::client_trait::Style::Rpc,
-        crate::client_trait::Auth::Token,
         "file_requests/list_v2",
         arg,
         None)
@@ -105,13 +99,12 @@ pub fn list_v2(
 /// Returns a list of file requests owned by this user. For apps with the app folder permission,
 /// this will only return file requests with destinations in the app folder.
 pub fn list(
-    client: &dyn crate::client_trait::HttpClient,
+    client: &impl crate::client_trait::UserAuthClient,
 ) -> crate::Result<Result<ListFileRequestsResult, ListFileRequestsError>> {
     crate::client_helpers::request(
         client,
         crate::client_trait::Endpoint::Api,
         crate::client_trait::Style::Rpc,
-        crate::client_trait::Auth::Token,
         "file_requests/list",
         &(),
         None)
@@ -121,14 +114,13 @@ pub fn list(
 /// file requests. The cursor must come from a previous call to [`list_v2()`](list_v2) or
 /// [`list_continue()`](list_continue).
 pub fn list_continue(
-    client: &dyn crate::client_trait::HttpClient,
+    client: &impl crate::client_trait::UserAuthClient,
     arg: &ListFileRequestsContinueArg,
 ) -> crate::Result<Result<ListFileRequestsV2Result, ListFileRequestsContinueError>> {
     crate::client_helpers::request(
         client,
         crate::client_trait::Endpoint::Api,
         crate::client_trait::Style::Rpc,
-        crate::client_trait::Auth::Token,
         "file_requests/list/continue",
         arg,
         None)
@@ -136,14 +128,13 @@ pub fn list_continue(
 
 /// Update a file request.
 pub fn update(
-    client: &dyn crate::client_trait::HttpClient,
+    client: &impl crate::client_trait::UserAuthClient,
     arg: &UpdateFileRequestArgs,
 ) -> crate::Result<Result<FileRequest, UpdateFileRequestError>> {
     crate::client_helpers::request(
         client,
         crate::client_trait::Endpoint::Api,
         crate::client_trait::Style::Rpc,
-        crate::client_trait::Auth::Token,
         "file_requests/update",
         arg,
         None)

--- a/src/generated/files.rs
+++ b/src/generated/files.rs
@@ -29,14 +29,13 @@ pub type WritePathOrId = String;
 /// Returns the metadata for a file or folder. This is an alpha endpoint compatible with the
 /// properties API. Note: Metadata for the root folder is unsupported.
 pub fn alpha_get_metadata(
-    client: &dyn crate::client_trait::HttpClient,
+    client: &impl crate::client_trait::UserAuthClient,
     arg: &AlphaGetMetadataArg,
 ) -> crate::Result<Result<Metadata, AlphaGetMetadataError>> {
     crate::client_helpers::request(
         client,
         crate::client_trait::Endpoint::Api,
         crate::client_trait::Style::Rpc,
-        crate::client_trait::Auth::Token,
         "files/alpha/get_metadata",
         arg,
         None)
@@ -47,7 +46,7 @@ pub fn alpha_get_metadata(
 /// upload a file larger than 150 MB. Instead, create an upload session with
 /// [`upload_session_start()`](upload_session_start).
 pub fn alpha_upload(
-    client: &dyn crate::client_trait::HttpClient,
+    client: &impl crate::client_trait::UserAuthClient,
     arg: &CommitInfoWithProperties,
     body: &[u8],
 ) -> crate::Result<Result<FileMetadata, UploadErrorWithProperties>> {
@@ -55,7 +54,6 @@ pub fn alpha_upload(
         client,
         crate::client_trait::Endpoint::Content,
         crate::client_trait::Style::Upload,
-        crate::client_trait::Auth::Token,
         "files/alpha/upload",
         arg,
         Some(body))
@@ -64,14 +62,13 @@ pub fn alpha_upload(
 /// Copy a file or folder to a different location in the user's Dropbox. If the source path is a
 /// folder all its contents will be copied.
 pub fn copy_v2(
-    client: &dyn crate::client_trait::HttpClient,
+    client: &impl crate::client_trait::UserAuthClient,
     arg: &RelocationArg,
 ) -> crate::Result<Result<RelocationResult, RelocationError>> {
     crate::client_helpers::request(
         client,
         crate::client_trait::Endpoint::Api,
         crate::client_trait::Style::Rpc,
-        crate::client_trait::Auth::Token,
         "files/copy_v2",
         arg,
         None)
@@ -80,14 +77,13 @@ pub fn copy_v2(
 /// Copy a file or folder to a different location in the user's Dropbox. If the source path is a
 /// folder all its contents will be copied.
 pub fn copy(
-    client: &dyn crate::client_trait::HttpClient,
+    client: &impl crate::client_trait::UserAuthClient,
     arg: &RelocationArg,
 ) -> crate::Result<Result<Metadata, RelocationError>> {
     crate::client_helpers::request(
         client,
         crate::client_trait::Endpoint::Api,
         crate::client_trait::Style::Rpc,
-        crate::client_trait::Auth::Token,
         "files/copy",
         arg,
         None)
@@ -99,14 +95,13 @@ pub fn copy(
 /// will either finish synchronously, or return a job ID and do the async copy job in background.
 /// Please use [`copy_batch_check_v2()`](copy_batch_check_v2) to check the job status.
 pub fn copy_batch_v2(
-    client: &dyn crate::client_trait::HttpClient,
+    client: &impl crate::client_trait::UserAuthClient,
     arg: &CopyBatchArg,
 ) -> crate::Result<Result<RelocationBatchV2Launch, ()>> {
     crate::client_helpers::request(
         client,
         crate::client_trait::Endpoint::Api,
         crate::client_trait::Style::Rpc,
-        crate::client_trait::Auth::Token,
         "files/copy_batch_v2",
         arg,
         None)
@@ -120,14 +115,13 @@ pub fn copy_batch_v2(
 /// route will return job ID immediately and do the async copy job in background. Please use
 /// [`copy_batch_check()`](copy_batch_check) to check the job status.
 pub fn copy_batch(
-    client: &dyn crate::client_trait::HttpClient,
+    client: &impl crate::client_trait::UserAuthClient,
     arg: &RelocationBatchArg,
 ) -> crate::Result<Result<RelocationBatchLaunch, ()>> {
     crate::client_helpers::request(
         client,
         crate::client_trait::Endpoint::Api,
         crate::client_trait::Style::Rpc,
-        crate::client_trait::Auth::Token,
         "files/copy_batch",
         arg,
         None)
@@ -136,14 +130,13 @@ pub fn copy_batch(
 /// Returns the status of an asynchronous job for [`copy_batch_v2()`](copy_batch_v2). It returns
 /// list of results for each entry.
 pub fn copy_batch_check_v2(
-    client: &dyn crate::client_trait::HttpClient,
+    client: &impl crate::client_trait::UserAuthClient,
     arg: &super::dbx_async::PollArg,
 ) -> crate::Result<Result<RelocationBatchV2JobStatus, super::dbx_async::PollError>> {
     crate::client_helpers::request(
         client,
         crate::client_trait::Endpoint::Api,
         crate::client_trait::Style::Rpc,
-        crate::client_trait::Auth::Token,
         "files/copy_batch/check_v2",
         arg,
         None)
@@ -152,14 +145,13 @@ pub fn copy_batch_check_v2(
 /// Returns the status of an asynchronous job for [`copy_batch()`](copy_batch). If success, it
 /// returns list of results for each entry.
 pub fn copy_batch_check(
-    client: &dyn crate::client_trait::HttpClient,
+    client: &impl crate::client_trait::UserAuthClient,
     arg: &super::dbx_async::PollArg,
 ) -> crate::Result<Result<RelocationBatchJobStatus, super::dbx_async::PollError>> {
     crate::client_helpers::request(
         client,
         crate::client_trait::Endpoint::Api,
         crate::client_trait::Style::Rpc,
-        crate::client_trait::Auth::Token,
         "files/copy_batch/check",
         arg,
         None)
@@ -169,14 +161,13 @@ pub fn copy_batch_check(
 /// folder to another user's Dropbox by passing it to
 /// [`copy_reference_save()`](copy_reference_save).
 pub fn copy_reference_get(
-    client: &dyn crate::client_trait::HttpClient,
+    client: &impl crate::client_trait::UserAuthClient,
     arg: &GetCopyReferenceArg,
 ) -> crate::Result<Result<GetCopyReferenceResult, GetCopyReferenceError>> {
     crate::client_helpers::request(
         client,
         crate::client_trait::Endpoint::Api,
         crate::client_trait::Style::Rpc,
-        crate::client_trait::Auth::Token,
         "files/copy_reference/get",
         arg,
         None)
@@ -185,14 +176,13 @@ pub fn copy_reference_get(
 /// Save a copy reference returned by [`copy_reference_get()`](copy_reference_get) to the user's
 /// Dropbox.
 pub fn copy_reference_save(
-    client: &dyn crate::client_trait::HttpClient,
+    client: &impl crate::client_trait::UserAuthClient,
     arg: &SaveCopyReferenceArg,
 ) -> crate::Result<Result<SaveCopyReferenceResult, SaveCopyReferenceError>> {
     crate::client_helpers::request(
         client,
         crate::client_trait::Endpoint::Api,
         crate::client_trait::Style::Rpc,
-        crate::client_trait::Auth::Token,
         "files/copy_reference/save",
         arg,
         None)
@@ -200,14 +190,13 @@ pub fn copy_reference_save(
 
 /// Create a folder at a given path.
 pub fn create_folder_v2(
-    client: &dyn crate::client_trait::HttpClient,
+    client: &impl crate::client_trait::UserAuthClient,
     arg: &CreateFolderArg,
 ) -> crate::Result<Result<CreateFolderResult, CreateFolderError>> {
     crate::client_helpers::request(
         client,
         crate::client_trait::Endpoint::Api,
         crate::client_trait::Style::Rpc,
-        crate::client_trait::Auth::Token,
         "files/create_folder_v2",
         arg,
         None)
@@ -215,14 +204,13 @@ pub fn create_folder_v2(
 
 /// Create a folder at a given path.
 pub fn create_folder(
-    client: &dyn crate::client_trait::HttpClient,
+    client: &impl crate::client_trait::UserAuthClient,
     arg: &CreateFolderArg,
 ) -> crate::Result<Result<FolderMetadata, CreateFolderError>> {
     crate::client_helpers::request(
         client,
         crate::client_trait::Endpoint::Api,
         crate::client_trait::Style::Rpc,
-        crate::client_trait::Auth::Token,
         "files/create_folder",
         arg,
         None)
@@ -234,14 +222,13 @@ pub fn create_folder(
 /// behaviour by using the [`CreateFolderBatchArg::force_async`](CreateFolderBatchArg) flag.  Use
 /// [`create_folder_batch_check()`](create_folder_batch_check) to check the job status.
 pub fn create_folder_batch(
-    client: &dyn crate::client_trait::HttpClient,
+    client: &impl crate::client_trait::UserAuthClient,
     arg: &CreateFolderBatchArg,
 ) -> crate::Result<Result<CreateFolderBatchLaunch, ()>> {
     crate::client_helpers::request(
         client,
         crate::client_trait::Endpoint::Api,
         crate::client_trait::Style::Rpc,
-        crate::client_trait::Auth::Token,
         "files/create_folder_batch",
         arg,
         None)
@@ -250,14 +237,13 @@ pub fn create_folder_batch(
 /// Returns the status of an asynchronous job for [`create_folder_batch()`](create_folder_batch). If
 /// success, it returns list of result for each entry.
 pub fn create_folder_batch_check(
-    client: &dyn crate::client_trait::HttpClient,
+    client: &impl crate::client_trait::UserAuthClient,
     arg: &super::dbx_async::PollArg,
 ) -> crate::Result<Result<CreateFolderBatchJobStatus, super::dbx_async::PollError>> {
     crate::client_helpers::request(
         client,
         crate::client_trait::Endpoint::Api,
         crate::client_trait::Style::Rpc,
-        crate::client_trait::Auth::Token,
         "files/create_folder_batch/check",
         arg,
         None)
@@ -269,14 +255,13 @@ pub fn create_folder_batch_check(
 /// [`FolderMetadata`](FolderMetadata) for the item at time of deletion, and not a
 /// [`DeletedMetadata`](DeletedMetadata) object.
 pub fn delete_v2(
-    client: &dyn crate::client_trait::HttpClient,
+    client: &impl crate::client_trait::UserAuthClient,
     arg: &DeleteArg,
 ) -> crate::Result<Result<DeleteResult, DeleteError>> {
     crate::client_helpers::request(
         client,
         crate::client_trait::Endpoint::Api,
         crate::client_trait::Style::Rpc,
-        crate::client_trait::Auth::Token,
         "files/delete_v2",
         arg,
         None)
@@ -288,14 +273,13 @@ pub fn delete_v2(
 /// [`FolderMetadata`](FolderMetadata) for the item at time of deletion, and not a
 /// [`DeletedMetadata`](DeletedMetadata) object.
 pub fn delete(
-    client: &dyn crate::client_trait::HttpClient,
+    client: &impl crate::client_trait::UserAuthClient,
     arg: &DeleteArg,
 ) -> crate::Result<Result<Metadata, DeleteError>> {
     crate::client_helpers::request(
         client,
         crate::client_trait::Endpoint::Api,
         crate::client_trait::Style::Rpc,
-        crate::client_trait::Auth::Token,
         "files/delete",
         arg,
         None)
@@ -305,14 +289,13 @@ pub fn delete(
 /// immediately and runs the delete batch asynchronously. Use
 /// [`delete_batch_check()`](delete_batch_check) to check the job status.
 pub fn delete_batch(
-    client: &dyn crate::client_trait::HttpClient,
+    client: &impl crate::client_trait::UserAuthClient,
     arg: &DeleteBatchArg,
 ) -> crate::Result<Result<DeleteBatchLaunch, ()>> {
     crate::client_helpers::request(
         client,
         crate::client_trait::Endpoint::Api,
         crate::client_trait::Style::Rpc,
-        crate::client_trait::Auth::Token,
         "files/delete_batch",
         arg,
         None)
@@ -321,14 +304,13 @@ pub fn delete_batch(
 /// Returns the status of an asynchronous job for [`delete_batch()`](delete_batch). If success, it
 /// returns list of result for each entry.
 pub fn delete_batch_check(
-    client: &dyn crate::client_trait::HttpClient,
+    client: &impl crate::client_trait::UserAuthClient,
     arg: &super::dbx_async::PollArg,
 ) -> crate::Result<Result<DeleteBatchJobStatus, super::dbx_async::PollError>> {
     crate::client_helpers::request(
         client,
         crate::client_trait::Endpoint::Api,
         crate::client_trait::Style::Rpc,
-        crate::client_trait::Auth::Token,
         "files/delete_batch/check",
         arg,
         None)
@@ -336,7 +318,7 @@ pub fn delete_batch_check(
 
 /// Download a file from a user's Dropbox.
 pub fn download(
-    client: &dyn crate::client_trait::HttpClient,
+    client: &impl crate::client_trait::UserAuthClient,
     arg: &DownloadArg,
     range_start: Option<u64>,
     range_end: Option<u64>,
@@ -345,7 +327,6 @@ pub fn download(
         client,
         crate::client_trait::Endpoint::Content,
         crate::client_trait::Style::Download,
-        crate::client_trait::Auth::Token,
         "files/download",
         arg,
         None,
@@ -357,7 +338,7 @@ pub fn download(
 /// size and have fewer than 10,000 total files. The input cannot be a single file. Any single file
 /// must be less than 4GB in size.
 pub fn download_zip(
-    client: &dyn crate::client_trait::HttpClient,
+    client: &impl crate::client_trait::UserAuthClient,
     arg: &DownloadZipArg,
     range_start: Option<u64>,
     range_end: Option<u64>,
@@ -366,7 +347,6 @@ pub fn download_zip(
         client,
         crate::client_trait::Endpoint::Content,
         crate::client_trait::Style::Download,
-        crate::client_trait::Auth::Token,
         "files/download_zip",
         arg,
         None,
@@ -378,7 +358,7 @@ pub fn download_zip(
 /// downloaded directly  and whose [`ExportResult::file_metadata`](ExportResult) has
 /// [`ExportInfo::export_as`](ExportInfo) populated.
 pub fn export(
-    client: &dyn crate::client_trait::HttpClient,
+    client: &impl crate::client_trait::UserAuthClient,
     arg: &ExportArg,
     range_start: Option<u64>,
     range_end: Option<u64>,
@@ -387,7 +367,6 @@ pub fn export(
         client,
         crate::client_trait::Endpoint::Content,
         crate::client_trait::Style::Download,
-        crate::client_trait::Auth::Token,
         "files/export",
         arg,
         None,
@@ -397,14 +376,13 @@ pub fn export(
 
 /// Return the lock metadata for the given list of paths.
 pub fn get_file_lock_batch(
-    client: &dyn crate::client_trait::HttpClient,
+    client: &impl crate::client_trait::UserAuthClient,
     arg: &LockFileBatchArg,
 ) -> crate::Result<Result<LockFileBatchResult, LockFileError>> {
     crate::client_helpers::request(
         client,
         crate::client_trait::Endpoint::Api,
         crate::client_trait::Style::Rpc,
-        crate::client_trait::Auth::Token,
         "files/get_file_lock_batch",
         arg,
         None)
@@ -412,14 +390,13 @@ pub fn get_file_lock_batch(
 
 /// Returns the metadata for a file or folder. Note: Metadata for the root folder is unsupported.
 pub fn get_metadata(
-    client: &dyn crate::client_trait::HttpClient,
+    client: &impl crate::client_trait::UserAuthClient,
     arg: &GetMetadataArg,
 ) -> crate::Result<Result<Metadata, GetMetadataError>> {
     crate::client_helpers::request(
         client,
         crate::client_trait::Endpoint::Api,
         crate::client_trait::Style::Rpc,
-        crate::client_trait::Auth::Token,
         "files/get_metadata",
         arg,
         None)
@@ -431,7 +408,7 @@ pub fn get_metadata(
 /// .csv, .ods, .xls, .xlsm, .gsheet, .xlsx. Other formats will return an unsupported extension
 /// error.
 pub fn get_preview(
-    client: &dyn crate::client_trait::HttpClient,
+    client: &impl crate::client_trait::UserAuthClient,
     arg: &PreviewArg,
     range_start: Option<u64>,
     range_end: Option<u64>,
@@ -440,7 +417,6 @@ pub fn get_preview(
         client,
         crate::client_trait::Endpoint::Content,
         crate::client_trait::Style::Download,
-        crate::client_trait::Auth::Token,
         "files/get_preview",
         arg,
         None,
@@ -452,14 +428,13 @@ pub fn get_preview(
 /// afterwards you will get 410 Gone. This URL should not be used to display content directly in the
 /// browser. The Content-Type of the link is determined automatically by the file's mime type.
 pub fn get_temporary_link(
-    client: &dyn crate::client_trait::HttpClient,
+    client: &impl crate::client_trait::UserAuthClient,
     arg: &GetTemporaryLinkArg,
 ) -> crate::Result<Result<GetTemporaryLinkResult, GetTemporaryLinkError>> {
     crate::client_helpers::request(
         client,
         crate::client_trait::Endpoint::Api,
         crate::client_trait::Style::Rpc,
-        crate::client_trait::Auth::Token,
         "files/get_temporary_link",
         arg,
         None)
@@ -502,14 +477,13 @@ pub fn get_temporary_link(
 /// Example unsuccessful temporary upload link consumption response: Temporary upload link has been
 /// recently consumed.
 pub fn get_temporary_upload_link(
-    client: &dyn crate::client_trait::HttpClient,
+    client: &impl crate::client_trait::UserAuthClient,
     arg: &GetTemporaryUploadLinkArg,
 ) -> crate::Result<Result<GetTemporaryUploadLinkResult, ()>> {
     crate::client_helpers::request(
         client,
         crate::client_trait::Endpoint::Api,
         crate::client_trait::Style::Rpc,
-        crate::client_trait::Auth::Token,
         "files/get_temporary_upload_link",
         arg,
         None)
@@ -519,7 +493,7 @@ pub fn get_temporary_upload_link(
 /// extensions: jpg, jpeg, png, tiff, tif, gif and bmp. Photos that are larger than 20MB in size
 /// won't be converted to a thumbnail.
 pub fn get_thumbnail(
-    client: &dyn crate::client_trait::HttpClient,
+    client: &impl crate::client_trait::UserAuthClient,
     arg: &ThumbnailArg,
     range_start: Option<u64>,
     range_end: Option<u64>,
@@ -528,7 +502,6 @@ pub fn get_thumbnail(
         client,
         crate::client_trait::Endpoint::Content,
         crate::client_trait::Style::Download,
-        crate::client_trait::Auth::Token,
         "files/get_thumbnail",
         arg,
         None,
@@ -538,7 +511,7 @@ pub fn get_thumbnail(
 
 /// Get a thumbnail for a file.
 pub fn get_thumbnail_v2(
-    client: &dyn crate::client_trait::HttpClient,
+    client: &impl crate::client_trait::UserAuthClient,
     arg: &ThumbnailV2Arg,
     range_start: Option<u64>,
     range_end: Option<u64>,
@@ -547,7 +520,24 @@ pub fn get_thumbnail_v2(
         client,
         crate::client_trait::Endpoint::Content,
         crate::client_trait::Style::Download,
-        crate::client_trait::Auth::Token,
+        "files/get_thumbnail_v2",
+        arg,
+        None,
+        range_start,
+        range_end)
+}
+
+/// Get a thumbnail for a file.
+pub fn get_thumbnail_v2_app_auth(
+    client: &impl crate::client_trait::AppAuthClient,
+    arg: &ThumbnailV2Arg,
+    range_start: Option<u64>,
+    range_end: Option<u64>,
+) -> crate::Result<Result<crate::client_trait::HttpRequestResult<PreviewResult>, ThumbnailV2Error>> {
+    crate::client_helpers::request_with_body(
+        client,
+        crate::client_trait::Endpoint::Content,
+        crate::client_trait::Style::Download,
         "files/get_thumbnail_v2",
         arg,
         None,
@@ -559,14 +549,13 @@ pub fn get_thumbnail_v2(
 /// currently supports files with the following file extensions: jpg, jpeg, png, tiff, tif, gif and
 /// bmp. Photos that are larger than 20MB in size won't be converted to a thumbnail.
 pub fn get_thumbnail_batch(
-    client: &dyn crate::client_trait::HttpClient,
+    client: &impl crate::client_trait::UserAuthClient,
     arg: &GetThumbnailBatchArg,
 ) -> crate::Result<Result<GetThumbnailBatchResult, GetThumbnailBatchError>> {
     crate::client_helpers::request(
         client,
         crate::client_trait::Endpoint::Content,
         crate::client_trait::Style::Rpc,
-        crate::client_trait::Auth::Token,
         "files/get_thumbnail_batch",
         arg,
         None)
@@ -593,14 +582,13 @@ pub fn get_thumbnail_batch(
 /// simultaneously by same API app for same user. If your app implements retry logic, please hold
 /// off the retry until the previous request finishes.
 pub fn list_folder(
-    client: &dyn crate::client_trait::HttpClient,
+    client: &impl crate::client_trait::UserAuthClient,
     arg: &ListFolderArg,
 ) -> crate::Result<Result<ListFolderResult, ListFolderError>> {
     crate::client_helpers::request(
         client,
         crate::client_trait::Endpoint::Api,
         crate::client_trait::Style::Rpc,
-        crate::client_trait::Auth::Token,
         "files/list_folder",
         arg,
         None)
@@ -610,14 +598,13 @@ pub fn list_folder(
 /// through all files and retrieve updates to the folder, following the same rules as documented for
 /// [`list_folder()`](list_folder).
 pub fn list_folder_continue(
-    client: &dyn crate::client_trait::HttpClient,
+    client: &impl crate::client_trait::UserAuthClient,
     arg: &ListFolderContinueArg,
 ) -> crate::Result<Result<ListFolderResult, ListFolderContinueError>> {
     crate::client_helpers::request(
         client,
         crate::client_trait::Endpoint::Api,
         crate::client_trait::Style::Rpc,
-        crate::client_trait::Auth::Token,
         "files/list_folder/continue",
         arg,
         None)
@@ -628,14 +615,13 @@ pub fn list_folder_continue(
 /// This endpoint is for app which only needs to know about new files and modifications and doesn't
 /// need to know about files that already exist in Dropbox.
 pub fn list_folder_get_latest_cursor(
-    client: &dyn crate::client_trait::HttpClient,
+    client: &impl crate::client_trait::UserAuthClient,
     arg: &ListFolderArg,
 ) -> crate::Result<Result<ListFolderGetLatestCursorResult, ListFolderError>> {
     crate::client_helpers::request(
         client,
         crate::client_trait::Endpoint::Api,
         crate::client_trait::Style::Rpc,
-        crate::client_trait::Auth::Token,
         "files/list_folder/get_latest_cursor",
         arg,
         None)
@@ -648,14 +634,13 @@ pub fn list_folder_get_latest_cursor(
 /// server-side notifications, check out our [webhooks
 /// documentation](https://www.dropbox.com/developers/reference/webhooks).
 pub fn list_folder_longpoll(
-    client: &dyn crate::client_trait::HttpClient,
+    client: &impl crate::client_trait::NoauthClient,
     arg: &ListFolderLongpollArg,
 ) -> crate::Result<Result<ListFolderLongpollResult, ListFolderLongpollError>> {
     crate::client_helpers::request(
         client,
         crate::client_trait::Endpoint::Notify,
         crate::client_trait::Style::Rpc,
-        crate::client_trait::Auth::Noauth,
         "files/list_folder/longpoll",
         arg,
         None)
@@ -670,14 +655,13 @@ pub fn list_folder_longpoll(
 /// [`ListRevisionsMode::Id`](ListRevisionsMode::Id) mode is useful to retrieve revisions for a
 /// given file across moves or renames.
 pub fn list_revisions(
-    client: &dyn crate::client_trait::HttpClient,
+    client: &impl crate::client_trait::UserAuthClient,
     arg: &ListRevisionsArg,
 ) -> crate::Result<Result<ListRevisionsResult, ListRevisionsError>> {
     crate::client_helpers::request(
         client,
         crate::client_trait::Endpoint::Api,
         crate::client_trait::Style::Rpc,
-        crate::client_trait::Auth::Token,
         "files/list_revisions",
         arg,
         None)
@@ -687,14 +671,13 @@ pub fn list_revisions(
 /// successful response indicates that the file has been locked. Returns a list of the locked file
 /// paths and their metadata after this operation.
 pub fn lock_file_batch(
-    client: &dyn crate::client_trait::HttpClient,
+    client: &impl crate::client_trait::UserAuthClient,
     arg: &LockFileBatchArg,
 ) -> crate::Result<Result<LockFileBatchResult, LockFileError>> {
     crate::client_helpers::request(
         client,
         crate::client_trait::Endpoint::Api,
         crate::client_trait::Style::Rpc,
-        crate::client_trait::Auth::Token,
         "files/lock_file_batch",
         arg,
         None)
@@ -703,14 +686,13 @@ pub fn lock_file_batch(
 /// Move a file or folder to a different location in the user's Dropbox. If the source path is a
 /// folder all its contents will be moved. Note that we do not currently support case-only renaming.
 pub fn move_v2(
-    client: &dyn crate::client_trait::HttpClient,
+    client: &impl crate::client_trait::UserAuthClient,
     arg: &RelocationArg,
 ) -> crate::Result<Result<RelocationResult, RelocationError>> {
     crate::client_helpers::request(
         client,
         crate::client_trait::Endpoint::Api,
         crate::client_trait::Style::Rpc,
-        crate::client_trait::Auth::Token,
         "files/move_v2",
         arg,
         None)
@@ -719,14 +701,13 @@ pub fn move_v2(
 /// Move a file or folder to a different location in the user's Dropbox. If the source path is a
 /// folder all its contents will be moved.
 pub fn do_move(
-    client: &dyn crate::client_trait::HttpClient,
+    client: &impl crate::client_trait::UserAuthClient,
     arg: &RelocationArg,
 ) -> crate::Result<Result<Metadata, RelocationError>> {
     crate::client_helpers::request(
         client,
         crate::client_trait::Endpoint::Api,
         crate::client_trait::Style::Rpc,
-        crate::client_trait::Auth::Token,
         "files/move",
         arg,
         None)
@@ -739,14 +720,13 @@ pub fn do_move(
 /// either finish synchronously, or return a job ID and do the async move job in background. Please
 /// use [`move_batch_check_v2()`](move_batch_check_v2) to check the job status.
 pub fn move_batch_v2(
-    client: &dyn crate::client_trait::HttpClient,
+    client: &impl crate::client_trait::UserAuthClient,
     arg: &MoveBatchArg,
 ) -> crate::Result<Result<RelocationBatchV2Launch, ()>> {
     crate::client_helpers::request(
         client,
         crate::client_trait::Endpoint::Api,
         crate::client_trait::Style::Rpc,
-        crate::client_trait::Auth::Token,
         "files/move_batch_v2",
         arg,
         None)
@@ -756,14 +736,13 @@ pub fn move_batch_v2(
 /// will return job ID immediately and do the async moving job in background. Please use
 /// [`move_batch_check()`](move_batch_check) to check the job status.
 pub fn move_batch(
-    client: &dyn crate::client_trait::HttpClient,
+    client: &impl crate::client_trait::UserAuthClient,
     arg: &RelocationBatchArg,
 ) -> crate::Result<Result<RelocationBatchLaunch, ()>> {
     crate::client_helpers::request(
         client,
         crate::client_trait::Endpoint::Api,
         crate::client_trait::Style::Rpc,
-        crate::client_trait::Auth::Token,
         "files/move_batch",
         arg,
         None)
@@ -772,14 +751,13 @@ pub fn move_batch(
 /// Returns the status of an asynchronous job for [`move_batch_v2()`](move_batch_v2). It returns
 /// list of results for each entry.
 pub fn move_batch_check_v2(
-    client: &dyn crate::client_trait::HttpClient,
+    client: &impl crate::client_trait::UserAuthClient,
     arg: &super::dbx_async::PollArg,
 ) -> crate::Result<Result<RelocationBatchV2JobStatus, super::dbx_async::PollError>> {
     crate::client_helpers::request(
         client,
         crate::client_trait::Endpoint::Api,
         crate::client_trait::Style::Rpc,
-        crate::client_trait::Auth::Token,
         "files/move_batch/check_v2",
         arg,
         None)
@@ -788,14 +766,13 @@ pub fn move_batch_check_v2(
 /// Returns the status of an asynchronous job for [`move_batch()`](move_batch). If success, it
 /// returns list of results for each entry.
 pub fn move_batch_check(
-    client: &dyn crate::client_trait::HttpClient,
+    client: &impl crate::client_trait::UserAuthClient,
     arg: &super::dbx_async::PollArg,
 ) -> crate::Result<Result<RelocationBatchJobStatus, super::dbx_async::PollError>> {
     crate::client_helpers::request(
         client,
         crate::client_trait::Endpoint::Api,
         crate::client_trait::Style::Rpc,
-        crate::client_trait::Auth::Token,
         "files/move_batch/check",
         arg,
         None)
@@ -804,97 +781,90 @@ pub fn move_batch_check(
 /// Permanently delete the file or folder at a given path (see https://www.dropbox.com/en/help/40).
 /// Note: This endpoint is only available for Dropbox Business apps.
 pub fn permanently_delete(
-    client: &dyn crate::client_trait::HttpClient,
+    client: &impl crate::client_trait::UserAuthClient,
     arg: &DeleteArg,
 ) -> crate::Result<Result<(), DeleteError>> {
     crate::client_helpers::request(
         client,
         crate::client_trait::Endpoint::Api,
         crate::client_trait::Style::Rpc,
-        crate::client_trait::Auth::Token,
         "files/permanently_delete",
         arg,
         None)
 }
 
 pub fn properties_add(
-    client: &dyn crate::client_trait::HttpClient,
+    client: &impl crate::client_trait::UserAuthClient,
     arg: &super::file_properties::AddPropertiesArg,
 ) -> crate::Result<Result<(), super::file_properties::AddPropertiesError>> {
     crate::client_helpers::request(
         client,
         crate::client_trait::Endpoint::Api,
         crate::client_trait::Style::Rpc,
-        crate::client_trait::Auth::Token,
         "files/properties/add",
         arg,
         None)
 }
 
 pub fn properties_overwrite(
-    client: &dyn crate::client_trait::HttpClient,
+    client: &impl crate::client_trait::UserAuthClient,
     arg: &super::file_properties::OverwritePropertyGroupArg,
 ) -> crate::Result<Result<(), super::file_properties::InvalidPropertyGroupError>> {
     crate::client_helpers::request(
         client,
         crate::client_trait::Endpoint::Api,
         crate::client_trait::Style::Rpc,
-        crate::client_trait::Auth::Token,
         "files/properties/overwrite",
         arg,
         None)
 }
 
 pub fn properties_remove(
-    client: &dyn crate::client_trait::HttpClient,
+    client: &impl crate::client_trait::UserAuthClient,
     arg: &super::file_properties::RemovePropertiesArg,
 ) -> crate::Result<Result<(), super::file_properties::RemovePropertiesError>> {
     crate::client_helpers::request(
         client,
         crate::client_trait::Endpoint::Api,
         crate::client_trait::Style::Rpc,
-        crate::client_trait::Auth::Token,
         "files/properties/remove",
         arg,
         None)
 }
 
 pub fn properties_template_get(
-    client: &dyn crate::client_trait::HttpClient,
+    client: &impl crate::client_trait::UserAuthClient,
     arg: &super::file_properties::GetTemplateArg,
 ) -> crate::Result<Result<super::file_properties::GetTemplateResult, super::file_properties::TemplateError>> {
     crate::client_helpers::request(
         client,
         crate::client_trait::Endpoint::Api,
         crate::client_trait::Style::Rpc,
-        crate::client_trait::Auth::Token,
         "files/properties/template/get",
         arg,
         None)
 }
 
 pub fn properties_template_list(
-    client: &dyn crate::client_trait::HttpClient,
+    client: &impl crate::client_trait::UserAuthClient,
 ) -> crate::Result<Result<super::file_properties::ListTemplateResult, super::file_properties::TemplateError>> {
     crate::client_helpers::request(
         client,
         crate::client_trait::Endpoint::Api,
         crate::client_trait::Style::Rpc,
-        crate::client_trait::Auth::Token,
         "files/properties/template/list",
         &(),
         None)
 }
 
 pub fn properties_update(
-    client: &dyn crate::client_trait::HttpClient,
+    client: &impl crate::client_trait::UserAuthClient,
     arg: &super::file_properties::UpdatePropertiesArg,
 ) -> crate::Result<Result<(), super::file_properties::UpdatePropertiesError>> {
     crate::client_helpers::request(
         client,
         crate::client_trait::Endpoint::Api,
         crate::client_trait::Style::Rpc,
-        crate::client_trait::Auth::Token,
         "files/properties/update",
         arg,
         None)
@@ -902,14 +872,13 @@ pub fn properties_update(
 
 /// Restore a specific revision of a file to the given path.
 pub fn restore(
-    client: &dyn crate::client_trait::HttpClient,
+    client: &impl crate::client_trait::UserAuthClient,
     arg: &RestoreArg,
 ) -> crate::Result<Result<FileMetadata, RestoreError>> {
     crate::client_helpers::request(
         client,
         crate::client_trait::Endpoint::Api,
         crate::client_trait::Style::Rpc,
-        crate::client_trait::Auth::Token,
         "files/restore",
         arg,
         None)
@@ -920,14 +889,13 @@ pub fn restore(
 /// the given path already exists, the file will be renamed to avoid the conflict (e.g. myfile
 /// (1).txt).
 pub fn save_url(
-    client: &dyn crate::client_trait::HttpClient,
+    client: &impl crate::client_trait::UserAuthClient,
     arg: &SaveUrlArg,
 ) -> crate::Result<Result<SaveUrlResult, SaveUrlError>> {
     crate::client_helpers::request(
         client,
         crate::client_trait::Endpoint::Api,
         crate::client_trait::Style::Rpc,
-        crate::client_trait::Auth::Token,
         "files/save_url",
         arg,
         None)
@@ -935,14 +903,13 @@ pub fn save_url(
 
 /// Check the status of a [`save_url()`](save_url) job.
 pub fn save_url_check_job_status(
-    client: &dyn crate::client_trait::HttpClient,
+    client: &impl crate::client_trait::UserAuthClient,
     arg: &super::dbx_async::PollArg,
 ) -> crate::Result<Result<SaveUrlJobStatus, super::dbx_async::PollError>> {
     crate::client_helpers::request(
         client,
         crate::client_trait::Endpoint::Api,
         crate::client_trait::Style::Rpc,
-        crate::client_trait::Auth::Token,
         "files/save_url/check_job_status",
         arg,
         None)
@@ -952,14 +919,13 @@ pub fn save_url_check_job_status(
 /// a few seconds and older revisions of existing files may still match your query for up to a few
 /// days.
 pub fn search(
-    client: &dyn crate::client_trait::HttpClient,
+    client: &impl crate::client_trait::UserAuthClient,
     arg: &SearchArg,
 ) -> crate::Result<Result<SearchResult, SearchError>> {
     crate::client_helpers::request(
         client,
         crate::client_trait::Endpoint::Api,
         crate::client_trait::Style::Rpc,
-        crate::client_trait::Auth::Token,
         "files/search",
         arg,
         None)
@@ -970,14 +936,13 @@ pub fn search(
 /// matches. Recent changes may not immediately be reflected in search results due to a short delay
 /// in indexing. Duplicate results may be returned across pages. Some results may not be returned.
 pub fn search_v2(
-    client: &dyn crate::client_trait::HttpClient,
+    client: &impl crate::client_trait::UserAuthClient,
     arg: &SearchV2Arg,
 ) -> crate::Result<Result<SearchV2Result, SearchError>> {
     crate::client_helpers::request(
         client,
         crate::client_trait::Endpoint::Api,
         crate::client_trait::Style::Rpc,
-        crate::client_trait::Auth::Token,
         "files/search_v2",
         arg,
         None)
@@ -989,14 +954,13 @@ pub fn search_v2(
 /// search results due to a short delay in indexing. Duplicate results may be returned across pages.
 /// Some results may not be returned.
 pub fn search_continue_v2(
-    client: &dyn crate::client_trait::HttpClient,
+    client: &impl crate::client_trait::UserAuthClient,
     arg: &SearchV2ContinueArg,
 ) -> crate::Result<Result<SearchV2Result, SearchError>> {
     crate::client_helpers::request(
         client,
         crate::client_trait::Endpoint::Api,
         crate::client_trait::Style::Rpc,
-        crate::client_trait::Auth::Token,
         "files/search/continue_v2",
         arg,
         None)
@@ -1006,14 +970,13 @@ pub fn search_continue_v2(
 /// if a business account, a team admin. A successful response indicates that the file has been
 /// unlocked. Returns a list of the unlocked file paths and their metadata after this operation.
 pub fn unlock_file_batch(
-    client: &dyn crate::client_trait::HttpClient,
+    client: &impl crate::client_trait::UserAuthClient,
     arg: &UnlockFileBatchArg,
 ) -> crate::Result<Result<LockFileBatchResult, LockFileError>> {
     crate::client_helpers::request(
         client,
         crate::client_trait::Endpoint::Api,
         crate::client_trait::Style::Rpc,
-        crate::client_trait::Auth::Token,
         "files/unlock_file_batch",
         arg,
         None)
@@ -1026,7 +989,7 @@ pub fn unlock_file_batch(
 /// calls allowed per month. For more information, see the [Data transport limit
 /// page](https://www.dropbox.com/developers/reference/data-transport-limit).
 pub fn upload(
-    client: &dyn crate::client_trait::HttpClient,
+    client: &impl crate::client_trait::UserAuthClient,
     arg: &CommitInfo,
     body: &[u8],
 ) -> crate::Result<Result<FileMetadata, UploadError>> {
@@ -1034,7 +997,6 @@ pub fn upload(
         client,
         crate::client_trait::Endpoint::Content,
         crate::client_trait::Style::Upload,
-        crate::client_trait::Auth::Token,
         "files/upload",
         arg,
         Some(body))
@@ -1047,7 +1009,7 @@ pub fn upload(
 /// month. For more information, see the [Data transport limit
 /// page](https://www.dropbox.com/developers/reference/data-transport-limit).
 pub fn upload_session_append_v2(
-    client: &dyn crate::client_trait::HttpClient,
+    client: &impl crate::client_trait::UserAuthClient,
     arg: &UploadSessionAppendArg,
     body: &[u8],
 ) -> crate::Result<Result<(), UploadSessionLookupError>> {
@@ -1055,7 +1017,6 @@ pub fn upload_session_append_v2(
         client,
         crate::client_trait::Endpoint::Content,
         crate::client_trait::Style::Upload,
-        crate::client_trait::Auth::Token,
         "files/upload_session/append_v2",
         arg,
         Some(body))
@@ -1067,7 +1028,7 @@ pub fn upload_session_append_v2(
 /// data transport calls allowed per month. For more information, see the [Data transport limit
 /// page](https://www.dropbox.com/developers/reference/data-transport-limit).
 pub fn upload_session_append(
-    client: &dyn crate::client_trait::HttpClient,
+    client: &impl crate::client_trait::UserAuthClient,
     arg: &UploadSessionCursor,
     body: &[u8],
 ) -> crate::Result<Result<(), UploadSessionLookupError>> {
@@ -1075,7 +1036,6 @@ pub fn upload_session_append(
         client,
         crate::client_trait::Endpoint::Content,
         crate::client_trait::Style::Upload,
-        crate::client_trait::Auth::Token,
         "files/upload_session/append",
         arg,
         Some(body))
@@ -1088,7 +1048,7 @@ pub fn upload_session_append(
 /// information, see the [Data transport limit
 /// page](https://www.dropbox.com/developers/reference/data-transport-limit).
 pub fn upload_session_finish(
-    client: &dyn crate::client_trait::HttpClient,
+    client: &impl crate::client_trait::UserAuthClient,
     arg: &UploadSessionFinishArg,
     body: &[u8],
 ) -> crate::Result<Result<FileMetadata, UploadSessionFinishError>> {
@@ -1096,7 +1056,6 @@ pub fn upload_session_finish(
         client,
         crate::client_trait::Endpoint::Content,
         crate::client_trait::Style::Upload,
-        crate::client_trait::Auth::Token,
         "files/upload_session/finish",
         arg,
         Some(body))
@@ -1121,14 +1080,13 @@ pub fn upload_session_finish(
 /// limit on the number of data transport calls allowed per month. For more information, see the
 /// [Data transport limit page](https://www.dropbox.com/developers/reference/data-transport-limit).
 pub fn upload_session_finish_batch(
-    client: &dyn crate::client_trait::HttpClient,
+    client: &impl crate::client_trait::UserAuthClient,
     arg: &UploadSessionFinishBatchArg,
 ) -> crate::Result<Result<UploadSessionFinishBatchLaunch, ()>> {
     crate::client_helpers::request(
         client,
         crate::client_trait::Endpoint::Api,
         crate::client_trait::Style::Rpc,
-        crate::client_trait::Auth::Token,
         "files/upload_session/finish_batch",
         arg,
         None)
@@ -1138,14 +1096,13 @@ pub fn upload_session_finish_batch(
 /// [`upload_session_finish_batch()`](upload_session_finish_batch). If success, it returns list of
 /// result for each entry.
 pub fn upload_session_finish_batch_check(
-    client: &dyn crate::client_trait::HttpClient,
+    client: &impl crate::client_trait::UserAuthClient,
     arg: &super::dbx_async::PollArg,
 ) -> crate::Result<Result<UploadSessionFinishBatchJobStatus, super::dbx_async::PollError>> {
     crate::client_helpers::request(
         client,
         crate::client_trait::Endpoint::Api,
         crate::client_trait::Style::Rpc,
-        crate::client_trait::Auth::Token,
         "files/upload_session/finish_batch/check",
         arg,
         None)
@@ -1165,7 +1122,7 @@ pub fn upload_session_finish_batch_check(
 /// the number of data transport calls allowed per month. For more information, see the [Data
 /// transport limit page](https://www.dropbox.com/developers/reference/data-transport-limit).
 pub fn upload_session_start(
-    client: &dyn crate::client_trait::HttpClient,
+    client: &impl crate::client_trait::UserAuthClient,
     arg: &UploadSessionStartArg,
     body: &[u8],
 ) -> crate::Result<Result<UploadSessionStartResult, ()>> {
@@ -1173,7 +1130,6 @@ pub fn upload_session_start(
         client,
         crate::client_trait::Endpoint::Content,
         crate::client_trait::Style::Upload,
-        crate::client_trait::Auth::Token,
         "files/upload_session/start",
         arg,
         Some(body))

--- a/src/generated/files.rs
+++ b/src/generated/files.rs
@@ -36,6 +36,7 @@ pub fn alpha_get_metadata(
         client,
         crate::client_trait::Endpoint::Api,
         crate::client_trait::Style::Rpc,
+        crate::client_trait::Auth::Token,
         "files/alpha/get_metadata",
         arg,
         None)
@@ -54,6 +55,7 @@ pub fn alpha_upload(
         client,
         crate::client_trait::Endpoint::Content,
         crate::client_trait::Style::Upload,
+        crate::client_trait::Auth::Token,
         "files/alpha/upload",
         arg,
         Some(body))
@@ -69,6 +71,7 @@ pub fn copy_v2(
         client,
         crate::client_trait::Endpoint::Api,
         crate::client_trait::Style::Rpc,
+        crate::client_trait::Auth::Token,
         "files/copy_v2",
         arg,
         None)
@@ -84,6 +87,7 @@ pub fn copy(
         client,
         crate::client_trait::Endpoint::Api,
         crate::client_trait::Style::Rpc,
+        crate::client_trait::Auth::Token,
         "files/copy",
         arg,
         None)
@@ -102,6 +106,7 @@ pub fn copy_batch_v2(
         client,
         crate::client_trait::Endpoint::Api,
         crate::client_trait::Style::Rpc,
+        crate::client_trait::Auth::Token,
         "files/copy_batch_v2",
         arg,
         None)
@@ -122,6 +127,7 @@ pub fn copy_batch(
         client,
         crate::client_trait::Endpoint::Api,
         crate::client_trait::Style::Rpc,
+        crate::client_trait::Auth::Token,
         "files/copy_batch",
         arg,
         None)
@@ -137,6 +143,7 @@ pub fn copy_batch_check_v2(
         client,
         crate::client_trait::Endpoint::Api,
         crate::client_trait::Style::Rpc,
+        crate::client_trait::Auth::Token,
         "files/copy_batch/check_v2",
         arg,
         None)
@@ -152,6 +159,7 @@ pub fn copy_batch_check(
         client,
         crate::client_trait::Endpoint::Api,
         crate::client_trait::Style::Rpc,
+        crate::client_trait::Auth::Token,
         "files/copy_batch/check",
         arg,
         None)
@@ -168,6 +176,7 @@ pub fn copy_reference_get(
         client,
         crate::client_trait::Endpoint::Api,
         crate::client_trait::Style::Rpc,
+        crate::client_trait::Auth::Token,
         "files/copy_reference/get",
         arg,
         None)
@@ -183,6 +192,7 @@ pub fn copy_reference_save(
         client,
         crate::client_trait::Endpoint::Api,
         crate::client_trait::Style::Rpc,
+        crate::client_trait::Auth::Token,
         "files/copy_reference/save",
         arg,
         None)
@@ -197,6 +207,7 @@ pub fn create_folder_v2(
         client,
         crate::client_trait::Endpoint::Api,
         crate::client_trait::Style::Rpc,
+        crate::client_trait::Auth::Token,
         "files/create_folder_v2",
         arg,
         None)
@@ -211,6 +222,7 @@ pub fn create_folder(
         client,
         crate::client_trait::Endpoint::Api,
         crate::client_trait::Style::Rpc,
+        crate::client_trait::Auth::Token,
         "files/create_folder",
         arg,
         None)
@@ -229,6 +241,7 @@ pub fn create_folder_batch(
         client,
         crate::client_trait::Endpoint::Api,
         crate::client_trait::Style::Rpc,
+        crate::client_trait::Auth::Token,
         "files/create_folder_batch",
         arg,
         None)
@@ -244,6 +257,7 @@ pub fn create_folder_batch_check(
         client,
         crate::client_trait::Endpoint::Api,
         crate::client_trait::Style::Rpc,
+        crate::client_trait::Auth::Token,
         "files/create_folder_batch/check",
         arg,
         None)
@@ -262,6 +276,7 @@ pub fn delete_v2(
         client,
         crate::client_trait::Endpoint::Api,
         crate::client_trait::Style::Rpc,
+        crate::client_trait::Auth::Token,
         "files/delete_v2",
         arg,
         None)
@@ -280,6 +295,7 @@ pub fn delete(
         client,
         crate::client_trait::Endpoint::Api,
         crate::client_trait::Style::Rpc,
+        crate::client_trait::Auth::Token,
         "files/delete",
         arg,
         None)
@@ -296,6 +312,7 @@ pub fn delete_batch(
         client,
         crate::client_trait::Endpoint::Api,
         crate::client_trait::Style::Rpc,
+        crate::client_trait::Auth::Token,
         "files/delete_batch",
         arg,
         None)
@@ -311,6 +328,7 @@ pub fn delete_batch_check(
         client,
         crate::client_trait::Endpoint::Api,
         crate::client_trait::Style::Rpc,
+        crate::client_trait::Auth::Token,
         "files/delete_batch/check",
         arg,
         None)
@@ -327,6 +345,7 @@ pub fn download(
         client,
         crate::client_trait::Endpoint::Content,
         crate::client_trait::Style::Download,
+        crate::client_trait::Auth::Token,
         "files/download",
         arg,
         None,
@@ -347,6 +366,7 @@ pub fn download_zip(
         client,
         crate::client_trait::Endpoint::Content,
         crate::client_trait::Style::Download,
+        crate::client_trait::Auth::Token,
         "files/download_zip",
         arg,
         None,
@@ -367,6 +387,7 @@ pub fn export(
         client,
         crate::client_trait::Endpoint::Content,
         crate::client_trait::Style::Download,
+        crate::client_trait::Auth::Token,
         "files/export",
         arg,
         None,
@@ -383,6 +404,7 @@ pub fn get_file_lock_batch(
         client,
         crate::client_trait::Endpoint::Api,
         crate::client_trait::Style::Rpc,
+        crate::client_trait::Auth::Token,
         "files/get_file_lock_batch",
         arg,
         None)
@@ -397,6 +419,7 @@ pub fn get_metadata(
         client,
         crate::client_trait::Endpoint::Api,
         crate::client_trait::Style::Rpc,
+        crate::client_trait::Auth::Token,
         "files/get_metadata",
         arg,
         None)
@@ -417,6 +440,7 @@ pub fn get_preview(
         client,
         crate::client_trait::Endpoint::Content,
         crate::client_trait::Style::Download,
+        crate::client_trait::Auth::Token,
         "files/get_preview",
         arg,
         None,
@@ -435,6 +459,7 @@ pub fn get_temporary_link(
         client,
         crate::client_trait::Endpoint::Api,
         crate::client_trait::Style::Rpc,
+        crate::client_trait::Auth::Token,
         "files/get_temporary_link",
         arg,
         None)
@@ -484,6 +509,7 @@ pub fn get_temporary_upload_link(
         client,
         crate::client_trait::Endpoint::Api,
         crate::client_trait::Style::Rpc,
+        crate::client_trait::Auth::Token,
         "files/get_temporary_upload_link",
         arg,
         None)
@@ -502,6 +528,7 @@ pub fn get_thumbnail(
         client,
         crate::client_trait::Endpoint::Content,
         crate::client_trait::Style::Download,
+        crate::client_trait::Auth::Token,
         "files/get_thumbnail",
         arg,
         None,
@@ -520,6 +547,7 @@ pub fn get_thumbnail_v2(
         client,
         crate::client_trait::Endpoint::Content,
         crate::client_trait::Style::Download,
+        crate::client_trait::Auth::Token,
         "files/get_thumbnail_v2",
         arg,
         None,
@@ -538,6 +566,7 @@ pub fn get_thumbnail_batch(
         client,
         crate::client_trait::Endpoint::Content,
         crate::client_trait::Style::Rpc,
+        crate::client_trait::Auth::Token,
         "files/get_thumbnail_batch",
         arg,
         None)
@@ -571,6 +600,7 @@ pub fn list_folder(
         client,
         crate::client_trait::Endpoint::Api,
         crate::client_trait::Style::Rpc,
+        crate::client_trait::Auth::Token,
         "files/list_folder",
         arg,
         None)
@@ -587,6 +617,7 @@ pub fn list_folder_continue(
         client,
         crate::client_trait::Endpoint::Api,
         crate::client_trait::Style::Rpc,
+        crate::client_trait::Auth::Token,
         "files/list_folder/continue",
         arg,
         None)
@@ -604,6 +635,7 @@ pub fn list_folder_get_latest_cursor(
         client,
         crate::client_trait::Endpoint::Api,
         crate::client_trait::Style::Rpc,
+        crate::client_trait::Auth::Token,
         "files/list_folder/get_latest_cursor",
         arg,
         None)
@@ -623,6 +655,7 @@ pub fn list_folder_longpoll(
         client,
         crate::client_trait::Endpoint::Notify,
         crate::client_trait::Style::Rpc,
+        crate::client_trait::Auth::Noauth,
         "files/list_folder/longpoll",
         arg,
         None)
@@ -644,6 +677,7 @@ pub fn list_revisions(
         client,
         crate::client_trait::Endpoint::Api,
         crate::client_trait::Style::Rpc,
+        crate::client_trait::Auth::Token,
         "files/list_revisions",
         arg,
         None)
@@ -660,6 +694,7 @@ pub fn lock_file_batch(
         client,
         crate::client_trait::Endpoint::Api,
         crate::client_trait::Style::Rpc,
+        crate::client_trait::Auth::Token,
         "files/lock_file_batch",
         arg,
         None)
@@ -675,6 +710,7 @@ pub fn move_v2(
         client,
         crate::client_trait::Endpoint::Api,
         crate::client_trait::Style::Rpc,
+        crate::client_trait::Auth::Token,
         "files/move_v2",
         arg,
         None)
@@ -690,6 +726,7 @@ pub fn do_move(
         client,
         crate::client_trait::Endpoint::Api,
         crate::client_trait::Style::Rpc,
+        crate::client_trait::Auth::Token,
         "files/move",
         arg,
         None)
@@ -709,6 +746,7 @@ pub fn move_batch_v2(
         client,
         crate::client_trait::Endpoint::Api,
         crate::client_trait::Style::Rpc,
+        crate::client_trait::Auth::Token,
         "files/move_batch_v2",
         arg,
         None)
@@ -725,6 +763,7 @@ pub fn move_batch(
         client,
         crate::client_trait::Endpoint::Api,
         crate::client_trait::Style::Rpc,
+        crate::client_trait::Auth::Token,
         "files/move_batch",
         arg,
         None)
@@ -740,6 +779,7 @@ pub fn move_batch_check_v2(
         client,
         crate::client_trait::Endpoint::Api,
         crate::client_trait::Style::Rpc,
+        crate::client_trait::Auth::Token,
         "files/move_batch/check_v2",
         arg,
         None)
@@ -755,6 +795,7 @@ pub fn move_batch_check(
         client,
         crate::client_trait::Endpoint::Api,
         crate::client_trait::Style::Rpc,
+        crate::client_trait::Auth::Token,
         "files/move_batch/check",
         arg,
         None)
@@ -770,6 +811,7 @@ pub fn permanently_delete(
         client,
         crate::client_trait::Endpoint::Api,
         crate::client_trait::Style::Rpc,
+        crate::client_trait::Auth::Token,
         "files/permanently_delete",
         arg,
         None)
@@ -783,6 +825,7 @@ pub fn properties_add(
         client,
         crate::client_trait::Endpoint::Api,
         crate::client_trait::Style::Rpc,
+        crate::client_trait::Auth::Token,
         "files/properties/add",
         arg,
         None)
@@ -796,6 +839,7 @@ pub fn properties_overwrite(
         client,
         crate::client_trait::Endpoint::Api,
         crate::client_trait::Style::Rpc,
+        crate::client_trait::Auth::Token,
         "files/properties/overwrite",
         arg,
         None)
@@ -809,6 +853,7 @@ pub fn properties_remove(
         client,
         crate::client_trait::Endpoint::Api,
         crate::client_trait::Style::Rpc,
+        crate::client_trait::Auth::Token,
         "files/properties/remove",
         arg,
         None)
@@ -822,6 +867,7 @@ pub fn properties_template_get(
         client,
         crate::client_trait::Endpoint::Api,
         crate::client_trait::Style::Rpc,
+        crate::client_trait::Auth::Token,
         "files/properties/template/get",
         arg,
         None)
@@ -834,6 +880,7 @@ pub fn properties_template_list(
         client,
         crate::client_trait::Endpoint::Api,
         crate::client_trait::Style::Rpc,
+        crate::client_trait::Auth::Token,
         "files/properties/template/list",
         &(),
         None)
@@ -847,6 +894,7 @@ pub fn properties_update(
         client,
         crate::client_trait::Endpoint::Api,
         crate::client_trait::Style::Rpc,
+        crate::client_trait::Auth::Token,
         "files/properties/update",
         arg,
         None)
@@ -861,6 +909,7 @@ pub fn restore(
         client,
         crate::client_trait::Endpoint::Api,
         crate::client_trait::Style::Rpc,
+        crate::client_trait::Auth::Token,
         "files/restore",
         arg,
         None)
@@ -878,6 +927,7 @@ pub fn save_url(
         client,
         crate::client_trait::Endpoint::Api,
         crate::client_trait::Style::Rpc,
+        crate::client_trait::Auth::Token,
         "files/save_url",
         arg,
         None)
@@ -892,6 +942,7 @@ pub fn save_url_check_job_status(
         client,
         crate::client_trait::Endpoint::Api,
         crate::client_trait::Style::Rpc,
+        crate::client_trait::Auth::Token,
         "files/save_url/check_job_status",
         arg,
         None)
@@ -908,6 +959,7 @@ pub fn search(
         client,
         crate::client_trait::Endpoint::Api,
         crate::client_trait::Style::Rpc,
+        crate::client_trait::Auth::Token,
         "files/search",
         arg,
         None)
@@ -925,6 +977,7 @@ pub fn search_v2(
         client,
         crate::client_trait::Endpoint::Api,
         crate::client_trait::Style::Rpc,
+        crate::client_trait::Auth::Token,
         "files/search_v2",
         arg,
         None)
@@ -943,6 +996,7 @@ pub fn search_continue_v2(
         client,
         crate::client_trait::Endpoint::Api,
         crate::client_trait::Style::Rpc,
+        crate::client_trait::Auth::Token,
         "files/search/continue_v2",
         arg,
         None)
@@ -959,6 +1013,7 @@ pub fn unlock_file_batch(
         client,
         crate::client_trait::Endpoint::Api,
         crate::client_trait::Style::Rpc,
+        crate::client_trait::Auth::Token,
         "files/unlock_file_batch",
         arg,
         None)
@@ -979,6 +1034,7 @@ pub fn upload(
         client,
         crate::client_trait::Endpoint::Content,
         crate::client_trait::Style::Upload,
+        crate::client_trait::Auth::Token,
         "files/upload",
         arg,
         Some(body))
@@ -999,6 +1055,7 @@ pub fn upload_session_append_v2(
         client,
         crate::client_trait::Endpoint::Content,
         crate::client_trait::Style::Upload,
+        crate::client_trait::Auth::Token,
         "files/upload_session/append_v2",
         arg,
         Some(body))
@@ -1018,6 +1075,7 @@ pub fn upload_session_append(
         client,
         crate::client_trait::Endpoint::Content,
         crate::client_trait::Style::Upload,
+        crate::client_trait::Auth::Token,
         "files/upload_session/append",
         arg,
         Some(body))
@@ -1038,6 +1096,7 @@ pub fn upload_session_finish(
         client,
         crate::client_trait::Endpoint::Content,
         crate::client_trait::Style::Upload,
+        crate::client_trait::Auth::Token,
         "files/upload_session/finish",
         arg,
         Some(body))
@@ -1069,6 +1128,7 @@ pub fn upload_session_finish_batch(
         client,
         crate::client_trait::Endpoint::Api,
         crate::client_trait::Style::Rpc,
+        crate::client_trait::Auth::Token,
         "files/upload_session/finish_batch",
         arg,
         None)
@@ -1085,6 +1145,7 @@ pub fn upload_session_finish_batch_check(
         client,
         crate::client_trait::Endpoint::Api,
         crate::client_trait::Style::Rpc,
+        crate::client_trait::Auth::Token,
         "files/upload_session/finish_batch/check",
         arg,
         None)
@@ -1112,6 +1173,7 @@ pub fn upload_session_start(
         client,
         crate::client_trait::Endpoint::Content,
         crate::client_trait::Style::Upload,
+        crate::client_trait::Auth::Token,
         "files/upload_session/start",
         arg,
         Some(body))

--- a/src/generated/paper.rs
+++ b/src/generated/paper.rs
@@ -30,6 +30,7 @@ pub fn docs_archive(
         client,
         crate::client_trait::Endpoint::Api,
         crate::client_trait::Style::Rpc,
+        crate::client_trait::Auth::Token,
         "paper/docs/archive",
         arg,
         None)
@@ -51,6 +52,7 @@ pub fn docs_create(
         client,
         crate::client_trait::Endpoint::Api,
         crate::client_trait::Style::Upload,
+        crate::client_trait::Auth::Token,
         "paper/docs/create",
         arg,
         Some(body))
@@ -72,6 +74,7 @@ pub fn docs_download(
         client,
         crate::client_trait::Endpoint::Api,
         crate::client_trait::Style::Download,
+        crate::client_trait::Auth::Token,
         "paper/docs/download",
         arg,
         None,
@@ -95,6 +98,7 @@ pub fn docs_folder_users_list(
         client,
         crate::client_trait::Endpoint::Api,
         crate::client_trait::Style::Rpc,
+        crate::client_trait::Auth::Token,
         "paper/docs/folder_users/list",
         arg,
         None)
@@ -115,6 +119,7 @@ pub fn docs_folder_users_list_continue(
         client,
         crate::client_trait::Endpoint::Api,
         crate::client_trait::Style::Rpc,
+        crate::client_trait::Auth::Token,
         "paper/docs/folder_users/list/continue",
         arg,
         None)
@@ -139,6 +144,7 @@ pub fn docs_get_folder_info(
         client,
         crate::client_trait::Endpoint::Api,
         crate::client_trait::Style::Rpc,
+        crate::client_trait::Auth::Token,
         "paper/docs/get_folder_info",
         arg,
         None)
@@ -160,6 +166,7 @@ pub fn docs_list(
         client,
         crate::client_trait::Endpoint::Api,
         crate::client_trait::Style::Rpc,
+        crate::client_trait::Auth::Token,
         "paper/docs/list",
         arg,
         None)
@@ -180,6 +187,7 @@ pub fn docs_list_continue(
         client,
         crate::client_trait::Endpoint::Api,
         crate::client_trait::Style::Rpc,
+        crate::client_trait::Auth::Token,
         "paper/docs/list/continue",
         arg,
         None)
@@ -200,6 +208,7 @@ pub fn docs_permanently_delete(
         client,
         crate::client_trait::Endpoint::Api,
         crate::client_trait::Style::Rpc,
+        crate::client_trait::Auth::Token,
         "paper/docs/permanently_delete",
         arg,
         None)
@@ -219,6 +228,7 @@ pub fn docs_sharing_policy_get(
         client,
         crate::client_trait::Endpoint::Api,
         crate::client_trait::Style::Rpc,
+        crate::client_trait::Auth::Token,
         "paper/docs/sharing_policy/get",
         arg,
         None)
@@ -241,6 +251,7 @@ pub fn docs_sharing_policy_set(
         client,
         crate::client_trait::Endpoint::Api,
         crate::client_trait::Style::Rpc,
+        crate::client_trait::Auth::Token,
         "paper/docs/sharing_policy/set",
         arg,
         None)
@@ -262,6 +273,7 @@ pub fn docs_update(
         client,
         crate::client_trait::Endpoint::Api,
         crate::client_trait::Style::Upload,
+        crate::client_trait::Auth::Token,
         "paper/docs/update",
         arg,
         Some(body))
@@ -283,6 +295,7 @@ pub fn docs_users_add(
         client,
         crate::client_trait::Endpoint::Api,
         crate::client_trait::Style::Rpc,
+        crate::client_trait::Auth::Token,
         "paper/docs/users/add",
         arg,
         None)
@@ -305,6 +318,7 @@ pub fn docs_users_list(
         client,
         crate::client_trait::Endpoint::Api,
         crate::client_trait::Style::Rpc,
+        crate::client_trait::Auth::Token,
         "paper/docs/users/list",
         arg,
         None)
@@ -325,6 +339,7 @@ pub fn docs_users_list_continue(
         client,
         crate::client_trait::Endpoint::Api,
         crate::client_trait::Style::Rpc,
+        crate::client_trait::Auth::Token,
         "paper/docs/users/list/continue",
         arg,
         None)
@@ -345,6 +360,7 @@ pub fn docs_users_remove(
         client,
         crate::client_trait::Endpoint::Api,
         crate::client_trait::Style::Rpc,
+        crate::client_trait::Auth::Token,
         "paper/docs/users/remove",
         arg,
         None)
@@ -364,6 +380,7 @@ pub fn folders_create(
         client,
         crate::client_trait::Endpoint::Api,
         crate::client_trait::Style::Rpc,
+        crate::client_trait::Auth::Token,
         "paper/folders/create",
         arg,
         None)

--- a/src/generated/paper.rs
+++ b/src/generated/paper.rs
@@ -23,14 +23,13 @@ pub type PaperDocId = String;
 /// Migration Guide](https://www.dropbox.com/lp/developers/reference/paper-migration-guide) for more
 /// information.
 pub fn docs_archive(
-    client: &dyn crate::client_trait::HttpClient,
+    client: &impl crate::client_trait::UserAuthClient,
     arg: &RefPaperDoc,
 ) -> crate::Result<Result<(), DocLookupError>> {
     crate::client_helpers::request(
         client,
         crate::client_trait::Endpoint::Api,
         crate::client_trait::Style::Rpc,
-        crate::client_trait::Auth::Token,
         "paper/docs/archive",
         arg,
         None)
@@ -44,7 +43,7 @@ pub fn docs_archive(
 /// Guide](https://www.dropbox.com/lp/developers/reference/paper-migration-guide) for more
 /// information.
 pub fn docs_create(
-    client: &dyn crate::client_trait::HttpClient,
+    client: &impl crate::client_trait::UserAuthClient,
     arg: &PaperDocCreateArgs,
     body: &[u8],
 ) -> crate::Result<Result<PaperDocCreateUpdateResult, PaperDocCreateError>> {
@@ -52,7 +51,6 @@ pub fn docs_create(
         client,
         crate::client_trait::Endpoint::Api,
         crate::client_trait::Style::Upload,
-        crate::client_trait::Auth::Token,
         "paper/docs/create",
         arg,
         Some(body))
@@ -65,7 +63,7 @@ pub fn docs_create(
 /// Guide](https://www.dropbox.com/lp/developers/reference/paper-migration-guide) for migration
 /// information.
 pub fn docs_download(
-    client: &dyn crate::client_trait::HttpClient,
+    client: &impl crate::client_trait::UserAuthClient,
     arg: &PaperDocExport,
     range_start: Option<u64>,
     range_end: Option<u64>,
@@ -74,7 +72,6 @@ pub fn docs_download(
         client,
         crate::client_trait::Endpoint::Api,
         crate::client_trait::Style::Download,
-        crate::client_trait::Auth::Token,
         "paper/docs/download",
         arg,
         None,
@@ -91,14 +88,13 @@ pub fn docs_download(
 /// Guide](https://www.dropbox.com/lp/developers/reference/paper-migration-guide) for migration
 /// information.
 pub fn docs_folder_users_list(
-    client: &dyn crate::client_trait::HttpClient,
+    client: &impl crate::client_trait::UserAuthClient,
     arg: &ListUsersOnFolderArgs,
 ) -> crate::Result<Result<ListUsersOnFolderResponse, DocLookupError>> {
     crate::client_helpers::request(
         client,
         crate::client_trait::Endpoint::Api,
         crate::client_trait::Style::Rpc,
-        crate::client_trait::Auth::Token,
         "paper/docs/folder_users/list",
         arg,
         None)
@@ -112,14 +108,13 @@ pub fn docs_folder_users_list(
 /// Guide](https://www.dropbox.com/lp/developers/reference/paper-migration-guide) for migration
 /// information.
 pub fn docs_folder_users_list_continue(
-    client: &dyn crate::client_trait::HttpClient,
+    client: &impl crate::client_trait::UserAuthClient,
     arg: &ListUsersOnFolderContinueArgs,
 ) -> crate::Result<Result<ListUsersOnFolderResponse, ListUsersCursorError>> {
     crate::client_helpers::request(
         client,
         crate::client_trait::Endpoint::Api,
         crate::client_trait::Style::Rpc,
-        crate::client_trait::Auth::Token,
         "paper/docs/folder_users/list/continue",
         arg,
         None)
@@ -137,14 +132,13 @@ pub fn docs_folder_users_list_continue(
 /// Migration Guide](https://www.dropbox.com/lp/developers/reference/paper-migration-guide) for
 /// migration information.
 pub fn docs_get_folder_info(
-    client: &dyn crate::client_trait::HttpClient,
+    client: &impl crate::client_trait::UserAuthClient,
     arg: &RefPaperDoc,
 ) -> crate::Result<Result<FoldersContainingPaperDoc, DocLookupError>> {
     crate::client_helpers::request(
         client,
         crate::client_trait::Endpoint::Api,
         crate::client_trait::Style::Rpc,
-        crate::client_trait::Auth::Token,
         "paper/docs/get_folder_info",
         arg,
         None)
@@ -159,14 +153,13 @@ pub fn docs_get_folder_info(
 /// Guide](https://www.dropbox.com/lp/developers/reference/paper-migration-guide) for migration
 /// information.
 pub fn docs_list(
-    client: &dyn crate::client_trait::HttpClient,
+    client: &impl crate::client_trait::UserAuthClient,
     arg: &ListPaperDocsArgs,
 ) -> crate::Result<Result<ListPaperDocsResponse, ()>> {
     crate::client_helpers::request(
         client,
         crate::client_trait::Endpoint::Api,
         crate::client_trait::Style::Rpc,
-        crate::client_trait::Auth::Token,
         "paper/docs/list",
         arg,
         None)
@@ -180,14 +173,13 @@ pub fn docs_list(
 /// Guide](https://www.dropbox.com/lp/developers/reference/paper-migration-guide) for migration
 /// information.
 pub fn docs_list_continue(
-    client: &dyn crate::client_trait::HttpClient,
+    client: &impl crate::client_trait::UserAuthClient,
     arg: &ListPaperDocsContinueArgs,
 ) -> crate::Result<Result<ListPaperDocsResponse, ListDocsCursorError>> {
     crate::client_helpers::request(
         client,
         crate::client_trait::Endpoint::Api,
         crate::client_trait::Style::Rpc,
-        crate::client_trait::Auth::Token,
         "paper/docs/list/continue",
         arg,
         None)
@@ -201,14 +193,13 @@ pub fn docs_list_continue(
 /// Guide](https://www.dropbox.com/lp/developers/reference/paper-migration-guide) for migration
 /// information.
 pub fn docs_permanently_delete(
-    client: &dyn crate::client_trait::HttpClient,
+    client: &impl crate::client_trait::UserAuthClient,
     arg: &RefPaperDoc,
 ) -> crate::Result<Result<(), DocLookupError>> {
     crate::client_helpers::request(
         client,
         crate::client_trait::Endpoint::Api,
         crate::client_trait::Style::Rpc,
-        crate::client_trait::Auth::Token,
         "paper/docs/permanently_delete",
         arg,
         None)
@@ -221,14 +212,13 @@ pub fn docs_permanently_delete(
 /// Guide](https://www.dropbox.com/lp/developers/reference/paper-migration-guide) for migration
 /// information.
 pub fn docs_sharing_policy_get(
-    client: &dyn crate::client_trait::HttpClient,
+    client: &impl crate::client_trait::UserAuthClient,
     arg: &RefPaperDoc,
 ) -> crate::Result<Result<SharingPolicy, DocLookupError>> {
     crate::client_helpers::request(
         client,
         crate::client_trait::Endpoint::Api,
         crate::client_trait::Style::Rpc,
-        crate::client_trait::Auth::Token,
         "paper/docs/sharing_policy/get",
         arg,
         None)
@@ -244,14 +234,13 @@ pub fn docs_sharing_policy_get(
 /// Guide](https://www.dropbox.com/lp/developers/reference/paper-migration-guide) for migration
 /// information.
 pub fn docs_sharing_policy_set(
-    client: &dyn crate::client_trait::HttpClient,
+    client: &impl crate::client_trait::UserAuthClient,
     arg: &PaperDocSharingPolicy,
 ) -> crate::Result<Result<(), DocLookupError>> {
     crate::client_helpers::request(
         client,
         crate::client_trait::Endpoint::Api,
         crate::client_trait::Style::Rpc,
-        crate::client_trait::Auth::Token,
         "paper/docs/sharing_policy/set",
         arg,
         None)
@@ -265,7 +254,7 @@ pub fn docs_sharing_policy_set(
 /// Guide](https://www.dropbox.com/lp/developers/reference/paper-migration-guide) for more
 /// information.
 pub fn docs_update(
-    client: &dyn crate::client_trait::HttpClient,
+    client: &impl crate::client_trait::UserAuthClient,
     arg: &PaperDocUpdateArgs,
     body: &[u8],
 ) -> crate::Result<Result<PaperDocCreateUpdateResult, PaperDocUpdateError>> {
@@ -273,7 +262,6 @@ pub fn docs_update(
         client,
         crate::client_trait::Endpoint::Api,
         crate::client_trait::Style::Upload,
-        crate::client_trait::Auth::Token,
         "paper/docs/update",
         arg,
         Some(body))
@@ -288,14 +276,13 @@ pub fn docs_update(
 /// Guide](https://www.dropbox.com/lp/developers/reference/paper-migration-guide) for migration
 /// information.
 pub fn docs_users_add(
-    client: &dyn crate::client_trait::HttpClient,
+    client: &impl crate::client_trait::UserAuthClient,
     arg: &AddPaperDocUser,
 ) -> crate::Result<Result<Vec<AddPaperDocUserMemberResult>, DocLookupError>> {
     crate::client_helpers::request(
         client,
         crate::client_trait::Endpoint::Api,
         crate::client_trait::Style::Rpc,
-        crate::client_trait::Auth::Token,
         "paper/docs/users/add",
         arg,
         None)
@@ -311,14 +298,13 @@ pub fn docs_users_add(
 /// Guide](https://www.dropbox.com/lp/developers/reference/paper-migration-guide) for migration
 /// information.
 pub fn docs_users_list(
-    client: &dyn crate::client_trait::HttpClient,
+    client: &impl crate::client_trait::UserAuthClient,
     arg: &ListUsersOnPaperDocArgs,
 ) -> crate::Result<Result<ListUsersOnPaperDocResponse, DocLookupError>> {
     crate::client_helpers::request(
         client,
         crate::client_trait::Endpoint::Api,
         crate::client_trait::Style::Rpc,
-        crate::client_trait::Auth::Token,
         "paper/docs/users/list",
         arg,
         None)
@@ -332,14 +318,13 @@ pub fn docs_users_list(
 /// Guide](https://www.dropbox.com/lp/developers/reference/paper-migration-guide) for migration
 /// information.
 pub fn docs_users_list_continue(
-    client: &dyn crate::client_trait::HttpClient,
+    client: &impl crate::client_trait::UserAuthClient,
     arg: &ListUsersOnPaperDocContinueArgs,
 ) -> crate::Result<Result<ListUsersOnPaperDocResponse, ListUsersCursorError>> {
     crate::client_helpers::request(
         client,
         crate::client_trait::Endpoint::Api,
         crate::client_trait::Style::Rpc,
-        crate::client_trait::Auth::Token,
         "paper/docs/users/list/continue",
         arg,
         None)
@@ -353,14 +338,13 @@ pub fn docs_users_list_continue(
 /// Guide](https://www.dropbox.com/lp/developers/reference/paper-migration-guide) for migration
 /// information.
 pub fn docs_users_remove(
-    client: &dyn crate::client_trait::HttpClient,
+    client: &impl crate::client_trait::UserAuthClient,
     arg: &RemovePaperDocUser,
 ) -> crate::Result<Result<(), DocLookupError>> {
     crate::client_helpers::request(
         client,
         crate::client_trait::Endpoint::Api,
         crate::client_trait::Style::Rpc,
-        crate::client_trait::Auth::Token,
         "paper/docs/users/remove",
         arg,
         None)
@@ -373,14 +357,13 @@ pub fn docs_users_remove(
 /// Guide](https://www.dropbox.com/lp/developers/reference/paper-migration-guide) for migration
 /// information.
 pub fn folders_create(
-    client: &dyn crate::client_trait::HttpClient,
+    client: &impl crate::client_trait::UserAuthClient,
     arg: &PaperFolderCreateArg,
 ) -> crate::Result<Result<PaperFolderCreateResult, PaperFolderCreateError>> {
     crate::client_helpers::request(
         client,
         crate::client_trait::Endpoint::Api,
         crate::client_trait::Style::Rpc,
-        crate::client_trait::Auth::Token,
         "paper/folders/create",
         arg,
         None)

--- a/src/generated/sharing.rs
+++ b/src/generated/sharing.rs
@@ -28,6 +28,7 @@ pub fn add_file_member(
         client,
         crate::client_trait::Endpoint::Api,
         crate::client_trait::Style::Rpc,
+        crate::client_trait::Auth::Token,
         "sharing/add_file_member",
         arg,
         None)
@@ -44,6 +45,7 @@ pub fn add_folder_member(
         client,
         crate::client_trait::Endpoint::Api,
         crate::client_trait::Style::Rpc,
+        crate::client_trait::Auth::Token,
         "sharing/add_folder_member",
         arg,
         None)
@@ -58,6 +60,7 @@ pub fn change_file_member_access(
         client,
         crate::client_trait::Endpoint::Api,
         crate::client_trait::Style::Rpc,
+        crate::client_trait::Auth::Token,
         "sharing/change_file_member_access",
         arg,
         None)
@@ -72,6 +75,7 @@ pub fn check_job_status(
         client,
         crate::client_trait::Endpoint::Api,
         crate::client_trait::Style::Rpc,
+        crate::client_trait::Auth::Token,
         "sharing/check_job_status",
         arg,
         None)
@@ -86,6 +90,7 @@ pub fn check_remove_member_job_status(
         client,
         crate::client_trait::Endpoint::Api,
         crate::client_trait::Style::Rpc,
+        crate::client_trait::Auth::Token,
         "sharing/check_remove_member_job_status",
         arg,
         None)
@@ -100,6 +105,7 @@ pub fn check_share_job_status(
         client,
         crate::client_trait::Endpoint::Api,
         crate::client_trait::Style::Rpc,
+        crate::client_trait::Auth::Token,
         "sharing/check_share_job_status",
         arg,
         None)
@@ -121,6 +127,7 @@ pub fn create_shared_link(
         client,
         crate::client_trait::Endpoint::Api,
         crate::client_trait::Style::Rpc,
+        crate::client_trait::Auth::Token,
         "sharing/create_shared_link",
         arg,
         None)
@@ -137,6 +144,7 @@ pub fn create_shared_link_with_settings(
         client,
         crate::client_trait::Endpoint::Api,
         crate::client_trait::Style::Rpc,
+        crate::client_trait::Auth::Token,
         "sharing/create_shared_link_with_settings",
         arg,
         None)
@@ -151,6 +159,7 @@ pub fn get_file_metadata(
         client,
         crate::client_trait::Endpoint::Api,
         crate::client_trait::Style::Rpc,
+        crate::client_trait::Auth::Token,
         "sharing/get_file_metadata",
         arg,
         None)
@@ -165,6 +174,7 @@ pub fn get_file_metadata_batch(
         client,
         crate::client_trait::Endpoint::Api,
         crate::client_trait::Style::Rpc,
+        crate::client_trait::Auth::Token,
         "sharing/get_file_metadata/batch",
         arg,
         None)
@@ -179,6 +189,7 @@ pub fn get_folder_metadata(
         client,
         crate::client_trait::Endpoint::Api,
         crate::client_trait::Style::Rpc,
+        crate::client_trait::Auth::Token,
         "sharing/get_folder_metadata",
         arg,
         None)
@@ -195,6 +206,7 @@ pub fn get_shared_link_file(
         client,
         crate::client_trait::Endpoint::Content,
         crate::client_trait::Style::Download,
+        crate::client_trait::Auth::Token,
         "sharing/get_shared_link_file",
         arg,
         None,
@@ -211,6 +223,7 @@ pub fn get_shared_link_metadata(
         client,
         crate::client_trait::Endpoint::Api,
         crate::client_trait::Style::Rpc,
+        crate::client_trait::Auth::Token,
         "sharing/get_shared_link_metadata",
         arg,
         None)
@@ -229,6 +242,7 @@ pub fn get_shared_links(
         client,
         crate::client_trait::Endpoint::Api,
         crate::client_trait::Style::Rpc,
+        crate::client_trait::Auth::Token,
         "sharing/get_shared_links",
         arg,
         None)
@@ -244,6 +258,7 @@ pub fn list_file_members(
         client,
         crate::client_trait::Endpoint::Api,
         crate::client_trait::Style::Rpc,
+        crate::client_trait::Auth::Token,
         "sharing/list_file_members",
         arg,
         None)
@@ -261,6 +276,7 @@ pub fn list_file_members_batch(
         client,
         crate::client_trait::Endpoint::Api,
         crate::client_trait::Style::Rpc,
+        crate::client_trait::Auth::Token,
         "sharing/list_file_members/batch",
         arg,
         None)
@@ -277,6 +293,7 @@ pub fn list_file_members_continue(
         client,
         crate::client_trait::Endpoint::Api,
         crate::client_trait::Style::Rpc,
+        crate::client_trait::Auth::Token,
         "sharing/list_file_members/continue",
         arg,
         None)
@@ -291,6 +308,7 @@ pub fn list_folder_members(
         client,
         crate::client_trait::Endpoint::Api,
         crate::client_trait::Style::Rpc,
+        crate::client_trait::Auth::Token,
         "sharing/list_folder_members",
         arg,
         None)
@@ -306,6 +324,7 @@ pub fn list_folder_members_continue(
         client,
         crate::client_trait::Endpoint::Api,
         crate::client_trait::Style::Rpc,
+        crate::client_trait::Auth::Token,
         "sharing/list_folder_members/continue",
         arg,
         None)
@@ -320,6 +339,7 @@ pub fn list_folders(
         client,
         crate::client_trait::Endpoint::Api,
         crate::client_trait::Style::Rpc,
+        crate::client_trait::Auth::Token,
         "sharing/list_folders",
         arg,
         None)
@@ -336,6 +356,7 @@ pub fn list_folders_continue(
         client,
         crate::client_trait::Endpoint::Api,
         crate::client_trait::Style::Rpc,
+        crate::client_trait::Auth::Token,
         "sharing/list_folders/continue",
         arg,
         None)
@@ -350,6 +371,7 @@ pub fn list_mountable_folders(
         client,
         crate::client_trait::Endpoint::Api,
         crate::client_trait::Style::Rpc,
+        crate::client_trait::Auth::Token,
         "sharing/list_mountable_folders",
         arg,
         None)
@@ -367,6 +389,7 @@ pub fn list_mountable_folders_continue(
         client,
         crate::client_trait::Endpoint::Api,
         crate::client_trait::Style::Rpc,
+        crate::client_trait::Auth::Token,
         "sharing/list_mountable_folders/continue",
         arg,
         None)
@@ -382,6 +405,7 @@ pub fn list_received_files(
         client,
         crate::client_trait::Endpoint::Api,
         crate::client_trait::Style::Rpc,
+        crate::client_trait::Auth::Token,
         "sharing/list_received_files",
         arg,
         None)
@@ -396,6 +420,7 @@ pub fn list_received_files_continue(
         client,
         crate::client_trait::Endpoint::Api,
         crate::client_trait::Style::Rpc,
+        crate::client_trait::Auth::Token,
         "sharing/list_received_files/continue",
         arg,
         None)
@@ -417,6 +442,7 @@ pub fn list_shared_links(
         client,
         crate::client_trait::Endpoint::Api,
         crate::client_trait::Style::Rpc,
+        crate::client_trait::Auth::Token,
         "sharing/list_shared_links",
         arg,
         None)
@@ -436,6 +462,7 @@ pub fn modify_shared_link_settings(
         client,
         crate::client_trait::Endpoint::Api,
         crate::client_trait::Style::Rpc,
+        crate::client_trait::Auth::Token,
         "sharing/modify_shared_link_settings",
         arg,
         None)
@@ -451,6 +478,7 @@ pub fn mount_folder(
         client,
         crate::client_trait::Endpoint::Api,
         crate::client_trait::Style::Rpc,
+        crate::client_trait::Auth::Token,
         "sharing/mount_folder",
         arg,
         None)
@@ -466,6 +494,7 @@ pub fn relinquish_file_membership(
         client,
         crate::client_trait::Endpoint::Api,
         crate::client_trait::Style::Rpc,
+        crate::client_trait::Auth::Token,
         "sharing/relinquish_file_membership",
         arg,
         None)
@@ -483,6 +512,7 @@ pub fn relinquish_folder_membership(
         client,
         crate::client_trait::Endpoint::Api,
         crate::client_trait::Style::Rpc,
+        crate::client_trait::Auth::Token,
         "sharing/relinquish_folder_membership",
         arg,
         None)
@@ -497,6 +527,7 @@ pub fn remove_file_member(
         client,
         crate::client_trait::Endpoint::Api,
         crate::client_trait::Style::Rpc,
+        crate::client_trait::Auth::Token,
         "sharing/remove_file_member",
         arg,
         None)
@@ -511,6 +542,7 @@ pub fn remove_file_member_2(
         client,
         crate::client_trait::Endpoint::Api,
         crate::client_trait::Style::Rpc,
+        crate::client_trait::Auth::Token,
         "sharing/remove_file_member_2",
         arg,
         None)
@@ -526,6 +558,7 @@ pub fn remove_folder_member(
         client,
         crate::client_trait::Endpoint::Api,
         crate::client_trait::Style::Rpc,
+        crate::client_trait::Auth::Token,
         "sharing/remove_folder_member",
         arg,
         None)
@@ -544,6 +577,7 @@ pub fn revoke_shared_link(
         client,
         crate::client_trait::Endpoint::Api,
         crate::client_trait::Style::Rpc,
+        crate::client_trait::Auth::Token,
         "sharing/revoke_shared_link",
         arg,
         None)
@@ -561,6 +595,7 @@ pub fn set_access_inheritance(
         client,
         crate::client_trait::Endpoint::Api,
         crate::client_trait::Style::Rpc,
+        crate::client_trait::Auth::Token,
         "sharing/set_access_inheritance",
         arg,
         None)
@@ -580,6 +615,7 @@ pub fn share_folder(
         client,
         crate::client_trait::Endpoint::Api,
         crate::client_trait::Style::Rpc,
+        crate::client_trait::Auth::Token,
         "sharing/share_folder",
         arg,
         None)
@@ -595,6 +631,7 @@ pub fn transfer_folder(
         client,
         crate::client_trait::Endpoint::Api,
         crate::client_trait::Style::Rpc,
+        crate::client_trait::Auth::Token,
         "sharing/transfer_folder",
         arg,
         None)
@@ -610,6 +647,7 @@ pub fn unmount_folder(
         client,
         crate::client_trait::Endpoint::Api,
         crate::client_trait::Style::Rpc,
+        crate::client_trait::Auth::Token,
         "sharing/unmount_folder",
         arg,
         None)
@@ -624,6 +662,7 @@ pub fn unshare_file(
         client,
         crate::client_trait::Endpoint::Api,
         crate::client_trait::Style::Rpc,
+        crate::client_trait::Auth::Token,
         "sharing/unshare_file",
         arg,
         None)
@@ -639,6 +678,7 @@ pub fn unshare_folder(
         client,
         crate::client_trait::Endpoint::Api,
         crate::client_trait::Style::Rpc,
+        crate::client_trait::Auth::Token,
         "sharing/unshare_folder",
         arg,
         None)
@@ -653,6 +693,7 @@ pub fn update_file_member(
         client,
         crate::client_trait::Endpoint::Api,
         crate::client_trait::Style::Rpc,
+        crate::client_trait::Auth::Token,
         "sharing/update_file_member",
         arg,
         None)
@@ -667,6 +708,7 @@ pub fn update_folder_member(
         client,
         crate::client_trait::Endpoint::Api,
         crate::client_trait::Style::Rpc,
+        crate::client_trait::Auth::Token,
         "sharing/update_folder_member",
         arg,
         None)
@@ -682,6 +724,7 @@ pub fn update_folder_policy(
         client,
         crate::client_trait::Endpoint::Api,
         crate::client_trait::Style::Rpc,
+        crate::client_trait::Auth::Token,
         "sharing/update_folder_policy",
         arg,
         None)

--- a/src/generated/sharing.rs
+++ b/src/generated/sharing.rs
@@ -21,14 +21,13 @@ pub type TeamInfo = super::users::Team;
 
 /// Adds specified members to a file.
 pub fn add_file_member(
-    client: &dyn crate::client_trait::HttpClient,
+    client: &impl crate::client_trait::UserAuthClient,
     arg: &AddFileMemberArgs,
 ) -> crate::Result<Result<Vec<FileMemberActionResult>, AddFileMemberError>> {
     crate::client_helpers::request(
         client,
         crate::client_trait::Endpoint::Api,
         crate::client_trait::Style::Rpc,
-        crate::client_trait::Auth::Token,
         "sharing/add_file_member",
         arg,
         None)
@@ -38,14 +37,13 @@ pub fn add_file_member(
 /// member. For the new member to get access to all the functionality for this folder, you will need
 /// to call [`mount_folder()`](mount_folder) on their behalf.
 pub fn add_folder_member(
-    client: &dyn crate::client_trait::HttpClient,
+    client: &impl crate::client_trait::UserAuthClient,
     arg: &AddFolderMemberArg,
 ) -> crate::Result<Result<(), AddFolderMemberError>> {
     crate::client_helpers::request(
         client,
         crate::client_trait::Endpoint::Api,
         crate::client_trait::Style::Rpc,
-        crate::client_trait::Auth::Token,
         "sharing/add_folder_member",
         arg,
         None)
@@ -53,14 +51,13 @@ pub fn add_folder_member(
 
 /// Identical to update_file_member but with less information returned.
 pub fn change_file_member_access(
-    client: &dyn crate::client_trait::HttpClient,
+    client: &impl crate::client_trait::UserAuthClient,
     arg: &ChangeFileMemberAccessArgs,
 ) -> crate::Result<Result<FileMemberActionResult, FileMemberActionError>> {
     crate::client_helpers::request(
         client,
         crate::client_trait::Endpoint::Api,
         crate::client_trait::Style::Rpc,
-        crate::client_trait::Auth::Token,
         "sharing/change_file_member_access",
         arg,
         None)
@@ -68,14 +65,13 @@ pub fn change_file_member_access(
 
 /// Returns the status of an asynchronous job.
 pub fn check_job_status(
-    client: &dyn crate::client_trait::HttpClient,
+    client: &impl crate::client_trait::UserAuthClient,
     arg: &super::dbx_async::PollArg,
 ) -> crate::Result<Result<JobStatus, super::dbx_async::PollError>> {
     crate::client_helpers::request(
         client,
         crate::client_trait::Endpoint::Api,
         crate::client_trait::Style::Rpc,
-        crate::client_trait::Auth::Token,
         "sharing/check_job_status",
         arg,
         None)
@@ -83,14 +79,13 @@ pub fn check_job_status(
 
 /// Returns the status of an asynchronous job for sharing a folder.
 pub fn check_remove_member_job_status(
-    client: &dyn crate::client_trait::HttpClient,
+    client: &impl crate::client_trait::UserAuthClient,
     arg: &super::dbx_async::PollArg,
 ) -> crate::Result<Result<RemoveMemberJobStatus, super::dbx_async::PollError>> {
     crate::client_helpers::request(
         client,
         crate::client_trait::Endpoint::Api,
         crate::client_trait::Style::Rpc,
-        crate::client_trait::Auth::Token,
         "sharing/check_remove_member_job_status",
         arg,
         None)
@@ -98,14 +93,13 @@ pub fn check_remove_member_job_status(
 
 /// Returns the status of an asynchronous job for sharing a folder.
 pub fn check_share_job_status(
-    client: &dyn crate::client_trait::HttpClient,
+    client: &impl crate::client_trait::UserAuthClient,
     arg: &super::dbx_async::PollArg,
 ) -> crate::Result<Result<ShareFolderJobStatus, super::dbx_async::PollError>> {
     crate::client_helpers::request(
         client,
         crate::client_trait::Endpoint::Api,
         crate::client_trait::Style::Rpc,
-        crate::client_trait::Auth::Token,
         "sharing/check_share_job_status",
         arg,
         None)
@@ -120,14 +114,13 @@ pub fn check_share_job_status(
 /// behavior. Instead, if your app needs to revoke a shared link, use
 /// [`revoke_shared_link()`](revoke_shared_link).
 pub fn create_shared_link(
-    client: &dyn crate::client_trait::HttpClient,
+    client: &impl crate::client_trait::UserAuthClient,
     arg: &CreateSharedLinkArg,
 ) -> crate::Result<Result<PathLinkMetadata, CreateSharedLinkError>> {
     crate::client_helpers::request(
         client,
         crate::client_trait::Endpoint::Api,
         crate::client_trait::Style::Rpc,
-        crate::client_trait::Auth::Token,
         "sharing/create_shared_link",
         arg,
         None)
@@ -137,14 +130,13 @@ pub fn create_shared_link(
 /// is [`RequestedVisibility::Public`](RequestedVisibility::Public) (The resolved visibility,
 /// though, may depend on other aspects such as team and shared folder settings).
 pub fn create_shared_link_with_settings(
-    client: &dyn crate::client_trait::HttpClient,
+    client: &impl crate::client_trait::UserAuthClient,
     arg: &CreateSharedLinkWithSettingsArg,
 ) -> crate::Result<Result<SharedLinkMetadata, CreateSharedLinkWithSettingsError>> {
     crate::client_helpers::request(
         client,
         crate::client_trait::Endpoint::Api,
         crate::client_trait::Style::Rpc,
-        crate::client_trait::Auth::Token,
         "sharing/create_shared_link_with_settings",
         arg,
         None)
@@ -152,14 +144,13 @@ pub fn create_shared_link_with_settings(
 
 /// Returns shared file metadata.
 pub fn get_file_metadata(
-    client: &dyn crate::client_trait::HttpClient,
+    client: &impl crate::client_trait::UserAuthClient,
     arg: &GetFileMetadataArg,
 ) -> crate::Result<Result<SharedFileMetadata, GetFileMetadataError>> {
     crate::client_helpers::request(
         client,
         crate::client_trait::Endpoint::Api,
         crate::client_trait::Style::Rpc,
-        crate::client_trait::Auth::Token,
         "sharing/get_file_metadata",
         arg,
         None)
@@ -167,14 +158,13 @@ pub fn get_file_metadata(
 
 /// Returns shared file metadata.
 pub fn get_file_metadata_batch(
-    client: &dyn crate::client_trait::HttpClient,
+    client: &impl crate::client_trait::UserAuthClient,
     arg: &GetFileMetadataBatchArg,
 ) -> crate::Result<Result<Vec<GetFileMetadataBatchResult>, SharingUserError>> {
     crate::client_helpers::request(
         client,
         crate::client_trait::Endpoint::Api,
         crate::client_trait::Style::Rpc,
-        crate::client_trait::Auth::Token,
         "sharing/get_file_metadata/batch",
         arg,
         None)
@@ -182,14 +172,13 @@ pub fn get_file_metadata_batch(
 
 /// Returns shared folder metadata by its folder ID.
 pub fn get_folder_metadata(
-    client: &dyn crate::client_trait::HttpClient,
+    client: &impl crate::client_trait::UserAuthClient,
     arg: &GetMetadataArgs,
 ) -> crate::Result<Result<SharedFolderMetadata, SharedFolderAccessError>> {
     crate::client_helpers::request(
         client,
         crate::client_trait::Endpoint::Api,
         crate::client_trait::Style::Rpc,
-        crate::client_trait::Auth::Token,
         "sharing/get_folder_metadata",
         arg,
         None)
@@ -197,7 +186,7 @@ pub fn get_folder_metadata(
 
 /// Download the shared link's file from a user's Dropbox.
 pub fn get_shared_link_file(
-    client: &dyn crate::client_trait::HttpClient,
+    client: &impl crate::client_trait::UserAuthClient,
     arg: &GetSharedLinkFileArg,
     range_start: Option<u64>,
     range_end: Option<u64>,
@@ -206,7 +195,6 @@ pub fn get_shared_link_file(
         client,
         crate::client_trait::Endpoint::Content,
         crate::client_trait::Style::Download,
-        crate::client_trait::Auth::Token,
         "sharing/get_shared_link_file",
         arg,
         None,
@@ -216,14 +204,13 @@ pub fn get_shared_link_file(
 
 /// Get the shared link's metadata.
 pub fn get_shared_link_metadata(
-    client: &dyn crate::client_trait::HttpClient,
+    client: &impl crate::client_trait::UserAuthClient,
     arg: &GetSharedLinkMetadataArg,
 ) -> crate::Result<Result<SharedLinkMetadata, SharedLinkError>> {
     crate::client_helpers::request(
         client,
         crate::client_trait::Endpoint::Api,
         crate::client_trait::Style::Rpc,
-        crate::client_trait::Auth::Token,
         "sharing/get_shared_link_metadata",
         arg,
         None)
@@ -235,14 +222,13 @@ pub fn get_shared_link_metadata(
 /// all shared links that allow access to the given path.  Collection links are never returned in
 /// this case. Note that the url field in the response is never the shortened URL.
 pub fn get_shared_links(
-    client: &dyn crate::client_trait::HttpClient,
+    client: &impl crate::client_trait::UserAuthClient,
     arg: &GetSharedLinksArg,
 ) -> crate::Result<Result<GetSharedLinksResult, GetSharedLinksError>> {
     crate::client_helpers::request(
         client,
         crate::client_trait::Endpoint::Api,
         crate::client_trait::Style::Rpc,
-        crate::client_trait::Auth::Token,
         "sharing/get_shared_links",
         arg,
         None)
@@ -251,14 +237,13 @@ pub fn get_shared_links(
 /// Use to obtain the members who have been invited to a file, both inherited and uninherited
 /// members.
 pub fn list_file_members(
-    client: &dyn crate::client_trait::HttpClient,
+    client: &impl crate::client_trait::UserAuthClient,
     arg: &ListFileMembersArg,
 ) -> crate::Result<Result<SharedFileMembers, ListFileMembersError>> {
     crate::client_helpers::request(
         client,
         crate::client_trait::Endpoint::Api,
         crate::client_trait::Style::Rpc,
-        crate::client_trait::Auth::Token,
         "sharing/list_file_members",
         arg,
         None)
@@ -269,14 +254,13 @@ pub fn list_file_members(
 /// individual file endpoint. Inherited users and groups are not included in the result, and
 /// permissions are not returned for this endpoint.
 pub fn list_file_members_batch(
-    client: &dyn crate::client_trait::HttpClient,
+    client: &impl crate::client_trait::UserAuthClient,
     arg: &ListFileMembersBatchArg,
 ) -> crate::Result<Result<Vec<ListFileMembersBatchResult>, SharingUserError>> {
     crate::client_helpers::request(
         client,
         crate::client_trait::Endpoint::Api,
         crate::client_trait::Style::Rpc,
-        crate::client_trait::Auth::Token,
         "sharing/list_file_members/batch",
         arg,
         None)
@@ -286,14 +270,13 @@ pub fn list_file_members_batch(
 /// [`list_file_members_batch()`](list_file_members_batch), use this to paginate through all shared
 /// file members.
 pub fn list_file_members_continue(
-    client: &dyn crate::client_trait::HttpClient,
+    client: &impl crate::client_trait::UserAuthClient,
     arg: &ListFileMembersContinueArg,
 ) -> crate::Result<Result<SharedFileMembers, ListFileMembersContinueError>> {
     crate::client_helpers::request(
         client,
         crate::client_trait::Endpoint::Api,
         crate::client_trait::Style::Rpc,
-        crate::client_trait::Auth::Token,
         "sharing/list_file_members/continue",
         arg,
         None)
@@ -301,14 +284,13 @@ pub fn list_file_members_continue(
 
 /// Returns shared folder membership by its folder ID.
 pub fn list_folder_members(
-    client: &dyn crate::client_trait::HttpClient,
+    client: &impl crate::client_trait::UserAuthClient,
     arg: &ListFolderMembersArgs,
 ) -> crate::Result<Result<SharedFolderMembers, SharedFolderAccessError>> {
     crate::client_helpers::request(
         client,
         crate::client_trait::Endpoint::Api,
         crate::client_trait::Style::Rpc,
-        crate::client_trait::Auth::Token,
         "sharing/list_folder_members",
         arg,
         None)
@@ -317,14 +299,13 @@ pub fn list_folder_members(
 /// Once a cursor has been retrieved from [`list_folder_members()`](list_folder_members), use this
 /// to paginate through all shared folder members.
 pub fn list_folder_members_continue(
-    client: &dyn crate::client_trait::HttpClient,
+    client: &impl crate::client_trait::UserAuthClient,
     arg: &ListFolderMembersContinueArg,
 ) -> crate::Result<Result<SharedFolderMembers, ListFolderMembersContinueError>> {
     crate::client_helpers::request(
         client,
         crate::client_trait::Endpoint::Api,
         crate::client_trait::Style::Rpc,
-        crate::client_trait::Auth::Token,
         "sharing/list_folder_members/continue",
         arg,
         None)
@@ -332,14 +313,13 @@ pub fn list_folder_members_continue(
 
 /// Return the list of all shared folders the current user has access to.
 pub fn list_folders(
-    client: &dyn crate::client_trait::HttpClient,
+    client: &impl crate::client_trait::UserAuthClient,
     arg: &ListFoldersArgs,
 ) -> crate::Result<Result<ListFoldersResult, ()>> {
     crate::client_helpers::request(
         client,
         crate::client_trait::Endpoint::Api,
         crate::client_trait::Style::Rpc,
-        crate::client_trait::Auth::Token,
         "sharing/list_folders",
         arg,
         None)
@@ -349,14 +329,13 @@ pub fn list_folders(
 /// through all shared folders. The cursor must come from a previous call to
 /// [`list_folders()`](list_folders) or [`list_folders_continue()`](list_folders_continue).
 pub fn list_folders_continue(
-    client: &dyn crate::client_trait::HttpClient,
+    client: &impl crate::client_trait::UserAuthClient,
     arg: &ListFoldersContinueArg,
 ) -> crate::Result<Result<ListFoldersResult, ListFoldersContinueError>> {
     crate::client_helpers::request(
         client,
         crate::client_trait::Endpoint::Api,
         crate::client_trait::Style::Rpc,
-        crate::client_trait::Auth::Token,
         "sharing/list_folders/continue",
         arg,
         None)
@@ -364,14 +343,13 @@ pub fn list_folders_continue(
 
 /// Return the list of all shared folders the current user can mount or unmount.
 pub fn list_mountable_folders(
-    client: &dyn crate::client_trait::HttpClient,
+    client: &impl crate::client_trait::UserAuthClient,
     arg: &ListFoldersArgs,
 ) -> crate::Result<Result<ListFoldersResult, ()>> {
     crate::client_helpers::request(
         client,
         crate::client_trait::Endpoint::Api,
         crate::client_trait::Style::Rpc,
-        crate::client_trait::Auth::Token,
         "sharing/list_mountable_folders",
         arg,
         None)
@@ -382,14 +360,13 @@ pub fn list_mountable_folders(
 /// to [`list_mountable_folders()`](list_mountable_folders) or
 /// [`list_mountable_folders_continue()`](list_mountable_folders_continue).
 pub fn list_mountable_folders_continue(
-    client: &dyn crate::client_trait::HttpClient,
+    client: &impl crate::client_trait::UserAuthClient,
     arg: &ListFoldersContinueArg,
 ) -> crate::Result<Result<ListFoldersResult, ListFoldersContinueError>> {
     crate::client_helpers::request(
         client,
         crate::client_trait::Endpoint::Api,
         crate::client_trait::Style::Rpc,
-        crate::client_trait::Auth::Token,
         "sharing/list_mountable_folders/continue",
         arg,
         None)
@@ -398,14 +375,13 @@ pub fn list_mountable_folders_continue(
 /// Returns a list of all files shared with current user.  Does not include files the user has
 /// received via shared folders, and does  not include unclaimed invitations.
 pub fn list_received_files(
-    client: &dyn crate::client_trait::HttpClient,
+    client: &impl crate::client_trait::UserAuthClient,
     arg: &ListFilesArg,
 ) -> crate::Result<Result<ListFilesResult, SharingUserError>> {
     crate::client_helpers::request(
         client,
         crate::client_trait::Endpoint::Api,
         crate::client_trait::Style::Rpc,
-        crate::client_trait::Auth::Token,
         "sharing/list_received_files",
         arg,
         None)
@@ -413,14 +389,13 @@ pub fn list_received_files(
 
 /// Get more results with a cursor from [`list_received_files()`](list_received_files).
 pub fn list_received_files_continue(
-    client: &dyn crate::client_trait::HttpClient,
+    client: &impl crate::client_trait::UserAuthClient,
     arg: &ListFilesContinueArg,
 ) -> crate::Result<Result<ListFilesResult, ListFilesContinueError>> {
     crate::client_helpers::request(
         client,
         crate::client_trait::Endpoint::Api,
         crate::client_trait::Style::Rpc,
-        crate::client_trait::Auth::Token,
         "sharing/list_received_files/continue",
         arg,
         None)
@@ -435,14 +410,13 @@ pub fn list_received_files_continue(
 /// the given path and links to parent folders of the given path. Links to parent folders can be
 /// suppressed by setting direct_only to true.
 pub fn list_shared_links(
-    client: &dyn crate::client_trait::HttpClient,
+    client: &impl crate::client_trait::UserAuthClient,
     arg: &ListSharedLinksArg,
 ) -> crate::Result<Result<ListSharedLinksResult, ListSharedLinksError>> {
     crate::client_helpers::request(
         client,
         crate::client_trait::Endpoint::Api,
         crate::client_trait::Style::Rpc,
-        crate::client_trait::Auth::Token,
         "sharing/list_shared_links",
         arg,
         None)
@@ -455,14 +429,13 @@ pub fn list_shared_links(
 /// and the [`LinkPermissions::requested_visibility`](LinkPermissions) will reflect the requested
 /// visibility.
 pub fn modify_shared_link_settings(
-    client: &dyn crate::client_trait::HttpClient,
+    client: &impl crate::client_trait::UserAuthClient,
     arg: &ModifySharedLinkSettingsArgs,
 ) -> crate::Result<Result<SharedLinkMetadata, ModifySharedLinkSettingsError>> {
     crate::client_helpers::request(
         client,
         crate::client_trait::Endpoint::Api,
         crate::client_trait::Style::Rpc,
-        crate::client_trait::Auth::Token,
         "sharing/modify_shared_link_settings",
         arg,
         None)
@@ -471,14 +444,13 @@ pub fn modify_shared_link_settings(
 /// The current user mounts the designated folder. Mount a shared folder for a user after they have
 /// been added as a member. Once mounted, the shared folder will appear in their Dropbox.
 pub fn mount_folder(
-    client: &dyn crate::client_trait::HttpClient,
+    client: &impl crate::client_trait::UserAuthClient,
     arg: &MountFolderArg,
 ) -> crate::Result<Result<SharedFolderMetadata, MountFolderError>> {
     crate::client_helpers::request(
         client,
         crate::client_trait::Endpoint::Api,
         crate::client_trait::Style::Rpc,
-        crate::client_trait::Auth::Token,
         "sharing/mount_folder",
         arg,
         None)
@@ -487,14 +459,13 @@ pub fn mount_folder(
 /// The current user relinquishes their membership in the designated file. Note that the current
 /// user may still have inherited access to this file through the parent folder.
 pub fn relinquish_file_membership(
-    client: &dyn crate::client_trait::HttpClient,
+    client: &impl crate::client_trait::UserAuthClient,
     arg: &RelinquishFileMembershipArg,
 ) -> crate::Result<Result<(), RelinquishFileMembershipError>> {
     crate::client_helpers::request(
         client,
         crate::client_trait::Endpoint::Api,
         crate::client_trait::Style::Rpc,
-        crate::client_trait::Auth::Token,
         "sharing/relinquish_file_membership",
         arg,
         None)
@@ -505,14 +476,13 @@ pub fn relinquish_file_membership(
 /// folder. This will run synchronously if leave_a_copy is false, and asynchronously if leave_a_copy
 /// is true.
 pub fn relinquish_folder_membership(
-    client: &dyn crate::client_trait::HttpClient,
+    client: &impl crate::client_trait::UserAuthClient,
     arg: &RelinquishFolderMembershipArg,
 ) -> crate::Result<Result<super::dbx_async::LaunchEmptyResult, RelinquishFolderMembershipError>> {
     crate::client_helpers::request(
         client,
         crate::client_trait::Endpoint::Api,
         crate::client_trait::Style::Rpc,
-        crate::client_trait::Auth::Token,
         "sharing/relinquish_folder_membership",
         arg,
         None)
@@ -520,14 +490,13 @@ pub fn relinquish_folder_membership(
 
 /// Identical to remove_file_member_2 but with less information returned.
 pub fn remove_file_member(
-    client: &dyn crate::client_trait::HttpClient,
+    client: &impl crate::client_trait::UserAuthClient,
     arg: &RemoveFileMemberArg,
 ) -> crate::Result<Result<FileMemberActionIndividualResult, RemoveFileMemberError>> {
     crate::client_helpers::request(
         client,
         crate::client_trait::Endpoint::Api,
         crate::client_trait::Style::Rpc,
-        crate::client_trait::Auth::Token,
         "sharing/remove_file_member",
         arg,
         None)
@@ -535,14 +504,13 @@ pub fn remove_file_member(
 
 /// Removes a specified member from the file.
 pub fn remove_file_member_2(
-    client: &dyn crate::client_trait::HttpClient,
+    client: &impl crate::client_trait::UserAuthClient,
     arg: &RemoveFileMemberArg,
 ) -> crate::Result<Result<FileMemberRemoveActionResult, RemoveFileMemberError>> {
     crate::client_helpers::request(
         client,
         crate::client_trait::Endpoint::Api,
         crate::client_trait::Style::Rpc,
-        crate::client_trait::Auth::Token,
         "sharing/remove_file_member_2",
         arg,
         None)
@@ -551,14 +519,13 @@ pub fn remove_file_member_2(
 /// Allows an owner or editor (if the ACL update policy allows) of a shared folder to remove another
 /// member.
 pub fn remove_folder_member(
-    client: &dyn crate::client_trait::HttpClient,
+    client: &impl crate::client_trait::UserAuthClient,
     arg: &RemoveFolderMemberArg,
 ) -> crate::Result<Result<super::dbx_async::LaunchResultBase, RemoveFolderMemberError>> {
     crate::client_helpers::request(
         client,
         crate::client_trait::Endpoint::Api,
         crate::client_trait::Style::Rpc,
-        crate::client_trait::Auth::Token,
         "sharing/remove_folder_member",
         arg,
         None)
@@ -570,14 +537,13 @@ pub fn remove_folder_member(
 /// [`list_shared_links()`](list_shared_links) with the file as the
 /// [`ListSharedLinksArg::path`](ListSharedLinksArg) argument.
 pub fn revoke_shared_link(
-    client: &dyn crate::client_trait::HttpClient,
+    client: &impl crate::client_trait::UserAuthClient,
     arg: &RevokeSharedLinkArg,
 ) -> crate::Result<Result<(), RevokeSharedLinkError>> {
     crate::client_helpers::request(
         client,
         crate::client_trait::Endpoint::Api,
         crate::client_trait::Style::Rpc,
-        crate::client_trait::Auth::Token,
         "sharing/revoke_shared_link",
         arg,
         None)
@@ -588,14 +554,13 @@ pub fn revoke_shared_link(
 /// returned, you'll need to call [`check_share_job_status()`](check_share_job_status) until the
 /// action completes to get the metadata for the folder.
 pub fn set_access_inheritance(
-    client: &dyn crate::client_trait::HttpClient,
+    client: &impl crate::client_trait::UserAuthClient,
     arg: &SetAccessInheritanceArg,
 ) -> crate::Result<Result<ShareFolderLaunch, SetAccessInheritanceError>> {
     crate::client_helpers::request(
         client,
         crate::client_trait::Endpoint::Api,
         crate::client_trait::Style::Rpc,
-        crate::client_trait::Auth::Token,
         "sharing/set_access_inheritance",
         arg,
         None)
@@ -608,14 +573,13 @@ pub fn set_access_inheritance(
 /// call [`check_share_job_status()`](check_share_job_status) until the action completes to get the
 /// metadata for the folder.
 pub fn share_folder(
-    client: &dyn crate::client_trait::HttpClient,
+    client: &impl crate::client_trait::UserAuthClient,
     arg: &ShareFolderArg,
 ) -> crate::Result<Result<ShareFolderLaunch, ShareFolderError>> {
     crate::client_helpers::request(
         client,
         crate::client_trait::Endpoint::Api,
         crate::client_trait::Style::Rpc,
-        crate::client_trait::Auth::Token,
         "sharing/share_folder",
         arg,
         None)
@@ -624,14 +588,13 @@ pub fn share_folder(
 /// Transfer ownership of a shared folder to a member of the shared folder. User must have
 /// [`AccessLevel::Owner`](AccessLevel::Owner) access to the shared folder to perform a transfer.
 pub fn transfer_folder(
-    client: &dyn crate::client_trait::HttpClient,
+    client: &impl crate::client_trait::UserAuthClient,
     arg: &TransferFolderArg,
 ) -> crate::Result<Result<(), TransferFolderError>> {
     crate::client_helpers::request(
         client,
         crate::client_trait::Endpoint::Api,
         crate::client_trait::Style::Rpc,
-        crate::client_trait::Auth::Token,
         "sharing/transfer_folder",
         arg,
         None)
@@ -640,14 +603,13 @@ pub fn transfer_folder(
 /// The current user unmounts the designated folder. They can re-mount the folder at a later time
 /// using [`mount_folder()`](mount_folder).
 pub fn unmount_folder(
-    client: &dyn crate::client_trait::HttpClient,
+    client: &impl crate::client_trait::UserAuthClient,
     arg: &UnmountFolderArg,
 ) -> crate::Result<Result<(), UnmountFolderError>> {
     crate::client_helpers::request(
         client,
         crate::client_trait::Endpoint::Api,
         crate::client_trait::Style::Rpc,
-        crate::client_trait::Auth::Token,
         "sharing/unmount_folder",
         arg,
         None)
@@ -655,14 +617,13 @@ pub fn unmount_folder(
 
 /// Remove all members from this file. Does not remove inherited members.
 pub fn unshare_file(
-    client: &dyn crate::client_trait::HttpClient,
+    client: &impl crate::client_trait::UserAuthClient,
     arg: &UnshareFileArg,
 ) -> crate::Result<Result<(), UnshareFileError>> {
     crate::client_helpers::request(
         client,
         crate::client_trait::Endpoint::Api,
         crate::client_trait::Style::Rpc,
-        crate::client_trait::Auth::Token,
         "sharing/unshare_file",
         arg,
         None)
@@ -671,14 +632,13 @@ pub fn unshare_file(
 /// Allows a shared folder owner to unshare the folder. You'll need to call
 /// [`check_job_status()`](check_job_status) to determine if the action has completed successfully.
 pub fn unshare_folder(
-    client: &dyn crate::client_trait::HttpClient,
+    client: &impl crate::client_trait::UserAuthClient,
     arg: &UnshareFolderArg,
 ) -> crate::Result<Result<super::dbx_async::LaunchEmptyResult, UnshareFolderError>> {
     crate::client_helpers::request(
         client,
         crate::client_trait::Endpoint::Api,
         crate::client_trait::Style::Rpc,
-        crate::client_trait::Auth::Token,
         "sharing/unshare_folder",
         arg,
         None)
@@ -686,14 +646,13 @@ pub fn unshare_folder(
 
 /// Changes a member's access on a shared file.
 pub fn update_file_member(
-    client: &dyn crate::client_trait::HttpClient,
+    client: &impl crate::client_trait::UserAuthClient,
     arg: &UpdateFileMemberArgs,
 ) -> crate::Result<Result<MemberAccessLevelResult, FileMemberActionError>> {
     crate::client_helpers::request(
         client,
         crate::client_trait::Endpoint::Api,
         crate::client_trait::Style::Rpc,
-        crate::client_trait::Auth::Token,
         "sharing/update_file_member",
         arg,
         None)
@@ -701,14 +660,13 @@ pub fn update_file_member(
 
 /// Allows an owner or editor of a shared folder to update another member's permissions.
 pub fn update_folder_member(
-    client: &dyn crate::client_trait::HttpClient,
+    client: &impl crate::client_trait::UserAuthClient,
     arg: &UpdateFolderMemberArg,
 ) -> crate::Result<Result<MemberAccessLevelResult, UpdateFolderMemberError>> {
     crate::client_helpers::request(
         client,
         crate::client_trait::Endpoint::Api,
         crate::client_trait::Style::Rpc,
-        crate::client_trait::Auth::Token,
         "sharing/update_folder_member",
         arg,
         None)
@@ -717,14 +675,13 @@ pub fn update_folder_member(
 /// Update the sharing policies for a shared folder. User must have
 /// [`AccessLevel::Owner`](AccessLevel::Owner) access to the shared folder to update its policies.
 pub fn update_folder_policy(
-    client: &dyn crate::client_trait::HttpClient,
+    client: &impl crate::client_trait::UserAuthClient,
     arg: &UpdateFolderPolicyArg,
 ) -> crate::Result<Result<SharedFolderMetadata, UpdateFolderPolicyError>> {
     crate::client_helpers::request(
         client,
         crate::client_trait::Endpoint::Api,
         crate::client_trait::Style::Rpc,
-        crate::client_trait::Auth::Token,
         "sharing/update_folder_policy",
         arg,
         None)

--- a/src/generated/team.rs
+++ b/src/generated/team.rs
@@ -30,6 +30,7 @@ pub fn devices_list_member_devices(
         client,
         crate::client_trait::Endpoint::Api,
         crate::client_trait::Style::Rpc,
+        crate::client_trait::Auth::Token,
         "team/devices/list_member_devices",
         arg,
         None)
@@ -44,6 +45,7 @@ pub fn devices_list_members_devices(
         client,
         crate::client_trait::Endpoint::Api,
         crate::client_trait::Style::Rpc,
+        crate::client_trait::Auth::Token,
         "team/devices/list_members_devices",
         arg,
         None)
@@ -58,6 +60,7 @@ pub fn devices_list_team_devices(
         client,
         crate::client_trait::Endpoint::Api,
         crate::client_trait::Style::Rpc,
+        crate::client_trait::Auth::Token,
         "team/devices/list_team_devices",
         arg,
         None)
@@ -72,6 +75,7 @@ pub fn devices_revoke_device_session(
         client,
         crate::client_trait::Endpoint::Api,
         crate::client_trait::Style::Rpc,
+        crate::client_trait::Auth::Token,
         "team/devices/revoke_device_session",
         arg,
         None)
@@ -86,6 +90,7 @@ pub fn devices_revoke_device_session_batch(
         client,
         crate::client_trait::Endpoint::Api,
         crate::client_trait::Style::Rpc,
+        crate::client_trait::Auth::Token,
         "team/devices/revoke_device_session_batch",
         arg,
         None)
@@ -102,6 +107,7 @@ pub fn features_get_values(
         client,
         crate::client_trait::Endpoint::Api,
         crate::client_trait::Style::Rpc,
+        crate::client_trait::Auth::Token,
         "team/features/get_values",
         arg,
         None)
@@ -115,6 +121,7 @@ pub fn get_info(
         client,
         crate::client_trait::Endpoint::Api,
         crate::client_trait::Style::Rpc,
+        crate::client_trait::Auth::Token,
         "team/get_info",
         &(),
         None)
@@ -129,6 +136,7 @@ pub fn groups_create(
         client,
         crate::client_trait::Endpoint::Api,
         crate::client_trait::Style::Rpc,
+        crate::client_trait::Auth::Token,
         "team/groups/create",
         arg,
         None)
@@ -145,6 +153,7 @@ pub fn groups_delete(
         client,
         crate::client_trait::Endpoint::Api,
         crate::client_trait::Style::Rpc,
+        crate::client_trait::Auth::Token,
         "team/groups/delete",
         arg,
         None)
@@ -161,6 +170,7 @@ pub fn groups_get_info(
         client,
         crate::client_trait::Endpoint::Api,
         crate::client_trait::Style::Rpc,
+        crate::client_trait::Auth::Token,
         "team/groups/get_info",
         arg,
         None)
@@ -179,6 +189,7 @@ pub fn groups_job_status_get(
         client,
         crate::client_trait::Endpoint::Api,
         crate::client_trait::Style::Rpc,
+        crate::client_trait::Auth::Token,
         "team/groups/job_status/get",
         arg,
         None)
@@ -193,6 +204,7 @@ pub fn groups_list(
         client,
         crate::client_trait::Endpoint::Api,
         crate::client_trait::Style::Rpc,
+        crate::client_trait::Auth::Token,
         "team/groups/list",
         arg,
         None)
@@ -208,6 +220,7 @@ pub fn groups_list_continue(
         client,
         crate::client_trait::Endpoint::Api,
         crate::client_trait::Style::Rpc,
+        crate::client_trait::Auth::Token,
         "team/groups/list/continue",
         arg,
         None)
@@ -224,6 +237,7 @@ pub fn groups_members_add(
         client,
         crate::client_trait::Endpoint::Api,
         crate::client_trait::Style::Rpc,
+        crate::client_trait::Auth::Token,
         "team/groups/members/add",
         arg,
         None)
@@ -238,6 +252,7 @@ pub fn groups_members_list(
         client,
         crate::client_trait::Endpoint::Api,
         crate::client_trait::Style::Rpc,
+        crate::client_trait::Auth::Token,
         "team/groups/members/list",
         arg,
         None)
@@ -253,6 +268,7 @@ pub fn groups_members_list_continue(
         client,
         crate::client_trait::Endpoint::Api,
         crate::client_trait::Style::Rpc,
+        crate::client_trait::Auth::Token,
         "team/groups/members/list/continue",
         arg,
         None)
@@ -271,6 +287,7 @@ pub fn groups_members_remove(
         client,
         crate::client_trait::Endpoint::Api,
         crate::client_trait::Style::Rpc,
+        crate::client_trait::Auth::Token,
         "team/groups/members/remove",
         arg,
         None)
@@ -285,6 +302,7 @@ pub fn groups_members_set_access_type(
         client,
         crate::client_trait::Endpoint::Api,
         crate::client_trait::Style::Rpc,
+        crate::client_trait::Auth::Token,
         "team/groups/members/set_access_type",
         arg,
         None)
@@ -299,6 +317,7 @@ pub fn groups_update(
         client,
         crate::client_trait::Endpoint::Api,
         crate::client_trait::Style::Rpc,
+        crate::client_trait::Auth::Token,
         "team/groups/update",
         arg,
         None)
@@ -314,6 +333,7 @@ pub fn legal_holds_create_policy(
         client,
         crate::client_trait::Endpoint::Api,
         crate::client_trait::Style::Rpc,
+        crate::client_trait::Auth::Token,
         "team/legal_holds/create_policy",
         arg,
         None)
@@ -329,6 +349,7 @@ pub fn legal_holds_get_policy(
         client,
         crate::client_trait::Endpoint::Api,
         crate::client_trait::Style::Rpc,
+        crate::client_trait::Auth::Token,
         "team/legal_holds/get_policy",
         arg,
         None)
@@ -344,6 +365,7 @@ pub fn legal_holds_list_held_revisions(
         client,
         crate::client_trait::Endpoint::Api,
         crate::client_trait::Style::Rpc,
+        crate::client_trait::Auth::Token,
         "team/legal_holds/list_held_revisions",
         arg,
         None)
@@ -359,6 +381,7 @@ pub fn legal_holds_list_held_revisions_continue(
         client,
         crate::client_trait::Endpoint::Api,
         crate::client_trait::Style::Rpc,
+        crate::client_trait::Auth::Token,
         "team/legal_holds/list_held_revisions_continue",
         arg,
         None)
@@ -374,6 +397,7 @@ pub fn legal_holds_list_policies(
         client,
         crate::client_trait::Endpoint::Api,
         crate::client_trait::Style::Rpc,
+        crate::client_trait::Auth::Token,
         "team/legal_holds/list_policies",
         arg,
         None)
@@ -389,6 +413,7 @@ pub fn legal_holds_release_policy(
         client,
         crate::client_trait::Endpoint::Api,
         crate::client_trait::Style::Rpc,
+        crate::client_trait::Auth::Token,
         "team/legal_holds/release_policy",
         arg,
         None)
@@ -404,6 +429,7 @@ pub fn legal_holds_update_policy(
         client,
         crate::client_trait::Endpoint::Api,
         crate::client_trait::Style::Rpc,
+        crate::client_trait::Auth::Token,
         "team/legal_holds/update_policy",
         arg,
         None)
@@ -419,6 +445,7 @@ pub fn linked_apps_list_member_linked_apps(
         client,
         crate::client_trait::Endpoint::Api,
         crate::client_trait::Style::Rpc,
+        crate::client_trait::Auth::Token,
         "team/linked_apps/list_member_linked_apps",
         arg,
         None)
@@ -434,6 +461,7 @@ pub fn linked_apps_list_members_linked_apps(
         client,
         crate::client_trait::Endpoint::Api,
         crate::client_trait::Style::Rpc,
+        crate::client_trait::Auth::Token,
         "team/linked_apps/list_members_linked_apps",
         arg,
         None)
@@ -449,6 +477,7 @@ pub fn linked_apps_list_team_linked_apps(
         client,
         crate::client_trait::Endpoint::Api,
         crate::client_trait::Style::Rpc,
+        crate::client_trait::Auth::Token,
         "team/linked_apps/list_team_linked_apps",
         arg,
         None)
@@ -463,6 +492,7 @@ pub fn linked_apps_revoke_linked_app(
         client,
         crate::client_trait::Endpoint::Api,
         crate::client_trait::Style::Rpc,
+        crate::client_trait::Auth::Token,
         "team/linked_apps/revoke_linked_app",
         arg,
         None)
@@ -477,6 +507,7 @@ pub fn linked_apps_revoke_linked_app_batch(
         client,
         crate::client_trait::Endpoint::Api,
         crate::client_trait::Style::Rpc,
+        crate::client_trait::Auth::Token,
         "team/linked_apps/revoke_linked_app_batch",
         arg,
         None)
@@ -491,6 +522,7 @@ pub fn member_space_limits_excluded_users_add(
         client,
         crate::client_trait::Endpoint::Api,
         crate::client_trait::Style::Rpc,
+        crate::client_trait::Auth::Token,
         "team/member_space_limits/excluded_users/add",
         arg,
         None)
@@ -505,6 +537,7 @@ pub fn member_space_limits_excluded_users_list(
         client,
         crate::client_trait::Endpoint::Api,
         crate::client_trait::Style::Rpc,
+        crate::client_trait::Auth::Token,
         "team/member_space_limits/excluded_users/list",
         arg,
         None)
@@ -519,6 +552,7 @@ pub fn member_space_limits_excluded_users_list_continue(
         client,
         crate::client_trait::Endpoint::Api,
         crate::client_trait::Style::Rpc,
+        crate::client_trait::Auth::Token,
         "team/member_space_limits/excluded_users/list/continue",
         arg,
         None)
@@ -533,6 +567,7 @@ pub fn member_space_limits_excluded_users_remove(
         client,
         crate::client_trait::Endpoint::Api,
         crate::client_trait::Style::Rpc,
+        crate::client_trait::Auth::Token,
         "team/member_space_limits/excluded_users/remove",
         arg,
         None)
@@ -548,6 +583,7 @@ pub fn member_space_limits_get_custom_quota(
         client,
         crate::client_trait::Endpoint::Api,
         crate::client_trait::Style::Rpc,
+        crate::client_trait::Auth::Token,
         "team/member_space_limits/get_custom_quota",
         arg,
         None)
@@ -562,6 +598,7 @@ pub fn member_space_limits_remove_custom_quota(
         client,
         crate::client_trait::Endpoint::Api,
         crate::client_trait::Style::Rpc,
+        crate::client_trait::Auth::Token,
         "team/member_space_limits/remove_custom_quota",
         arg,
         None)
@@ -577,6 +614,7 @@ pub fn member_space_limits_set_custom_quota(
         client,
         crate::client_trait::Endpoint::Api,
         crate::client_trait::Style::Rpc,
+        crate::client_trait::Auth::Token,
         "team/member_space_limits/set_custom_quota",
         arg,
         None)
@@ -599,6 +637,7 @@ pub fn members_add(
         client,
         crate::client_trait::Endpoint::Api,
         crate::client_trait::Style::Rpc,
+        crate::client_trait::Auth::Token,
         "team/members/add",
         arg,
         None)
@@ -614,6 +653,7 @@ pub fn members_add_job_status_get(
         client,
         crate::client_trait::Endpoint::Api,
         crate::client_trait::Style::Rpc,
+        crate::client_trait::Auth::Token,
         "team/members/add/job_status/get",
         arg,
         None)
@@ -628,6 +668,7 @@ pub fn members_delete_profile_photo(
         client,
         crate::client_trait::Endpoint::Api,
         crate::client_trait::Style::Rpc,
+        crate::client_trait::Auth::Token,
         "team/members/delete_profile_photo",
         arg,
         None)
@@ -644,6 +685,7 @@ pub fn members_get_info(
         client,
         crate::client_trait::Endpoint::Api,
         crate::client_trait::Style::Rpc,
+        crate::client_trait::Auth::Token,
         "team/members/get_info",
         arg,
         None)
@@ -658,6 +700,7 @@ pub fn members_list(
         client,
         crate::client_trait::Endpoint::Api,
         crate::client_trait::Style::Rpc,
+        crate::client_trait::Auth::Token,
         "team/members/list",
         arg,
         None)
@@ -673,6 +716,7 @@ pub fn members_list_continue(
         client,
         crate::client_trait::Endpoint::Api,
         crate::client_trait::Style::Rpc,
+        crate::client_trait::Auth::Token,
         "team/members/list/continue",
         arg,
         None)
@@ -690,6 +734,7 @@ pub fn members_move_former_member_files(
         client,
         crate::client_trait::Endpoint::Api,
         crate::client_trait::Style::Rpc,
+        crate::client_trait::Auth::Token,
         "team/members/move_former_member_files",
         arg,
         None)
@@ -706,6 +751,7 @@ pub fn members_move_former_member_files_job_status_check(
         client,
         crate::client_trait::Endpoint::Api,
         crate::client_trait::Style::Rpc,
+        crate::client_trait::Auth::Token,
         "team/members/move_former_member_files/job_status/check",
         arg,
         None)
@@ -721,6 +767,7 @@ pub fn members_recover(
         client,
         crate::client_trait::Endpoint::Api,
         crate::client_trait::Style::Rpc,
+        crate::client_trait::Auth::Token,
         "team/members/recover",
         arg,
         None)
@@ -744,6 +791,7 @@ pub fn members_remove(
         client,
         crate::client_trait::Endpoint::Api,
         crate::client_trait::Style::Rpc,
+        crate::client_trait::Auth::Token,
         "team/members/remove",
         arg,
         None)
@@ -759,6 +807,7 @@ pub fn members_remove_job_status_get(
         client,
         crate::client_trait::Endpoint::Api,
         crate::client_trait::Style::Rpc,
+        crate::client_trait::Auth::Token,
         "team/members/remove/job_status/get",
         arg,
         None)
@@ -775,6 +824,7 @@ pub fn members_secondary_emails_add(
         client,
         crate::client_trait::Endpoint::Api,
         crate::client_trait::Style::Rpc,
+        crate::client_trait::Auth::Token,
         "team/members/secondary_emails/add",
         arg,
         None)
@@ -790,6 +840,7 @@ pub fn members_secondary_emails_delete(
         client,
         crate::client_trait::Endpoint::Api,
         crate::client_trait::Style::Rpc,
+        crate::client_trait::Auth::Token,
         "team/members/secondary_emails/delete",
         arg,
         None)
@@ -804,6 +855,7 @@ pub fn members_secondary_emails_resend_verification_emails(
         client,
         crate::client_trait::Endpoint::Api,
         crate::client_trait::Style::Rpc,
+        crate::client_trait::Auth::Token,
         "team/members/secondary_emails/resend_verification_emails",
         arg,
         None)
@@ -820,6 +872,7 @@ pub fn members_send_welcome_email(
         client,
         crate::client_trait::Endpoint::Api,
         crate::client_trait::Style::Rpc,
+        crate::client_trait::Auth::Token,
         "team/members/send_welcome_email",
         arg,
         None)
@@ -834,6 +887,7 @@ pub fn members_set_admin_permissions(
         client,
         crate::client_trait::Endpoint::Api,
         crate::client_trait::Style::Rpc,
+        crate::client_trait::Auth::Token,
         "team/members/set_admin_permissions",
         arg,
         None)
@@ -848,6 +902,7 @@ pub fn members_set_profile(
         client,
         crate::client_trait::Endpoint::Api,
         crate::client_trait::Style::Rpc,
+        crate::client_trait::Auth::Token,
         "team/members/set_profile",
         arg,
         None)
@@ -862,6 +917,7 @@ pub fn members_set_profile_photo(
         client,
         crate::client_trait::Endpoint::Api,
         crate::client_trait::Style::Rpc,
+        crate::client_trait::Auth::Token,
         "team/members/set_profile_photo",
         arg,
         None)
@@ -877,6 +933,7 @@ pub fn members_suspend(
         client,
         crate::client_trait::Endpoint::Api,
         crate::client_trait::Style::Rpc,
+        crate::client_trait::Auth::Token,
         "team/members/suspend",
         arg,
         None)
@@ -892,6 +949,7 @@ pub fn members_unsuspend(
         client,
         crate::client_trait::Endpoint::Api,
         crate::client_trait::Style::Rpc,
+        crate::client_trait::Auth::Token,
         "team/members/unsuspend",
         arg,
         None)
@@ -909,6 +967,7 @@ pub fn namespaces_list(
         client,
         crate::client_trait::Endpoint::Api,
         crate::client_trait::Style::Rpc,
+        crate::client_trait::Auth::Token,
         "team/namespaces/list",
         arg,
         None)
@@ -924,6 +983,7 @@ pub fn namespaces_list_continue(
         client,
         crate::client_trait::Endpoint::Api,
         crate::client_trait::Style::Rpc,
+        crate::client_trait::Auth::Token,
         "team/namespaces/list/continue",
         arg,
         None)
@@ -938,6 +998,7 @@ pub fn properties_template_add(
         client,
         crate::client_trait::Endpoint::Api,
         crate::client_trait::Style::Rpc,
+        crate::client_trait::Auth::Token,
         "team/properties/template/add",
         arg,
         None)
@@ -952,6 +1013,7 @@ pub fn properties_template_get(
         client,
         crate::client_trait::Endpoint::Api,
         crate::client_trait::Style::Rpc,
+        crate::client_trait::Auth::Token,
         "team/properties/template/get",
         arg,
         None)
@@ -965,6 +1027,7 @@ pub fn properties_template_list(
         client,
         crate::client_trait::Endpoint::Api,
         crate::client_trait::Style::Rpc,
+        crate::client_trait::Auth::Token,
         "team/properties/template/list",
         &(),
         None)
@@ -979,6 +1042,7 @@ pub fn properties_template_update(
         client,
         crate::client_trait::Endpoint::Api,
         crate::client_trait::Style::Rpc,
+        crate::client_trait::Auth::Token,
         "team/properties/template/update",
         arg,
         None)
@@ -993,6 +1057,7 @@ pub fn reports_get_activity(
         client,
         crate::client_trait::Endpoint::Api,
         crate::client_trait::Style::Rpc,
+        crate::client_trait::Auth::Token,
         "team/reports/get_activity",
         arg,
         None)
@@ -1007,6 +1072,7 @@ pub fn reports_get_devices(
         client,
         crate::client_trait::Endpoint::Api,
         crate::client_trait::Style::Rpc,
+        crate::client_trait::Auth::Token,
         "team/reports/get_devices",
         arg,
         None)
@@ -1021,6 +1087,7 @@ pub fn reports_get_membership(
         client,
         crate::client_trait::Endpoint::Api,
         crate::client_trait::Style::Rpc,
+        crate::client_trait::Auth::Token,
         "team/reports/get_membership",
         arg,
         None)
@@ -1035,6 +1102,7 @@ pub fn reports_get_storage(
         client,
         crate::client_trait::Endpoint::Api,
         crate::client_trait::Style::Rpc,
+        crate::client_trait::Auth::Token,
         "team/reports/get_storage",
         arg,
         None)
@@ -1049,6 +1117,7 @@ pub fn team_folder_activate(
         client,
         crate::client_trait::Endpoint::Api,
         crate::client_trait::Style::Rpc,
+        crate::client_trait::Auth::Token,
         "team/team_folder/activate",
         arg,
         None)
@@ -1064,6 +1133,7 @@ pub fn team_folder_archive(
         client,
         crate::client_trait::Endpoint::Api,
         crate::client_trait::Style::Rpc,
+        crate::client_trait::Auth::Token,
         "team/team_folder/archive",
         arg,
         None)
@@ -1079,6 +1149,7 @@ pub fn team_folder_archive_check(
         client,
         crate::client_trait::Endpoint::Api,
         crate::client_trait::Style::Rpc,
+        crate::client_trait::Auth::Token,
         "team/team_folder/archive/check",
         arg,
         None)
@@ -1093,6 +1164,7 @@ pub fn team_folder_create(
         client,
         crate::client_trait::Endpoint::Api,
         crate::client_trait::Style::Rpc,
+        crate::client_trait::Auth::Token,
         "team/team_folder/create",
         arg,
         None)
@@ -1107,6 +1179,7 @@ pub fn team_folder_get_info(
         client,
         crate::client_trait::Endpoint::Api,
         crate::client_trait::Style::Rpc,
+        crate::client_trait::Auth::Token,
         "team/team_folder/get_info",
         arg,
         None)
@@ -1121,6 +1194,7 @@ pub fn team_folder_list(
         client,
         crate::client_trait::Endpoint::Api,
         crate::client_trait::Style::Rpc,
+        crate::client_trait::Auth::Token,
         "team/team_folder/list",
         arg,
         None)
@@ -1136,6 +1210,7 @@ pub fn team_folder_list_continue(
         client,
         crate::client_trait::Endpoint::Api,
         crate::client_trait::Style::Rpc,
+        crate::client_trait::Auth::Token,
         "team/team_folder/list/continue",
         arg,
         None)
@@ -1150,6 +1225,7 @@ pub fn team_folder_permanently_delete(
         client,
         crate::client_trait::Endpoint::Api,
         crate::client_trait::Style::Rpc,
+        crate::client_trait::Auth::Token,
         "team/team_folder/permanently_delete",
         arg,
         None)
@@ -1164,6 +1240,7 @@ pub fn team_folder_rename(
         client,
         crate::client_trait::Endpoint::Api,
         crate::client_trait::Style::Rpc,
+        crate::client_trait::Auth::Token,
         "team/team_folder/rename",
         arg,
         None)
@@ -1179,6 +1256,7 @@ pub fn team_folder_update_sync_settings(
         client,
         crate::client_trait::Endpoint::Api,
         crate::client_trait::Style::Rpc,
+        crate::client_trait::Auth::Token,
         "team/team_folder/update_sync_settings",
         arg,
         None)
@@ -1193,6 +1271,7 @@ pub fn token_get_authenticated_admin(
         client,
         crate::client_trait::Endpoint::Api,
         crate::client_trait::Style::Rpc,
+        crate::client_trait::Auth::Token,
         "team/token/get_authenticated_admin",
         &(),
         None)

--- a/src/generated/team.rs
+++ b/src/generated/team.rs
@@ -23,14 +23,13 @@ pub type UserQuota = u32;
 
 /// List all device sessions of a team's member.
 pub fn devices_list_member_devices(
-    client: &dyn crate::client_trait::HttpClient,
+    client: &impl crate::client_trait::TeamAuthClient,
     arg: &ListMemberDevicesArg,
 ) -> crate::Result<Result<ListMemberDevicesResult, ListMemberDevicesError>> {
     crate::client_helpers::request(
         client,
         crate::client_trait::Endpoint::Api,
         crate::client_trait::Style::Rpc,
-        crate::client_trait::Auth::Token,
         "team/devices/list_member_devices",
         arg,
         None)
@@ -38,14 +37,13 @@ pub fn devices_list_member_devices(
 
 /// List all device sessions of a team. Permission : Team member file access.
 pub fn devices_list_members_devices(
-    client: &dyn crate::client_trait::HttpClient,
+    client: &impl crate::client_trait::TeamAuthClient,
     arg: &ListMembersDevicesArg,
 ) -> crate::Result<Result<ListMembersDevicesResult, ListMembersDevicesError>> {
     crate::client_helpers::request(
         client,
         crate::client_trait::Endpoint::Api,
         crate::client_trait::Style::Rpc,
-        crate::client_trait::Auth::Token,
         "team/devices/list_members_devices",
         arg,
         None)
@@ -53,14 +51,13 @@ pub fn devices_list_members_devices(
 
 /// List all device sessions of a team. Permission : Team member file access.
 pub fn devices_list_team_devices(
-    client: &dyn crate::client_trait::HttpClient,
+    client: &impl crate::client_trait::TeamAuthClient,
     arg: &ListTeamDevicesArg,
 ) -> crate::Result<Result<ListTeamDevicesResult, ListTeamDevicesError>> {
     crate::client_helpers::request(
         client,
         crate::client_trait::Endpoint::Api,
         crate::client_trait::Style::Rpc,
-        crate::client_trait::Auth::Token,
         "team/devices/list_team_devices",
         arg,
         None)
@@ -68,14 +65,13 @@ pub fn devices_list_team_devices(
 
 /// Revoke a device session of a team's member.
 pub fn devices_revoke_device_session(
-    client: &dyn crate::client_trait::HttpClient,
+    client: &impl crate::client_trait::TeamAuthClient,
     arg: &RevokeDeviceSessionArg,
 ) -> crate::Result<Result<(), RevokeDeviceSessionError>> {
     crate::client_helpers::request(
         client,
         crate::client_trait::Endpoint::Api,
         crate::client_trait::Style::Rpc,
-        crate::client_trait::Auth::Token,
         "team/devices/revoke_device_session",
         arg,
         None)
@@ -83,14 +79,13 @@ pub fn devices_revoke_device_session(
 
 /// Revoke a list of device sessions of team members.
 pub fn devices_revoke_device_session_batch(
-    client: &dyn crate::client_trait::HttpClient,
+    client: &impl crate::client_trait::TeamAuthClient,
     arg: &RevokeDeviceSessionBatchArg,
 ) -> crate::Result<Result<RevokeDeviceSessionBatchResult, RevokeDeviceSessionBatchError>> {
     crate::client_helpers::request(
         client,
         crate::client_trait::Endpoint::Api,
         crate::client_trait::Style::Rpc,
-        crate::client_trait::Auth::Token,
         "team/devices/revoke_device_session_batch",
         arg,
         None)
@@ -100,14 +95,13 @@ pub fn devices_revoke_device_session_batch(
 /// for what feature you can access or what value you have for certain features. Permission : Team
 /// information.
 pub fn features_get_values(
-    client: &dyn crate::client_trait::HttpClient,
+    client: &impl crate::client_trait::TeamAuthClient,
     arg: &FeaturesGetValuesBatchArg,
 ) -> crate::Result<Result<FeaturesGetValuesBatchResult, FeaturesGetValuesBatchError>> {
     crate::client_helpers::request(
         client,
         crate::client_trait::Endpoint::Api,
         crate::client_trait::Style::Rpc,
-        crate::client_trait::Auth::Token,
         "team/features/get_values",
         arg,
         None)
@@ -115,13 +109,12 @@ pub fn features_get_values(
 
 /// Retrieves information about a team.
 pub fn get_info(
-    client: &dyn crate::client_trait::HttpClient,
+    client: &impl crate::client_trait::TeamAuthClient,
 ) -> crate::Result<Result<TeamGetInfoResult, ()>> {
     crate::client_helpers::request(
         client,
         crate::client_trait::Endpoint::Api,
         crate::client_trait::Style::Rpc,
-        crate::client_trait::Auth::Token,
         "team/get_info",
         &(),
         None)
@@ -129,14 +122,13 @@ pub fn get_info(
 
 /// Creates a new, empty group, with a requested name. Permission : Team member management.
 pub fn groups_create(
-    client: &dyn crate::client_trait::HttpClient,
+    client: &impl crate::client_trait::TeamAuthClient,
     arg: &GroupCreateArg,
 ) -> crate::Result<Result<GroupFullInfo, GroupCreateError>> {
     crate::client_helpers::request(
         client,
         crate::client_trait::Endpoint::Api,
         crate::client_trait::Style::Rpc,
-        crate::client_trait::Auth::Token,
         "team/groups/create",
         arg,
         None)
@@ -146,14 +138,13 @@ pub fn groups_create(
 /// may take additional time. Use the [`groups_job_status_get()`](groups_job_status_get) to
 /// determine whether this process has completed. Permission : Team member management.
 pub fn groups_delete(
-    client: &dyn crate::client_trait::HttpClient,
+    client: &impl crate::client_trait::TeamAuthClient,
     arg: &GroupSelector,
 ) -> crate::Result<Result<super::dbx_async::LaunchEmptyResult, GroupDeleteError>> {
     crate::client_helpers::request(
         client,
         crate::client_trait::Endpoint::Api,
         crate::client_trait::Style::Rpc,
-        crate::client_trait::Auth::Token,
         "team/groups/delete",
         arg,
         None)
@@ -163,14 +154,13 @@ pub fn groups_delete(
 /// [`GroupFullInfo::members`](GroupFullInfo) is not returned for system-managed groups. Permission
 /// : Team Information.
 pub fn groups_get_info(
-    client: &dyn crate::client_trait::HttpClient,
+    client: &impl crate::client_trait::TeamAuthClient,
     arg: &GroupsSelector,
 ) -> crate::Result<Result<GroupsGetInfoResult, GroupsGetInfoError>> {
     crate::client_helpers::request(
         client,
         crate::client_trait::Endpoint::Api,
         crate::client_trait::Style::Rpc,
-        crate::client_trait::Auth::Token,
         "team/groups/get_info",
         arg,
         None)
@@ -182,14 +172,13 @@ pub fn groups_get_info(
 /// granting/revoking group members' access to group-owned resources. Permission : Team member
 /// management.
 pub fn groups_job_status_get(
-    client: &dyn crate::client_trait::HttpClient,
+    client: &impl crate::client_trait::TeamAuthClient,
     arg: &super::dbx_async::PollArg,
 ) -> crate::Result<Result<super::dbx_async::PollEmptyResult, GroupsPollError>> {
     crate::client_helpers::request(
         client,
         crate::client_trait::Endpoint::Api,
         crate::client_trait::Style::Rpc,
-        crate::client_trait::Auth::Token,
         "team/groups/job_status/get",
         arg,
         None)
@@ -197,14 +186,13 @@ pub fn groups_job_status_get(
 
 /// Lists groups on a team. Permission : Team Information.
 pub fn groups_list(
-    client: &dyn crate::client_trait::HttpClient,
+    client: &impl crate::client_trait::TeamAuthClient,
     arg: &GroupsListArg,
 ) -> crate::Result<Result<GroupsListResult, ()>> {
     crate::client_helpers::request(
         client,
         crate::client_trait::Endpoint::Api,
         crate::client_trait::Style::Rpc,
-        crate::client_trait::Auth::Token,
         "team/groups/list",
         arg,
         None)
@@ -213,14 +201,13 @@ pub fn groups_list(
 /// Once a cursor has been retrieved from [`groups_list()`](groups_list), use this to paginate
 /// through all groups. Permission : Team Information.
 pub fn groups_list_continue(
-    client: &dyn crate::client_trait::HttpClient,
+    client: &impl crate::client_trait::TeamAuthClient,
     arg: &GroupsListContinueArg,
 ) -> crate::Result<Result<GroupsListResult, GroupsListContinueError>> {
     crate::client_helpers::request(
         client,
         crate::client_trait::Endpoint::Api,
         crate::client_trait::Style::Rpc,
-        crate::client_trait::Auth::Token,
         "team/groups/list/continue",
         arg,
         None)
@@ -230,14 +217,13 @@ pub fn groups_list_continue(
 /// resources may take additional time. Use the [`groups_job_status_get()`](groups_job_status_get)
 /// to determine whether this process has completed. Permission : Team member management.
 pub fn groups_members_add(
-    client: &dyn crate::client_trait::HttpClient,
+    client: &impl crate::client_trait::TeamAuthClient,
     arg: &GroupMembersAddArg,
 ) -> crate::Result<Result<GroupMembersChangeResult, GroupMembersAddError>> {
     crate::client_helpers::request(
         client,
         crate::client_trait::Endpoint::Api,
         crate::client_trait::Style::Rpc,
-        crate::client_trait::Auth::Token,
         "team/groups/members/add",
         arg,
         None)
@@ -245,14 +231,13 @@ pub fn groups_members_add(
 
 /// Lists members of a group. Permission : Team Information.
 pub fn groups_members_list(
-    client: &dyn crate::client_trait::HttpClient,
+    client: &impl crate::client_trait::TeamAuthClient,
     arg: &GroupsMembersListArg,
 ) -> crate::Result<Result<GroupsMembersListResult, GroupSelectorError>> {
     crate::client_helpers::request(
         client,
         crate::client_trait::Endpoint::Api,
         crate::client_trait::Style::Rpc,
-        crate::client_trait::Auth::Token,
         "team/groups/members/list",
         arg,
         None)
@@ -261,14 +246,13 @@ pub fn groups_members_list(
 /// Once a cursor has been retrieved from [`groups_members_list()`](groups_members_list), use this
 /// to paginate through all members of the group. Permission : Team information.
 pub fn groups_members_list_continue(
-    client: &dyn crate::client_trait::HttpClient,
+    client: &impl crate::client_trait::TeamAuthClient,
     arg: &GroupsMembersListContinueArg,
 ) -> crate::Result<Result<GroupsMembersListResult, GroupsMembersListContinueError>> {
     crate::client_helpers::request(
         client,
         crate::client_trait::Endpoint::Api,
         crate::client_trait::Style::Rpc,
-        crate::client_trait::Auth::Token,
         "team/groups/members/list/continue",
         arg,
         None)
@@ -280,14 +264,13 @@ pub fn groups_members_list_continue(
 /// completed. This method permits removing the only owner of a group, even in cases where this is
 /// not possible via the web client. Permission : Team member management.
 pub fn groups_members_remove(
-    client: &dyn crate::client_trait::HttpClient,
+    client: &impl crate::client_trait::TeamAuthClient,
     arg: &GroupMembersRemoveArg,
 ) -> crate::Result<Result<GroupMembersChangeResult, GroupMembersRemoveError>> {
     crate::client_helpers::request(
         client,
         crate::client_trait::Endpoint::Api,
         crate::client_trait::Style::Rpc,
-        crate::client_trait::Auth::Token,
         "team/groups/members/remove",
         arg,
         None)
@@ -295,14 +278,13 @@ pub fn groups_members_remove(
 
 /// Sets a member's access type in a group. Permission : Team member management.
 pub fn groups_members_set_access_type(
-    client: &dyn crate::client_trait::HttpClient,
+    client: &impl crate::client_trait::TeamAuthClient,
     arg: &GroupMembersSetAccessTypeArg,
 ) -> crate::Result<Result<GroupsGetInfoResult, GroupMemberSetAccessTypeError>> {
     crate::client_helpers::request(
         client,
         crate::client_trait::Endpoint::Api,
         crate::client_trait::Style::Rpc,
-        crate::client_trait::Auth::Token,
         "team/groups/members/set_access_type",
         arg,
         None)
@@ -310,14 +292,13 @@ pub fn groups_members_set_access_type(
 
 /// Updates a group's name and/or external ID. Permission : Team member management.
 pub fn groups_update(
-    client: &dyn crate::client_trait::HttpClient,
+    client: &impl crate::client_trait::TeamAuthClient,
     arg: &GroupUpdateArgs,
 ) -> crate::Result<Result<GroupFullInfo, GroupUpdateError>> {
     crate::client_helpers::request(
         client,
         crate::client_trait::Endpoint::Api,
         crate::client_trait::Style::Rpc,
-        crate::client_trait::Auth::Token,
         "team/groups/update",
         arg,
         None)
@@ -326,14 +307,13 @@ pub fn groups_update(
 /// Creates new legal hold policy. Note: Legal Holds is a paid add-on. Not all teams have the
 /// feature. Permission : Team member file access.
 pub fn legal_holds_create_policy(
-    client: &dyn crate::client_trait::HttpClient,
+    client: &impl crate::client_trait::TeamAuthClient,
     arg: &LegalHoldsPolicyCreateArg,
 ) -> crate::Result<Result<LegalHoldsPolicyCreateResult, LegalHoldsPolicyCreateError>> {
     crate::client_helpers::request(
         client,
         crate::client_trait::Endpoint::Api,
         crate::client_trait::Style::Rpc,
-        crate::client_trait::Auth::Token,
         "team/legal_holds/create_policy",
         arg,
         None)
@@ -342,14 +322,13 @@ pub fn legal_holds_create_policy(
 /// Gets a legal hold by Id. Note: Legal Holds is a paid add-on. Not all teams have the feature.
 /// Permission : Team member file access.
 pub fn legal_holds_get_policy(
-    client: &dyn crate::client_trait::HttpClient,
+    client: &impl crate::client_trait::TeamAuthClient,
     arg: &LegalHoldsGetPolicyArg,
 ) -> crate::Result<Result<LegalHoldsGetPolicyResult, LegalHoldsGetPolicyError>> {
     crate::client_helpers::request(
         client,
         crate::client_trait::Endpoint::Api,
         crate::client_trait::Style::Rpc,
-        crate::client_trait::Auth::Token,
         "team/legal_holds/get_policy",
         arg,
         None)
@@ -358,14 +337,13 @@ pub fn legal_holds_get_policy(
 /// List the file metadata that's under the hold. Note: Legal Holds is a paid add-on. Not all teams
 /// have the feature. Permission : Team member file access.
 pub fn legal_holds_list_held_revisions(
-    client: &dyn crate::client_trait::HttpClient,
+    client: &impl crate::client_trait::TeamAuthClient,
     arg: &LegalHoldsListHeldRevisionsArg,
 ) -> crate::Result<Result<LegalHoldsListHeldRevisionResult, LegalHoldsListHeldRevisionsError>> {
     crate::client_helpers::request(
         client,
         crate::client_trait::Endpoint::Api,
         crate::client_trait::Style::Rpc,
-        crate::client_trait::Auth::Token,
         "team/legal_holds/list_held_revisions",
         arg,
         None)
@@ -374,14 +352,13 @@ pub fn legal_holds_list_held_revisions(
 /// Continue listing the file metadata that's under the hold. Note: Legal Holds is a paid add-on.
 /// Not all teams have the feature. Permission : Team member file access.
 pub fn legal_holds_list_held_revisions_continue(
-    client: &dyn crate::client_trait::HttpClient,
+    client: &impl crate::client_trait::TeamAuthClient,
     arg: &LegalHoldsListHeldRevisionsContinueArg,
 ) -> crate::Result<Result<LegalHoldsListHeldRevisionResult, LegalHoldsListHeldRevisionsError>> {
     crate::client_helpers::request(
         client,
         crate::client_trait::Endpoint::Api,
         crate::client_trait::Style::Rpc,
-        crate::client_trait::Auth::Token,
         "team/legal_holds/list_held_revisions_continue",
         arg,
         None)
@@ -390,14 +367,13 @@ pub fn legal_holds_list_held_revisions_continue(
 /// Lists legal holds on a team. Note: Legal Holds is a paid add-on. Not all teams have the feature.
 /// Permission : Team member file access.
 pub fn legal_holds_list_policies(
-    client: &dyn crate::client_trait::HttpClient,
+    client: &impl crate::client_trait::TeamAuthClient,
     arg: &LegalHoldsListPoliciesArg,
 ) -> crate::Result<Result<LegalHoldsListPoliciesResult, LegalHoldsListPoliciesError>> {
     crate::client_helpers::request(
         client,
         crate::client_trait::Endpoint::Api,
         crate::client_trait::Style::Rpc,
-        crate::client_trait::Auth::Token,
         "team/legal_holds/list_policies",
         arg,
         None)
@@ -406,14 +382,13 @@ pub fn legal_holds_list_policies(
 /// Releases a legal hold by Id. Note: Legal Holds is a paid add-on. Not all teams have the feature.
 /// Permission : Team member file access.
 pub fn legal_holds_release_policy(
-    client: &dyn crate::client_trait::HttpClient,
+    client: &impl crate::client_trait::TeamAuthClient,
     arg: &LegalHoldsPolicyReleaseArg,
 ) -> crate::Result<Result<(), LegalHoldsPolicyReleaseError>> {
     crate::client_helpers::request(
         client,
         crate::client_trait::Endpoint::Api,
         crate::client_trait::Style::Rpc,
-        crate::client_trait::Auth::Token,
         "team/legal_holds/release_policy",
         arg,
         None)
@@ -422,14 +397,13 @@ pub fn legal_holds_release_policy(
 /// Updates a legal hold. Note: Legal Holds is a paid add-on. Not all teams have the feature.
 /// Permission : Team member file access.
 pub fn legal_holds_update_policy(
-    client: &dyn crate::client_trait::HttpClient,
+    client: &impl crate::client_trait::TeamAuthClient,
     arg: &LegalHoldsPolicyUpdateArg,
 ) -> crate::Result<Result<LegalHoldsPolicyUpdateResult, LegalHoldsPolicyUpdateError>> {
     crate::client_helpers::request(
         client,
         crate::client_trait::Endpoint::Api,
         crate::client_trait::Style::Rpc,
-        crate::client_trait::Auth::Token,
         "team/legal_holds/update_policy",
         arg,
         None)
@@ -438,14 +412,13 @@ pub fn legal_holds_update_policy(
 /// List all linked applications of the team member. Note, this endpoint does not list any
 /// team-linked applications.
 pub fn linked_apps_list_member_linked_apps(
-    client: &dyn crate::client_trait::HttpClient,
+    client: &impl crate::client_trait::TeamAuthClient,
     arg: &ListMemberAppsArg,
 ) -> crate::Result<Result<ListMemberAppsResult, ListMemberAppsError>> {
     crate::client_helpers::request(
         client,
         crate::client_trait::Endpoint::Api,
         crate::client_trait::Style::Rpc,
-        crate::client_trait::Auth::Token,
         "team/linked_apps/list_member_linked_apps",
         arg,
         None)
@@ -454,14 +427,13 @@ pub fn linked_apps_list_member_linked_apps(
 /// List all applications linked to the team members' accounts. Note, this endpoint does not list
 /// any team-linked applications.
 pub fn linked_apps_list_members_linked_apps(
-    client: &dyn crate::client_trait::HttpClient,
+    client: &impl crate::client_trait::TeamAuthClient,
     arg: &ListMembersAppsArg,
 ) -> crate::Result<Result<ListMembersAppsResult, ListMembersAppsError>> {
     crate::client_helpers::request(
         client,
         crate::client_trait::Endpoint::Api,
         crate::client_trait::Style::Rpc,
-        crate::client_trait::Auth::Token,
         "team/linked_apps/list_members_linked_apps",
         arg,
         None)
@@ -470,14 +442,13 @@ pub fn linked_apps_list_members_linked_apps(
 /// List all applications linked to the team members' accounts. Note, this endpoint doesn't list any
 /// team-linked applications.
 pub fn linked_apps_list_team_linked_apps(
-    client: &dyn crate::client_trait::HttpClient,
+    client: &impl crate::client_trait::TeamAuthClient,
     arg: &ListTeamAppsArg,
 ) -> crate::Result<Result<ListTeamAppsResult, ListTeamAppsError>> {
     crate::client_helpers::request(
         client,
         crate::client_trait::Endpoint::Api,
         crate::client_trait::Style::Rpc,
-        crate::client_trait::Auth::Token,
         "team/linked_apps/list_team_linked_apps",
         arg,
         None)
@@ -485,14 +456,13 @@ pub fn linked_apps_list_team_linked_apps(
 
 /// Revoke a linked application of the team member.
 pub fn linked_apps_revoke_linked_app(
-    client: &dyn crate::client_trait::HttpClient,
+    client: &impl crate::client_trait::TeamAuthClient,
     arg: &RevokeLinkedApiAppArg,
 ) -> crate::Result<Result<(), RevokeLinkedAppError>> {
     crate::client_helpers::request(
         client,
         crate::client_trait::Endpoint::Api,
         crate::client_trait::Style::Rpc,
-        crate::client_trait::Auth::Token,
         "team/linked_apps/revoke_linked_app",
         arg,
         None)
@@ -500,14 +470,13 @@ pub fn linked_apps_revoke_linked_app(
 
 /// Revoke a list of linked applications of the team members.
 pub fn linked_apps_revoke_linked_app_batch(
-    client: &dyn crate::client_trait::HttpClient,
+    client: &impl crate::client_trait::TeamAuthClient,
     arg: &RevokeLinkedApiAppBatchArg,
 ) -> crate::Result<Result<RevokeLinkedAppBatchResult, RevokeLinkedAppBatchError>> {
     crate::client_helpers::request(
         client,
         crate::client_trait::Endpoint::Api,
         crate::client_trait::Style::Rpc,
-        crate::client_trait::Auth::Token,
         "team/linked_apps/revoke_linked_app_batch",
         arg,
         None)
@@ -515,14 +484,13 @@ pub fn linked_apps_revoke_linked_app_batch(
 
 /// Add users to member space limits excluded users list.
 pub fn member_space_limits_excluded_users_add(
-    client: &dyn crate::client_trait::HttpClient,
+    client: &impl crate::client_trait::TeamAuthClient,
     arg: &ExcludedUsersUpdateArg,
 ) -> crate::Result<Result<ExcludedUsersUpdateResult, ExcludedUsersUpdateError>> {
     crate::client_helpers::request(
         client,
         crate::client_trait::Endpoint::Api,
         crate::client_trait::Style::Rpc,
-        crate::client_trait::Auth::Token,
         "team/member_space_limits/excluded_users/add",
         arg,
         None)
@@ -530,14 +498,13 @@ pub fn member_space_limits_excluded_users_add(
 
 /// List member space limits excluded users.
 pub fn member_space_limits_excluded_users_list(
-    client: &dyn crate::client_trait::HttpClient,
+    client: &impl crate::client_trait::TeamAuthClient,
     arg: &ExcludedUsersListArg,
 ) -> crate::Result<Result<ExcludedUsersListResult, ExcludedUsersListError>> {
     crate::client_helpers::request(
         client,
         crate::client_trait::Endpoint::Api,
         crate::client_trait::Style::Rpc,
-        crate::client_trait::Auth::Token,
         "team/member_space_limits/excluded_users/list",
         arg,
         None)
@@ -545,14 +512,13 @@ pub fn member_space_limits_excluded_users_list(
 
 /// Continue listing member space limits excluded users.
 pub fn member_space_limits_excluded_users_list_continue(
-    client: &dyn crate::client_trait::HttpClient,
+    client: &impl crate::client_trait::TeamAuthClient,
     arg: &ExcludedUsersListContinueArg,
 ) -> crate::Result<Result<ExcludedUsersListResult, ExcludedUsersListContinueError>> {
     crate::client_helpers::request(
         client,
         crate::client_trait::Endpoint::Api,
         crate::client_trait::Style::Rpc,
-        crate::client_trait::Auth::Token,
         "team/member_space_limits/excluded_users/list/continue",
         arg,
         None)
@@ -560,14 +526,13 @@ pub fn member_space_limits_excluded_users_list_continue(
 
 /// Remove users from member space limits excluded users list.
 pub fn member_space_limits_excluded_users_remove(
-    client: &dyn crate::client_trait::HttpClient,
+    client: &impl crate::client_trait::TeamAuthClient,
     arg: &ExcludedUsersUpdateArg,
 ) -> crate::Result<Result<ExcludedUsersUpdateResult, ExcludedUsersUpdateError>> {
     crate::client_helpers::request(
         client,
         crate::client_trait::Endpoint::Api,
         crate::client_trait::Style::Rpc,
-        crate::client_trait::Auth::Token,
         "team/member_space_limits/excluded_users/remove",
         arg,
         None)
@@ -576,14 +541,13 @@ pub fn member_space_limits_excluded_users_remove(
 /// Get users custom quota. Returns none as the custom quota if none was set. A maximum of 1000
 /// members can be specified in a single call.
 pub fn member_space_limits_get_custom_quota(
-    client: &dyn crate::client_trait::HttpClient,
+    client: &impl crate::client_trait::TeamAuthClient,
     arg: &CustomQuotaUsersArg,
 ) -> crate::Result<Result<Vec<CustomQuotaResult>, CustomQuotaError>> {
     crate::client_helpers::request(
         client,
         crate::client_trait::Endpoint::Api,
         crate::client_trait::Style::Rpc,
-        crate::client_trait::Auth::Token,
         "team/member_space_limits/get_custom_quota",
         arg,
         None)
@@ -591,14 +555,13 @@ pub fn member_space_limits_get_custom_quota(
 
 /// Remove users custom quota. A maximum of 1000 members can be specified in a single call.
 pub fn member_space_limits_remove_custom_quota(
-    client: &dyn crate::client_trait::HttpClient,
+    client: &impl crate::client_trait::TeamAuthClient,
     arg: &CustomQuotaUsersArg,
 ) -> crate::Result<Result<Vec<RemoveCustomQuotaResult>, CustomQuotaError>> {
     crate::client_helpers::request(
         client,
         crate::client_trait::Endpoint::Api,
         crate::client_trait::Style::Rpc,
-        crate::client_trait::Auth::Token,
         "team/member_space_limits/remove_custom_quota",
         arg,
         None)
@@ -607,14 +570,13 @@ pub fn member_space_limits_remove_custom_quota(
 /// Set users custom quota. Custom quota has to be at least 15GB. A maximum of 1000 members can be
 /// specified in a single call.
 pub fn member_space_limits_set_custom_quota(
-    client: &dyn crate::client_trait::HttpClient,
+    client: &impl crate::client_trait::TeamAuthClient,
     arg: &SetCustomQuotaArg,
 ) -> crate::Result<Result<Vec<CustomQuotaResult>, SetCustomQuotaError>> {
     crate::client_helpers::request(
         client,
         crate::client_trait::Endpoint::Api,
         crate::client_trait::Style::Rpc,
-        crate::client_trait::Auth::Token,
         "team/member_space_limits/set_custom_quota",
         arg,
         None)
@@ -630,14 +592,13 @@ pub fn member_space_limits_set_custom_quota(
 /// team invitation and for 'Perform as team member' actions taken on the user before they become
 /// 'active'.
 pub fn members_add(
-    client: &dyn crate::client_trait::HttpClient,
+    client: &impl crate::client_trait::TeamAuthClient,
     arg: &MembersAddArg,
 ) -> crate::Result<Result<MembersAddLaunch, ()>> {
     crate::client_helpers::request(
         client,
         crate::client_trait::Endpoint::Api,
         crate::client_trait::Style::Rpc,
-        crate::client_trait::Auth::Token,
         "team/members/add",
         arg,
         None)
@@ -646,14 +607,13 @@ pub fn members_add(
 /// Once an async_job_id is returned from [`members_add()`](members_add) , use this to poll the
 /// status of the asynchronous request. Permission : Team member management.
 pub fn members_add_job_status_get(
-    client: &dyn crate::client_trait::HttpClient,
+    client: &impl crate::client_trait::TeamAuthClient,
     arg: &super::dbx_async::PollArg,
 ) -> crate::Result<Result<MembersAddJobStatus, super::dbx_async::PollError>> {
     crate::client_helpers::request(
         client,
         crate::client_trait::Endpoint::Api,
         crate::client_trait::Style::Rpc,
-        crate::client_trait::Auth::Token,
         "team/members/add/job_status/get",
         arg,
         None)
@@ -661,14 +621,13 @@ pub fn members_add_job_status_get(
 
 /// Deletes a team member's profile photo. Permission : Team member management.
 pub fn members_delete_profile_photo(
-    client: &dyn crate::client_trait::HttpClient,
+    client: &impl crate::client_trait::TeamAuthClient,
     arg: &MembersDeleteProfilePhotoArg,
 ) -> crate::Result<Result<TeamMemberInfo, MembersDeleteProfilePhotoError>> {
     crate::client_helpers::request(
         client,
         crate::client_trait::Endpoint::Api,
         crate::client_trait::Style::Rpc,
-        crate::client_trait::Auth::Token,
         "team/members/delete_profile_photo",
         arg,
         None)
@@ -678,14 +637,13 @@ pub fn members_delete_profile_photo(
 /// will return [`MembersGetInfoItem::IdNotFound`](MembersGetInfoItem::IdNotFound), for IDs (or
 /// emails) that cannot be matched to a valid team member.
 pub fn members_get_info(
-    client: &dyn crate::client_trait::HttpClient,
+    client: &impl crate::client_trait::TeamAuthClient,
     arg: &MembersGetInfoArgs,
 ) -> crate::Result<Result<MembersGetInfoResult, MembersGetInfoError>> {
     crate::client_helpers::request(
         client,
         crate::client_trait::Endpoint::Api,
         crate::client_trait::Style::Rpc,
-        crate::client_trait::Auth::Token,
         "team/members/get_info",
         arg,
         None)
@@ -693,14 +651,13 @@ pub fn members_get_info(
 
 /// Lists members of a team. Permission : Team information.
 pub fn members_list(
-    client: &dyn crate::client_trait::HttpClient,
+    client: &impl crate::client_trait::TeamAuthClient,
     arg: &MembersListArg,
 ) -> crate::Result<Result<MembersListResult, MembersListError>> {
     crate::client_helpers::request(
         client,
         crate::client_trait::Endpoint::Api,
         crate::client_trait::Style::Rpc,
-        crate::client_trait::Auth::Token,
         "team/members/list",
         arg,
         None)
@@ -709,14 +666,13 @@ pub fn members_list(
 /// Once a cursor has been retrieved from [`members_list()`](members_list), use this to paginate
 /// through all team members. Permission : Team information.
 pub fn members_list_continue(
-    client: &dyn crate::client_trait::HttpClient,
+    client: &impl crate::client_trait::TeamAuthClient,
     arg: &MembersListContinueArg,
 ) -> crate::Result<Result<MembersListResult, MembersListContinueError>> {
     crate::client_helpers::request(
         client,
         crate::client_trait::Endpoint::Api,
         crate::client_trait::Style::Rpc,
-        crate::client_trait::Auth::Token,
         "team/members/list/continue",
         arg,
         None)
@@ -727,14 +683,13 @@ pub fn members_list_continue(
 /// [`members_move_former_member_files_job_status_check()`](members_move_former_member_files_job_status_check).
 /// Permission : Team member management.
 pub fn members_move_former_member_files(
-    client: &dyn crate::client_trait::HttpClient,
+    client: &impl crate::client_trait::TeamAuthClient,
     arg: &MembersDataTransferArg,
 ) -> crate::Result<Result<super::dbx_async::LaunchEmptyResult, MembersTransferFormerMembersFilesError>> {
     crate::client_helpers::request(
         client,
         crate::client_trait::Endpoint::Api,
         crate::client_trait::Style::Rpc,
-        crate::client_trait::Auth::Token,
         "team/members/move_former_member_files",
         arg,
         None)
@@ -744,14 +699,13 @@ pub fn members_move_former_member_files(
 /// [`members_move_former_member_files()`](members_move_former_member_files) , use this to poll the
 /// status of the asynchronous request. Permission : Team member management.
 pub fn members_move_former_member_files_job_status_check(
-    client: &dyn crate::client_trait::HttpClient,
+    client: &impl crate::client_trait::TeamAuthClient,
     arg: &super::dbx_async::PollArg,
 ) -> crate::Result<Result<super::dbx_async::PollEmptyResult, super::dbx_async::PollError>> {
     crate::client_helpers::request(
         client,
         crate::client_trait::Endpoint::Api,
         crate::client_trait::Style::Rpc,
-        crate::client_trait::Auth::Token,
         "team/members/move_former_member_files/job_status/check",
         arg,
         None)
@@ -760,14 +714,13 @@ pub fn members_move_former_member_files_job_status_check(
 /// Recover a deleted member. Permission : Team member management Exactly one of team_member_id,
 /// email, or external_id must be provided to identify the user account.
 pub fn members_recover(
-    client: &dyn crate::client_trait::HttpClient,
+    client: &impl crate::client_trait::TeamAuthClient,
     arg: &MembersRecoverArg,
 ) -> crate::Result<Result<(), MembersRecoverError>> {
     crate::client_helpers::request(
         client,
         crate::client_trait::Endpoint::Api,
         crate::client_trait::Style::Rpc,
-        crate::client_trait::Auth::Token,
         "team/members/recover",
         arg,
         None)
@@ -784,14 +737,13 @@ pub fn members_recover(
 /// asynchronous job. To obtain the final result of the job, the client should periodically poll
 /// [`members_remove_job_status_get()`](members_remove_job_status_get).
 pub fn members_remove(
-    client: &dyn crate::client_trait::HttpClient,
+    client: &impl crate::client_trait::TeamAuthClient,
     arg: &MembersRemoveArg,
 ) -> crate::Result<Result<super::dbx_async::LaunchEmptyResult, MembersRemoveError>> {
     crate::client_helpers::request(
         client,
         crate::client_trait::Endpoint::Api,
         crate::client_trait::Style::Rpc,
-        crate::client_trait::Auth::Token,
         "team/members/remove",
         arg,
         None)
@@ -800,14 +752,13 @@ pub fn members_remove(
 /// Once an async_job_id is returned from [`members_remove()`](members_remove) , use this to poll
 /// the status of the asynchronous request. Permission : Team member management.
 pub fn members_remove_job_status_get(
-    client: &dyn crate::client_trait::HttpClient,
+    client: &impl crate::client_trait::TeamAuthClient,
     arg: &super::dbx_async::PollArg,
 ) -> crate::Result<Result<super::dbx_async::PollEmptyResult, super::dbx_async::PollError>> {
     crate::client_helpers::request(
         client,
         crate::client_trait::Endpoint::Api,
         crate::client_trait::Style::Rpc,
-        crate::client_trait::Auth::Token,
         "team/members/remove/job_status/get",
         arg,
         None)
@@ -817,14 +768,13 @@ pub fn members_remove_job_status_get(
 /// domains will be verified automatically. For each email address not on a verified domain a
 /// verification email will be sent.
 pub fn members_secondary_emails_add(
-    client: &dyn crate::client_trait::HttpClient,
+    client: &impl crate::client_trait::TeamAuthClient,
     arg: &AddSecondaryEmailsArg,
 ) -> crate::Result<Result<AddSecondaryEmailsResult, AddSecondaryEmailsError>> {
     crate::client_helpers::request(
         client,
         crate::client_trait::Endpoint::Api,
         crate::client_trait::Style::Rpc,
-        crate::client_trait::Auth::Token,
         "team/members/secondary_emails/add",
         arg,
         None)
@@ -833,14 +783,13 @@ pub fn members_secondary_emails_add(
 /// Delete secondary emails from users Permission : Team member management. Users will be notified
 /// of deletions of verified secondary emails at both the secondary email and their primary email.
 pub fn members_secondary_emails_delete(
-    client: &dyn crate::client_trait::HttpClient,
+    client: &impl crate::client_trait::TeamAuthClient,
     arg: &DeleteSecondaryEmailsArg,
 ) -> crate::Result<Result<DeleteSecondaryEmailsResult, ()>> {
     crate::client_helpers::request(
         client,
         crate::client_trait::Endpoint::Api,
         crate::client_trait::Style::Rpc,
-        crate::client_trait::Auth::Token,
         "team/members/secondary_emails/delete",
         arg,
         None)
@@ -848,14 +797,13 @@ pub fn members_secondary_emails_delete(
 
 /// Resend secondary email verification emails. Permission : Team member management.
 pub fn members_secondary_emails_resend_verification_emails(
-    client: &dyn crate::client_trait::HttpClient,
+    client: &impl crate::client_trait::TeamAuthClient,
     arg: &ResendVerificationEmailArg,
 ) -> crate::Result<Result<ResendVerificationEmailResult, ()>> {
     crate::client_helpers::request(
         client,
         crate::client_trait::Endpoint::Api,
         crate::client_trait::Style::Rpc,
-        crate::client_trait::Auth::Token,
         "team/members/secondary_emails/resend_verification_emails",
         arg,
         None)
@@ -865,14 +813,13 @@ pub fn members_secondary_emails_resend_verification_emails(
 /// team_member_id, email, or external_id must be provided to identify the user account. No-op if
 /// team member is not pending.
 pub fn members_send_welcome_email(
-    client: &dyn crate::client_trait::HttpClient,
+    client: &impl crate::client_trait::TeamAuthClient,
     arg: &UserSelectorArg,
 ) -> crate::Result<Result<(), MembersSendWelcomeError>> {
     crate::client_helpers::request(
         client,
         crate::client_trait::Endpoint::Api,
         crate::client_trait::Style::Rpc,
-        crate::client_trait::Auth::Token,
         "team/members/send_welcome_email",
         arg,
         None)
@@ -880,14 +827,13 @@ pub fn members_send_welcome_email(
 
 /// Updates a team member's permissions. Permission : Team member management.
 pub fn members_set_admin_permissions(
-    client: &dyn crate::client_trait::HttpClient,
+    client: &impl crate::client_trait::TeamAuthClient,
     arg: &MembersSetPermissionsArg,
 ) -> crate::Result<Result<MembersSetPermissionsResult, MembersSetPermissionsError>> {
     crate::client_helpers::request(
         client,
         crate::client_trait::Endpoint::Api,
         crate::client_trait::Style::Rpc,
-        crate::client_trait::Auth::Token,
         "team/members/set_admin_permissions",
         arg,
         None)
@@ -895,14 +841,13 @@ pub fn members_set_admin_permissions(
 
 /// Updates a team member's profile. Permission : Team member management.
 pub fn members_set_profile(
-    client: &dyn crate::client_trait::HttpClient,
+    client: &impl crate::client_trait::TeamAuthClient,
     arg: &MembersSetProfileArg,
 ) -> crate::Result<Result<TeamMemberInfo, MembersSetProfileError>> {
     crate::client_helpers::request(
         client,
         crate::client_trait::Endpoint::Api,
         crate::client_trait::Style::Rpc,
-        crate::client_trait::Auth::Token,
         "team/members/set_profile",
         arg,
         None)
@@ -910,14 +855,13 @@ pub fn members_set_profile(
 
 /// Updates a team member's profile photo. Permission : Team member management.
 pub fn members_set_profile_photo(
-    client: &dyn crate::client_trait::HttpClient,
+    client: &impl crate::client_trait::TeamAuthClient,
     arg: &MembersSetProfilePhotoArg,
 ) -> crate::Result<Result<TeamMemberInfo, MembersSetProfilePhotoError>> {
     crate::client_helpers::request(
         client,
         crate::client_trait::Endpoint::Api,
         crate::client_trait::Style::Rpc,
-        crate::client_trait::Auth::Token,
         "team/members/set_profile_photo",
         arg,
         None)
@@ -926,14 +870,13 @@ pub fn members_set_profile_photo(
 /// Suspend a member from a team. Permission : Team member management Exactly one of team_member_id,
 /// email, or external_id must be provided to identify the user account.
 pub fn members_suspend(
-    client: &dyn crate::client_trait::HttpClient,
+    client: &impl crate::client_trait::TeamAuthClient,
     arg: &MembersDeactivateArg,
 ) -> crate::Result<Result<(), MembersSuspendError>> {
     crate::client_helpers::request(
         client,
         crate::client_trait::Endpoint::Api,
         crate::client_trait::Style::Rpc,
-        crate::client_trait::Auth::Token,
         "team/members/suspend",
         arg,
         None)
@@ -942,14 +885,13 @@ pub fn members_suspend(
 /// Unsuspend a member from a team. Permission : Team member management Exactly one of
 /// team_member_id, email, or external_id must be provided to identify the user account.
 pub fn members_unsuspend(
-    client: &dyn crate::client_trait::HttpClient,
+    client: &impl crate::client_trait::TeamAuthClient,
     arg: &MembersUnsuspendArg,
 ) -> crate::Result<Result<(), MembersUnsuspendError>> {
     crate::client_helpers::request(
         client,
         crate::client_trait::Endpoint::Api,
         crate::client_trait::Style::Rpc,
-        crate::client_trait::Auth::Token,
         "team/members/unsuspend",
         arg,
         None)
@@ -960,14 +902,13 @@ pub fn members_unsuspend(
 /// Home namespaces and app folders are always owned by this team or members of the team, but shared
 /// folders may be owned by other users or other teams. Duplicates may occur in the list.
 pub fn namespaces_list(
-    client: &dyn crate::client_trait::HttpClient,
+    client: &impl crate::client_trait::TeamAuthClient,
     arg: &TeamNamespacesListArg,
 ) -> crate::Result<Result<TeamNamespacesListResult, TeamNamespacesListError>> {
     crate::client_helpers::request(
         client,
         crate::client_trait::Endpoint::Api,
         crate::client_trait::Style::Rpc,
-        crate::client_trait::Auth::Token,
         "team/namespaces/list",
         arg,
         None)
@@ -976,14 +917,13 @@ pub fn namespaces_list(
 /// Once a cursor has been retrieved from [`namespaces_list()`](namespaces_list), use this to
 /// paginate through all team-accessible namespaces. Duplicates may occur in the list.
 pub fn namespaces_list_continue(
-    client: &dyn crate::client_trait::HttpClient,
+    client: &impl crate::client_trait::TeamAuthClient,
     arg: &TeamNamespacesListContinueArg,
 ) -> crate::Result<Result<TeamNamespacesListResult, TeamNamespacesListContinueError>> {
     crate::client_helpers::request(
         client,
         crate::client_trait::Endpoint::Api,
         crate::client_trait::Style::Rpc,
-        crate::client_trait::Auth::Token,
         "team/namespaces/list/continue",
         arg,
         None)
@@ -991,14 +931,13 @@ pub fn namespaces_list_continue(
 
 /// Permission : Team member file access.
 pub fn properties_template_add(
-    client: &dyn crate::client_trait::HttpClient,
+    client: &impl crate::client_trait::TeamAuthClient,
     arg: &super::file_properties::AddTemplateArg,
 ) -> crate::Result<Result<super::file_properties::AddTemplateResult, super::file_properties::ModifyTemplateError>> {
     crate::client_helpers::request(
         client,
         crate::client_trait::Endpoint::Api,
         crate::client_trait::Style::Rpc,
-        crate::client_trait::Auth::Token,
         "team/properties/template/add",
         arg,
         None)
@@ -1006,14 +945,13 @@ pub fn properties_template_add(
 
 /// Permission : Team member file access.
 pub fn properties_template_get(
-    client: &dyn crate::client_trait::HttpClient,
+    client: &impl crate::client_trait::TeamAuthClient,
     arg: &super::file_properties::GetTemplateArg,
 ) -> crate::Result<Result<super::file_properties::GetTemplateResult, super::file_properties::TemplateError>> {
     crate::client_helpers::request(
         client,
         crate::client_trait::Endpoint::Api,
         crate::client_trait::Style::Rpc,
-        crate::client_trait::Auth::Token,
         "team/properties/template/get",
         arg,
         None)
@@ -1021,13 +959,12 @@ pub fn properties_template_get(
 
 /// Permission : Team member file access.
 pub fn properties_template_list(
-    client: &dyn crate::client_trait::HttpClient,
+    client: &impl crate::client_trait::TeamAuthClient,
 ) -> crate::Result<Result<super::file_properties::ListTemplateResult, super::file_properties::TemplateError>> {
     crate::client_helpers::request(
         client,
         crate::client_trait::Endpoint::Api,
         crate::client_trait::Style::Rpc,
-        crate::client_trait::Auth::Token,
         "team/properties/template/list",
         &(),
         None)
@@ -1035,14 +972,13 @@ pub fn properties_template_list(
 
 /// Permission : Team member file access.
 pub fn properties_template_update(
-    client: &dyn crate::client_trait::HttpClient,
+    client: &impl crate::client_trait::TeamAuthClient,
     arg: &super::file_properties::UpdateTemplateArg,
 ) -> crate::Result<Result<super::file_properties::UpdateTemplateResult, super::file_properties::ModifyTemplateError>> {
     crate::client_helpers::request(
         client,
         crate::client_trait::Endpoint::Api,
         crate::client_trait::Style::Rpc,
-        crate::client_trait::Auth::Token,
         "team/properties/template/update",
         arg,
         None)
@@ -1050,14 +986,13 @@ pub fn properties_template_update(
 
 /// Retrieves reporting data about a team's user activity.
 pub fn reports_get_activity(
-    client: &dyn crate::client_trait::HttpClient,
+    client: &impl crate::client_trait::TeamAuthClient,
     arg: &DateRange,
 ) -> crate::Result<Result<GetActivityReport, DateRangeError>> {
     crate::client_helpers::request(
         client,
         crate::client_trait::Endpoint::Api,
         crate::client_trait::Style::Rpc,
-        crate::client_trait::Auth::Token,
         "team/reports/get_activity",
         arg,
         None)
@@ -1065,14 +1000,13 @@ pub fn reports_get_activity(
 
 /// Retrieves reporting data about a team's linked devices.
 pub fn reports_get_devices(
-    client: &dyn crate::client_trait::HttpClient,
+    client: &impl crate::client_trait::TeamAuthClient,
     arg: &DateRange,
 ) -> crate::Result<Result<GetDevicesReport, DateRangeError>> {
     crate::client_helpers::request(
         client,
         crate::client_trait::Endpoint::Api,
         crate::client_trait::Style::Rpc,
-        crate::client_trait::Auth::Token,
         "team/reports/get_devices",
         arg,
         None)
@@ -1080,14 +1014,13 @@ pub fn reports_get_devices(
 
 /// Retrieves reporting data about a team's membership.
 pub fn reports_get_membership(
-    client: &dyn crate::client_trait::HttpClient,
+    client: &impl crate::client_trait::TeamAuthClient,
     arg: &DateRange,
 ) -> crate::Result<Result<GetMembershipReport, DateRangeError>> {
     crate::client_helpers::request(
         client,
         crate::client_trait::Endpoint::Api,
         crate::client_trait::Style::Rpc,
-        crate::client_trait::Auth::Token,
         "team/reports/get_membership",
         arg,
         None)
@@ -1095,14 +1028,13 @@ pub fn reports_get_membership(
 
 /// Retrieves reporting data about a team's storage usage.
 pub fn reports_get_storage(
-    client: &dyn crate::client_trait::HttpClient,
+    client: &impl crate::client_trait::TeamAuthClient,
     arg: &DateRange,
 ) -> crate::Result<Result<GetStorageReport, DateRangeError>> {
     crate::client_helpers::request(
         client,
         crate::client_trait::Endpoint::Api,
         crate::client_trait::Style::Rpc,
-        crate::client_trait::Auth::Token,
         "team/reports/get_storage",
         arg,
         None)
@@ -1110,14 +1042,13 @@ pub fn reports_get_storage(
 
 /// Sets an archived team folder's status to active. Permission : Team member file access.
 pub fn team_folder_activate(
-    client: &dyn crate::client_trait::HttpClient,
+    client: &impl crate::client_trait::TeamAuthClient,
     arg: &TeamFolderIdArg,
 ) -> crate::Result<Result<TeamFolderMetadata, TeamFolderActivateError>> {
     crate::client_helpers::request(
         client,
         crate::client_trait::Endpoint::Api,
         crate::client_trait::Style::Rpc,
-        crate::client_trait::Auth::Token,
         "team/team_folder/activate",
         arg,
         None)
@@ -1126,14 +1057,13 @@ pub fn team_folder_activate(
 /// Sets an active team folder's status to archived and removes all folder and file members.
 /// Permission : Team member file access.
 pub fn team_folder_archive(
-    client: &dyn crate::client_trait::HttpClient,
+    client: &impl crate::client_trait::TeamAuthClient,
     arg: &TeamFolderArchiveArg,
 ) -> crate::Result<Result<TeamFolderArchiveLaunch, TeamFolderArchiveError>> {
     crate::client_helpers::request(
         client,
         crate::client_trait::Endpoint::Api,
         crate::client_trait::Style::Rpc,
-        crate::client_trait::Auth::Token,
         "team/team_folder/archive",
         arg,
         None)
@@ -1142,14 +1072,13 @@ pub fn team_folder_archive(
 /// Returns the status of an asynchronous job for archiving a team folder. Permission : Team member
 /// file access.
 pub fn team_folder_archive_check(
-    client: &dyn crate::client_trait::HttpClient,
+    client: &impl crate::client_trait::TeamAuthClient,
     arg: &super::dbx_async::PollArg,
 ) -> crate::Result<Result<TeamFolderArchiveJobStatus, super::dbx_async::PollError>> {
     crate::client_helpers::request(
         client,
         crate::client_trait::Endpoint::Api,
         crate::client_trait::Style::Rpc,
-        crate::client_trait::Auth::Token,
         "team/team_folder/archive/check",
         arg,
         None)
@@ -1157,14 +1086,13 @@ pub fn team_folder_archive_check(
 
 /// Creates a new, active, team folder with no members. Permission : Team member file access.
 pub fn team_folder_create(
-    client: &dyn crate::client_trait::HttpClient,
+    client: &impl crate::client_trait::TeamAuthClient,
     arg: &TeamFolderCreateArg,
 ) -> crate::Result<Result<TeamFolderMetadata, TeamFolderCreateError>> {
     crate::client_helpers::request(
         client,
         crate::client_trait::Endpoint::Api,
         crate::client_trait::Style::Rpc,
-        crate::client_trait::Auth::Token,
         "team/team_folder/create",
         arg,
         None)
@@ -1172,14 +1100,13 @@ pub fn team_folder_create(
 
 /// Retrieves metadata for team folders. Permission : Team member file access.
 pub fn team_folder_get_info(
-    client: &dyn crate::client_trait::HttpClient,
+    client: &impl crate::client_trait::TeamAuthClient,
     arg: &TeamFolderIdListArg,
 ) -> crate::Result<Result<Vec<TeamFolderGetInfoItem>, ()>> {
     crate::client_helpers::request(
         client,
         crate::client_trait::Endpoint::Api,
         crate::client_trait::Style::Rpc,
-        crate::client_trait::Auth::Token,
         "team/team_folder/get_info",
         arg,
         None)
@@ -1187,14 +1114,13 @@ pub fn team_folder_get_info(
 
 /// Lists all team folders. Permission : Team member file access.
 pub fn team_folder_list(
-    client: &dyn crate::client_trait::HttpClient,
+    client: &impl crate::client_trait::TeamAuthClient,
     arg: &TeamFolderListArg,
 ) -> crate::Result<Result<TeamFolderListResult, TeamFolderListError>> {
     crate::client_helpers::request(
         client,
         crate::client_trait::Endpoint::Api,
         crate::client_trait::Style::Rpc,
-        crate::client_trait::Auth::Token,
         "team/team_folder/list",
         arg,
         None)
@@ -1203,14 +1129,13 @@ pub fn team_folder_list(
 /// Once a cursor has been retrieved from [`team_folder_list()`](team_folder_list), use this to
 /// paginate through all team folders. Permission : Team member file access.
 pub fn team_folder_list_continue(
-    client: &dyn crate::client_trait::HttpClient,
+    client: &impl crate::client_trait::TeamAuthClient,
     arg: &TeamFolderListContinueArg,
 ) -> crate::Result<Result<TeamFolderListResult, TeamFolderListContinueError>> {
     crate::client_helpers::request(
         client,
         crate::client_trait::Endpoint::Api,
         crate::client_trait::Style::Rpc,
-        crate::client_trait::Auth::Token,
         "team/team_folder/list/continue",
         arg,
         None)
@@ -1218,14 +1143,13 @@ pub fn team_folder_list_continue(
 
 /// Permanently deletes an archived team folder. Permission : Team member file access.
 pub fn team_folder_permanently_delete(
-    client: &dyn crate::client_trait::HttpClient,
+    client: &impl crate::client_trait::TeamAuthClient,
     arg: &TeamFolderIdArg,
 ) -> crate::Result<Result<(), TeamFolderPermanentlyDeleteError>> {
     crate::client_helpers::request(
         client,
         crate::client_trait::Endpoint::Api,
         crate::client_trait::Style::Rpc,
-        crate::client_trait::Auth::Token,
         "team/team_folder/permanently_delete",
         arg,
         None)
@@ -1233,14 +1157,13 @@ pub fn team_folder_permanently_delete(
 
 /// Changes an active team folder's name. Permission : Team member file access.
 pub fn team_folder_rename(
-    client: &dyn crate::client_trait::HttpClient,
+    client: &impl crate::client_trait::TeamAuthClient,
     arg: &TeamFolderRenameArg,
 ) -> crate::Result<Result<TeamFolderMetadata, TeamFolderRenameError>> {
     crate::client_helpers::request(
         client,
         crate::client_trait::Endpoint::Api,
         crate::client_trait::Style::Rpc,
-        crate::client_trait::Auth::Token,
         "team/team_folder/rename",
         arg,
         None)
@@ -1249,14 +1172,13 @@ pub fn team_folder_rename(
 /// Updates the sync settings on a team folder or its contents.  Use of this endpoint requires that
 /// the team has team selective sync enabled.
 pub fn team_folder_update_sync_settings(
-    client: &dyn crate::client_trait::HttpClient,
+    client: &impl crate::client_trait::TeamAuthClient,
     arg: &TeamFolderUpdateSyncSettingsArg,
 ) -> crate::Result<Result<TeamFolderMetadata, TeamFolderUpdateSyncSettingsError>> {
     crate::client_helpers::request(
         client,
         crate::client_trait::Endpoint::Api,
         crate::client_trait::Style::Rpc,
-        crate::client_trait::Auth::Token,
         "team/team_folder/update_sync_settings",
         arg,
         None)
@@ -1265,13 +1187,12 @@ pub fn team_folder_update_sync_settings(
 /// Returns the member profile of the admin who generated the team access token used to make the
 /// call.
 pub fn token_get_authenticated_admin(
-    client: &dyn crate::client_trait::HttpClient,
+    client: &impl crate::client_trait::TeamAuthClient,
 ) -> crate::Result<Result<TokenGetAuthenticatedAdminResult, TokenGetAuthenticatedAdminError>> {
     crate::client_helpers::request(
         client,
         crate::client_trait::Endpoint::Api,
         crate::client_trait::Style::Rpc,
-        crate::client_trait::Auth::Token,
         "team/token/get_authenticated_admin",
         &(),
         None)

--- a/src/generated/users.rs
+++ b/src/generated/users.rs
@@ -20,6 +20,7 @@ pub fn features_get_values(
         client,
         crate::client_trait::Endpoint::Api,
         crate::client_trait::Style::Rpc,
+        crate::client_trait::Auth::Token,
         "users/features/get_values",
         arg,
         None)
@@ -34,6 +35,7 @@ pub fn get_account(
         client,
         crate::client_trait::Endpoint::Api,
         crate::client_trait::Style::Rpc,
+        crate::client_trait::Auth::Token,
         "users/get_account",
         arg,
         None)
@@ -48,6 +50,7 @@ pub fn get_account_batch(
         client,
         crate::client_trait::Endpoint::Api,
         crate::client_trait::Style::Rpc,
+        crate::client_trait::Auth::Token,
         "users/get_account_batch",
         arg,
         None)
@@ -61,6 +64,7 @@ pub fn get_current_account(
         client,
         crate::client_trait::Endpoint::Api,
         crate::client_trait::Style::Rpc,
+        crate::client_trait::Auth::Token,
         "users/get_current_account",
         &(),
         None)
@@ -74,6 +78,7 @@ pub fn get_space_usage(
         client,
         crate::client_trait::Endpoint::Api,
         crate::client_trait::Style::Rpc,
+        crate::client_trait::Auth::Token,
         "users/get_space_usage",
         &(),
         None)

--- a/src/generated/users.rs
+++ b/src/generated/users.rs
@@ -13,14 +13,13 @@ pub type GetAccountBatchResult = Vec<BasicAccount>;
 
 /// Get a list of feature values that may be configured for the current account.
 pub fn features_get_values(
-    client: &dyn crate::client_trait::HttpClient,
+    client: &impl crate::client_trait::UserAuthClient,
     arg: &UserFeaturesGetValuesBatchArg,
 ) -> crate::Result<Result<UserFeaturesGetValuesBatchResult, UserFeaturesGetValuesBatchError>> {
     crate::client_helpers::request(
         client,
         crate::client_trait::Endpoint::Api,
         crate::client_trait::Style::Rpc,
-        crate::client_trait::Auth::Token,
         "users/features/get_values",
         arg,
         None)
@@ -28,14 +27,13 @@ pub fn features_get_values(
 
 /// Get information about a user's account.
 pub fn get_account(
-    client: &dyn crate::client_trait::HttpClient,
+    client: &impl crate::client_trait::UserAuthClient,
     arg: &GetAccountArg,
 ) -> crate::Result<Result<BasicAccount, GetAccountError>> {
     crate::client_helpers::request(
         client,
         crate::client_trait::Endpoint::Api,
         crate::client_trait::Style::Rpc,
-        crate::client_trait::Auth::Token,
         "users/get_account",
         arg,
         None)
@@ -43,14 +41,13 @@ pub fn get_account(
 
 /// Get information about multiple user accounts.  At most 300 accounts may be queried per request.
 pub fn get_account_batch(
-    client: &dyn crate::client_trait::HttpClient,
+    client: &impl crate::client_trait::UserAuthClient,
     arg: &GetAccountBatchArg,
 ) -> crate::Result<Result<GetAccountBatchResult, GetAccountBatchError>> {
     crate::client_helpers::request(
         client,
         crate::client_trait::Endpoint::Api,
         crate::client_trait::Style::Rpc,
-        crate::client_trait::Auth::Token,
         "users/get_account_batch",
         arg,
         None)
@@ -58,13 +55,12 @@ pub fn get_account_batch(
 
 /// Get information about the current user's account.
 pub fn get_current_account(
-    client: &dyn crate::client_trait::HttpClient,
+    client: &impl crate::client_trait::UserAuthClient,
 ) -> crate::Result<Result<FullAccount, ()>> {
     crate::client_helpers::request(
         client,
         crate::client_trait::Endpoint::Api,
         crate::client_trait::Style::Rpc,
-        crate::client_trait::Auth::Token,
         "users/get_current_account",
         &(),
         None)
@@ -72,13 +68,12 @@ pub fn get_current_account(
 
 /// Get the space usage information for the current user's account.
 pub fn get_space_usage(
-    client: &dyn crate::client_trait::HttpClient,
+    client: &impl crate::client_trait::UserAuthClient,
 ) -> crate::Result<Result<SpaceUsage, ()>> {
     crate::client_helpers::request(
         client,
         crate::client_trait::Endpoint::Api,
         crate::client_trait::Style::Rpc,
-        crate::client_trait::Auth::Token,
         "users/get_space_usage",
         &(),
         None)

--- a/src/hyper_client.rs
+++ b/src/hyper_client.rs
@@ -274,7 +274,7 @@ impl HyperClient {
                 headers.set(Range::Bytes(vec![ByteRangeSpec::Last(end)]));
             }
 
-            // If the params are totally empt, don't send any arg header or body.
+            // If the params are totally empty, don't send any arg header or body.
             if !params_json.is_empty() {
                 match style {
                     Style::Rpc => {

--- a/src/hyper_client.rs
+++ b/src/hyper_client.rs
@@ -4,13 +4,12 @@ use std::io::{self, Read};
 use std::str;
 
 use crate::Error;
-use crate::client_trait::{Endpoint, Style, HttpClient, HttpRequestResultRaw, TeamAuthClient,
-    TeamSelect, UserAuthClient};
+use crate::client_trait::{Endpoint, Style, HttpClient, HttpRequestResultRaw, ParamsType,
+    TeamAuthClient, TeamSelect, UserAuthClient};
 use hyper::{self, Url};
 use hyper::header::Headers;
 use hyper::header::{
     Authorization, Bearer, ByteRangeSpec, Connection, ContentLength, ContentType, Range};
-use url::form_urlencoded::Serializer as UrlEncoder;
 
 const USER_AGENT: &str = concat!("Dropbox-APIv2-Rust/", env!("CARGO_PKG_VERSION"));
 
@@ -21,12 +20,13 @@ macro_rules! forward_request {
             endpoint: Endpoint,
             style: Style,
             function: &str,
-            params_json: String,
+            params: String,
+            params_type: ParamsType,
             body: Option<&[u8]>,
             range_start: Option<u64>,
             range_end: Option<u64>,
         ) -> crate::Result<HttpRequestResultRaw> {
-            $client.request(endpoint, style, function, params_json, body, range_start,
+            $client.request(endpoint, style, function, params, params_type, body, range_start,
                 range_end, $token, $team_select)
         }
     }
@@ -155,7 +155,8 @@ impl HyperClient {
         endpoint: Endpoint,
         style: Style,
         function: &str,
-        params_json: String,
+        params: String,
+        params_type: ParamsType,
         body: Option<&[u8]>,
         range_start: Option<u64>,
         range_end: Option<u64>,
@@ -194,17 +195,20 @@ impl HyperClient {
             }
 
             // If the params are totally empty, don't send any arg header or body.
-            if !params_json.is_empty() {
+            if !params.is_empty() {
                 match style {
                     Style::Rpc => {
                         // Send params in the body.
-                        headers.set(ContentType::json());
-                        builder = builder.body(params_json.as_bytes());
+                        match params_type {
+                            ParamsType::Json => headers.set(ContentType::json()),
+                            ParamsType::Form => headers.set(ContentType::form_url_encoded()),
+                        };
+                        builder = builder.body(params.as_bytes());
                         assert_eq!(None, body);
                     },
                     Style::Upload | Style::Download => {
                         // Send params in a header.
-                        headers.set_raw("Dropbox-API-Arg", vec![params_json.clone().into_bytes()]);
+                        headers.set_raw("Dropbox-API-Arg", vec![params.clone().into_bytes()]);
                         if style == Style::Upload {
                             headers.set(
                                 ContentType(
@@ -278,187 +282,6 @@ impl HyperClient {
             }
 
         }
-    }
-}
-
-// OAuth2 helpers:
-
-/// Given an authorization code, request an OAuth2 token from Dropbox API.
-/// Requires the App ID and secret, as well as the redirect URI used in the prior authorize
-/// request, if there was one.
-pub fn oauth2_token_from_authorization_code(
-    client_id: &str,
-    client_secret: &str,
-    authorization_code: &str,
-    redirect_uri: Option<&str>,
-) -> crate::Result<String> {
-
-    let client = http_client();
-    let url = Url::parse("https://api.dropboxapi.com/oauth2/token").unwrap();
-
-    let mut headers = Headers::new();
-    headers.set(UserAgent(USER_AGENT));
-
-    // This endpoint wants parameters using URL-encoding instead of JSON.
-    headers.set(ContentType("application/x-www-form-urlencoded".parse().unwrap()));
-    let mut params = UrlEncoder::new(String::new());
-    params.append_pair("code", authorization_code);
-    params.append_pair("grant_type", "authorization_code");
-    params.append_pair("client_id", client_id);
-    params.append_pair("client_secret", client_secret);
-    if let Some(value) = redirect_uri {
-        params.append_pair("redirect_uri", value);
-    }
-    let body = params.finish();
-
-    match client.post(url).headers(headers).body(body.as_bytes()).send() {
-        Ok(mut resp) => {
-            if !resp.status.is_success() {
-                let hyper::http::RawStatus(code, status) = resp.status_raw().clone();
-                let mut body = String::new();
-                resp.read_to_string(&mut body)?;
-                debug!("error body: {}", body);
-                Err(Error::UnexpectedHttpError {
-                    code,
-                    status: status.into_owned(),
-                    json: body,
-                })
-            } else {
-                let body = serde_json::from_reader(resp)?;
-                debug!("response: {:?}", body);
-                match body {
-                    serde_json::Value::Object(mut map) => {
-                        match map.remove("access_token") {
-                            Some(serde_json::Value::String(token)) => Ok(token),
-                            _ => Err(Error::UnexpectedResponse("no access token in response!")),
-                        }
-                    },
-                    _ => Err(Error::UnexpectedResponse("response is not a JSON object")),
-                }
-            }
-        },
-        Err(e) => {
-            error!("error getting OAuth2 token: {}", e);
-            Err(e.into())
-        }
-    }
-}
-
-/// Builds a URL that can be given to the user to visit to have Dropbox authorize your app.
-#[derive(Debug)]
-pub struct Oauth2AuthorizeUrlBuilder<'a> {
-    client_id: &'a str,
-    response_type: &'a str,
-    force_reapprove: bool,
-    force_reauthentication: bool,
-    disable_signup: bool,
-    redirect_uri: Option<&'a str>,
-    state: Option<&'a str>,
-    require_role: Option<&'a str>,
-    locale: Option<&'a str>,
-}
-
-/// Which type of OAuth2 flow to use.
-#[derive(Debug, Copy, Clone)]
-pub enum Oauth2Type {
-    /// Authorization yields a temporary authorization code which must be turned into an OAuth2
-    /// token by making another call. This can be used without a redirect URI, where the user
-    /// inputs the code directly into the program.
-    AuthorizationCode,
-
-    /// Authorization directly returns an OAuth2 token. This can only be used with a redirect URI
-    /// where the Dropbox server redirects the user's web browser to the program.
-    ImplicitGrant,
-}
-
-impl Oauth2Type {
-    pub fn as_str(self) -> &'static str {
-        match self {
-            Oauth2Type::AuthorizationCode => "code",
-            Oauth2Type::ImplicitGrant => "token",
-        }
-    }
-}
-
-impl<'a> Oauth2AuthorizeUrlBuilder<'a> {
-    pub fn new(client_id: &'a str, oauth2_type: Oauth2Type) -> Self {
-        Self {
-            client_id,
-            response_type: oauth2_type.as_str(),
-            force_reapprove: false,
-            force_reauthentication: false,
-            disable_signup: false,
-            redirect_uri: None,
-            state: None,
-            require_role: None,
-            locale: None,
-        }
-    }
-
-    pub fn force_reapprove(mut self, value: bool) -> Self {
-        self.force_reapprove = value;
-        self
-    }
-
-    pub fn force_reauthentication(mut self, value: bool) -> Self {
-        self.force_reauthentication = value;
-        self
-    }
-
-    pub fn disable_signup(mut self, value: bool) -> Self {
-        self.disable_signup = value;
-        self
-    }
-
-    pub fn redirect_uri(mut self, value: &'a str) -> Self {
-        self.redirect_uri = Some(value);
-        self
-    }
-
-    pub fn state(mut self, value: &'a str) -> Self {
-        self.state = Some(value);
-        self
-    }
-
-    pub fn require_role(mut self, value: &'a str) -> Self {
-        self.require_role = Some(value);
-        self
-    }
-
-    pub fn locale(mut self, value: &'a str) -> Self {
-        self.locale = Some(value);
-        self
-    }
-
-    pub fn build(self) -> Url {
-        let mut url = Url::parse("https://www.dropbox.com/oauth2/authorize").unwrap();
-        {
-            let mut params = url.query_pairs_mut();
-            params.append_pair("response_type", self.response_type);
-            params.append_pair("client_id", self.client_id);
-            if self.force_reapprove {
-                params.append_pair("force_reapprove", "true");
-            }
-            if self.force_reauthentication {
-                params.append_pair("force_reauthentication", "true");
-            }
-            if self.disable_signup {
-                params.append_pair("disable_signup", "true");
-            }
-            if let Some(value) = self.redirect_uri {
-                params.append_pair("redirect_uri", value);
-            }
-            if let Some(value) = self.state {
-                params.append_pair("state", value);
-            }
-            if let Some(value) = self.require_role {
-                params.append_pair("require_role", value);
-            }
-            if let Some(value) = self.locale {
-                params.append_pair("locale", value);
-            }
-        }
-        url
     }
 }
 

--- a/src/hyper_client.rs
+++ b/src/hyper_client.rs
@@ -4,7 +4,7 @@ use std::io::{self, Read};
 use std::str;
 
 use crate::Error;
-use crate::client_trait::{Endpoint, Style, HttpClient, HttpRequestResultRaw};
+use crate::client_trait::{Auth, Endpoint, Style, HttpClient, HttpRequestResultRaw};
 use hyper::{self, Url};
 use hyper::header::Headers;
 use hyper::header::{
@@ -131,6 +131,7 @@ impl HttpClient for HyperClient {
         &self,
         endpoint: Endpoint,
         style: Style,
+        auth: Auth,
         function: &str,
         params_json: String,
         body: Option<&[u8]>,
@@ -146,7 +147,12 @@ impl HttpClient for HyperClient {
 
             let mut headers = Headers::new();
             headers.set(UserAgent(USER_AGENT));
-            headers.set(Authorization(Bearer { token: self.token.clone() }));
+
+            match auth {
+                Auth::Noauth => (),
+                Auth::Token => headers.set(Authorization(Bearer { token: self.token.clone() })),
+            }
+
             headers.set(Connection::keep_alive());
 
             if let Some(start) = range_start {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -44,6 +44,7 @@ pub type Result<T> = std::result::Result<T, Error>;
 pub mod client_trait;
 pub use client_trait::{AppAuthClient, NoauthClient, UserAuthClient, TeamAuthClient};
 pub(crate) mod client_helpers;
+pub mod oauth2;
 
 mod generated; // You need to run the Stone generator to create this module.
 pub use generated::*;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -39,14 +39,10 @@ pub enum Error {
 
 pub type Result<T> = std::result::Result<T, Error>;
 
-#[cfg(feature = "hyper_client")] mod hyper_client;
-#[cfg(feature = "hyper_client")] pub use hyper_client::{
-    HyperClient,
-    Oauth2AuthorizeUrlBuilder,
-    Oauth2Type,
-};
+#[cfg(feature = "hyper_client")] pub mod hyper_client;
 
 pub mod client_trait;
+pub use client_trait::{AppAuthClient, NoauthClient, UserAuthClient, TeamAuthClient};
 pub(crate) mod client_helpers;
 
 mod generated; // You need to run the Stone generator to create this module.

--- a/src/oauth2.rs
+++ b/src/oauth2.rs
@@ -1,0 +1,170 @@
+// Copyright (c) 2019-2020 Dropbox, Inc.
+
+use crate::Error;
+use crate::client_trait::*;
+use url::form_urlencoded::Serializer as UrlEncoder;
+use url::Url;
+
+/// Given an authorization code, request an OAuth2 token from Dropbox API.
+/// Requires the App ID and secret, as well as the redirect URI used in the prior authorize
+/// request, if there was one.
+pub fn oauth2_token_from_authorization_code(
+    client: impl HttpClient,
+    client_id: &str,
+    client_secret: &str,
+    authorization_code: &str,
+    redirect_uri: Option<&str>,
+) -> crate::Result<String> {
+
+    let mut params = UrlEncoder::new(String::new());
+    params.append_pair("code", authorization_code);
+    params.append_pair("grant_type", "authorization_code");
+    params.append_pair("client_id", client_id);
+    params.append_pair("client_secret", client_secret);
+    if let Some(value) = redirect_uri {
+        params.append_pair("redirect_uri", value);
+    }
+
+    debug!("Requesting OAuth2 token");
+    let resp = client.request(
+        Endpoint::OAuth2,
+        Style::Rpc,
+        "oauth2/token",
+        params.finish(),
+        ParamsType::Form,
+        None,
+        None,
+        None,
+    )?;
+
+    let result_json = serde_json::from_str(&resp.result_json)?;
+
+    debug!("OAuth2 response: {:?}", result_json);
+    match result_json {
+        serde_json::Value::Object(mut map) => {
+            match map.remove("access_token") {
+                Some(serde_json::Value::String(token)) => Ok(token),
+                _ => Err(Error::UnexpectedResponse("no access token in response!")),
+            }
+        },
+        _ => Err(Error::UnexpectedResponse("response is not a JSON object")),
+    }
+}
+
+/// Builds a URL that can be given to the user to visit to have Dropbox authorize your app.
+#[derive(Debug)]
+pub struct Oauth2AuthorizeUrlBuilder<'a> {
+    client_id: &'a str,
+    response_type: &'a str,
+    force_reapprove: bool,
+    force_reauthentication: bool,
+    disable_signup: bool,
+    redirect_uri: Option<&'a str>,
+    state: Option<&'a str>,
+    require_role: Option<&'a str>,
+    locale: Option<&'a str>,
+}
+
+/// Which type of OAuth2 flow to use.
+#[derive(Debug, Copy, Clone)]
+pub enum Oauth2Type {
+    /// Authorization yields a temporary authorization code which must be turned into an OAuth2
+    /// token by making another call. This can be used without a redirect URI, where the user
+    /// inputs the code directly into the program.
+    AuthorizationCode,
+
+    /// Authorization directly returns an OAuth2 token. This can only be used with a redirect URI
+    /// where the Dropbox server redirects the user's web browser to the program.
+    ImplicitGrant,
+}
+
+impl Oauth2Type {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Oauth2Type::AuthorizationCode => "code",
+            Oauth2Type::ImplicitGrant => "token",
+        }
+    }
+}
+
+impl<'a> Oauth2AuthorizeUrlBuilder<'a> {
+    pub fn new(client_id: &'a str, oauth2_type: Oauth2Type) -> Self {
+        Self {
+            client_id,
+            response_type: oauth2_type.as_str(),
+            force_reapprove: false,
+            force_reauthentication: false,
+            disable_signup: false,
+            redirect_uri: None,
+            state: None,
+            require_role: None,
+            locale: None,
+        }
+    }
+
+    pub fn force_reapprove(mut self, value: bool) -> Self {
+        self.force_reapprove = value;
+        self
+    }
+
+    pub fn force_reauthentication(mut self, value: bool) -> Self {
+        self.force_reauthentication = value;
+        self
+    }
+
+    pub fn disable_signup(mut self, value: bool) -> Self {
+        self.disable_signup = value;
+        self
+    }
+
+    pub fn redirect_uri(mut self, value: &'a str) -> Self {
+        self.redirect_uri = Some(value);
+        self
+    }
+
+    pub fn state(mut self, value: &'a str) -> Self {
+        self.state = Some(value);
+        self
+    }
+
+    pub fn require_role(mut self, value: &'a str) -> Self {
+        self.require_role = Some(value);
+        self
+    }
+
+    pub fn locale(mut self, value: &'a str) -> Self {
+        self.locale = Some(value);
+        self
+    }
+
+    pub fn build(self) -> Url {
+        let mut url = Url::parse("https://www.dropbox.com/oauth2/authorize").unwrap();
+        {
+            let mut params = url.query_pairs_mut();
+            params.append_pair("response_type", self.response_type);
+            params.append_pair("client_id", self.client_id);
+            if self.force_reapprove {
+                params.append_pair("force_reapprove", "true");
+            }
+            if self.force_reauthentication {
+                params.append_pair("force_reauthentication", "true");
+            }
+            if self.disable_signup {
+                params.append_pair("disable_signup", "true");
+            }
+            if let Some(value) = self.redirect_uri {
+                params.append_pair("redirect_uri", value);
+            }
+            if let Some(value) = self.state {
+                params.append_pair("state", value);
+            }
+            if let Some(value) = self.require_role {
+                params.append_pair("require_role", value);
+            }
+            if let Some(value) = self.locale {
+                params.append_pair("locale", value);
+            }
+        }
+        url
+    }
+}


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description below.
-->

## **Checklist**
<!-- For completed items, change [ ] to [x]. -->

**General Contributing**
- [x] Have you read the Code of Conduct and signed the [CLA](https://opensource.dropbox.com/cla/)?

**Is This a Code Change?**
- [ ] Non-code related change (markdown/git settings etc)
- [x] SDK Code Change
- [ ] Example/Test Code Change

This implements different authentication types in the default Hyper client, and changes the client trait so that custom clients can do so as well. Previously, the Hyper client only did User auth, and the single client trait meant that API calls which require specific authentication types could not ensure they are only called by a capable client.

This change adds three new marker traits which require the general HttpClient trait, and indicate that a client is capable of User auth, Team auth, or unauthenticated access. API functions then require the appropriate type of client. Additionally, the Team auth mode allows specifying User or Admin context.

Finally, as a bit of a drive-by fix, but nice to do as long as I'm doing major changes to the HTTP client anyway, I've moved the OAuth2 helpers out of the Hyper client and made them client-independent, so that anyone with a custom client can make use of them as well. The request done for an OAuth2 token is essentially the same as a normal API call, except that the content-type of the request is different, so this necessitated adding another parameter to the request method.

Fixes #15.