### PR TITLE
avoid closures for default values in some cases

### DIFF
--- a/src/generated/file_properties.rs
+++ b/src/generated/file_properties.rs
@@ -1913,7 +1913,7 @@ impl PropertiesSearchArg {
         }
         let result = PropertiesSearchArg {
             queries: field_queries.ok_or_else(|| ::serde::de::Error::missing_field("queries"))?,
-            template_filter: field_template_filter.unwrap_or_else(|| TemplateFilter::FilterNone),
+            template_filter: field_template_filter.unwrap_or(TemplateFilter::FilterNone),
         };
         Ok(Some(result))
     }
@@ -2464,7 +2464,7 @@ impl PropertiesSearchQuery {
         let result = PropertiesSearchQuery {
             query: field_query.ok_or_else(|| ::serde::de::Error::missing_field("query"))?,
             mode: field_mode.ok_or_else(|| ::serde::de::Error::missing_field("mode"))?,
-            logical_operator: field_logical_operator.unwrap_or_else(|| LogicalOperator::OrOperator),
+            logical_operator: field_logical_operator.unwrap_or(LogicalOperator::OrOperator),
         };
         Ok(Some(result))
     }

--- a/src/generated/file_requests.rs
+++ b/src/generated/file_requests.rs
@@ -2807,7 +2807,7 @@ impl UpdateFileRequestArgs {
             id: field_id.ok_or_else(|| ::serde::de::Error::missing_field("id"))?,
             title: field_title,
             destination: field_destination,
-            deadline: field_deadline.unwrap_or_else(|| UpdateFileRequestDeadline::NoUpdate),
+            deadline: field_deadline.unwrap_or(UpdateFileRequestDeadline::NoUpdate),
             open: field_open,
             description: field_description,
         };

--- a/src/generated/files.rs
+++ b/src/generated/files.rs
@@ -1562,7 +1562,7 @@ impl CommitInfo {
         }
         let result = CommitInfo {
             path: field_path.ok_or_else(|| ::serde::de::Error::missing_field("path"))?,
-            mode: field_mode.unwrap_or_else(|| WriteMode::Add),
+            mode: field_mode.unwrap_or(WriteMode::Add),
             autorename: field_autorename.unwrap_or(false),
             client_modified: field_client_modified,
             mute: field_mute.unwrap_or(false),
@@ -1773,7 +1773,7 @@ impl CommitInfoWithProperties {
         }
         let result = CommitInfoWithProperties {
             path: field_path.ok_or_else(|| ::serde::de::Error::missing_field("path"))?,
-            mode: field_mode.unwrap_or_else(|| WriteMode::Add),
+            mode: field_mode.unwrap_or(WriteMode::Add),
             autorename: field_autorename.unwrap_or(false),
             client_modified: field_client_modified,
             mute: field_mute.unwrap_or(false),
@@ -9328,7 +9328,7 @@ impl ListRevisionsArg {
         }
         let result = ListRevisionsArg {
             path: field_path.ok_or_else(|| ::serde::de::Error::missing_field("path"))?,
-            mode: field_mode.unwrap_or_else(|| ListRevisionsMode::Path),
+            mode: field_mode.unwrap_or(ListRevisionsMode::Path),
             limit: field_limit.unwrap_or(10),
         };
         Ok(Some(result))
@@ -14429,7 +14429,7 @@ impl SearchArg {
             query: field_query.ok_or_else(|| ::serde::de::Error::missing_field("query"))?,
             start: field_start.unwrap_or(0),
             max_results: field_max_results.unwrap_or(100),
-            mode: field_mode.unwrap_or_else(|| SearchMode::Filename),
+            mode: field_mode.unwrap_or(SearchMode::Filename),
         };
         Ok(Some(result))
     }
@@ -15117,7 +15117,7 @@ impl SearchOptions {
         let result = SearchOptions {
             path: field_path,
             max_results: field_max_results.unwrap_or(100),
-            file_status: field_file_status.unwrap_or_else(|| FileStatus::Active),
+            file_status: field_file_status.unwrap_or(FileStatus::Active),
             filename_only: field_filename_only.unwrap_or(false),
             file_extensions: field_file_extensions,
             file_categories: field_file_categories,
@@ -16544,9 +16544,9 @@ impl ThumbnailArg {
         }
         let result = ThumbnailArg {
             path: field_path.ok_or_else(|| ::serde::de::Error::missing_field("path"))?,
-            format: field_format.unwrap_or_else(|| ThumbnailFormat::Jpeg),
-            size: field_size.unwrap_or_else(|| ThumbnailSize::W64h64),
-            mode: field_mode.unwrap_or_else(|| ThumbnailMode::Strict),
+            format: field_format.unwrap_or(ThumbnailFormat::Jpeg),
+            size: field_size.unwrap_or(ThumbnailSize::W64h64),
+            mode: field_mode.unwrap_or(ThumbnailMode::Strict),
         };
         Ok(Some(result))
     }
@@ -17086,9 +17086,9 @@ impl ThumbnailV2Arg {
         }
         let result = ThumbnailV2Arg {
             resource: field_resource.ok_or_else(|| ::serde::de::Error::missing_field("resource"))?,
-            format: field_format.unwrap_or_else(|| ThumbnailFormat::Jpeg),
-            size: field_size.unwrap_or_else(|| ThumbnailSize::W64h64),
-            mode: field_mode.unwrap_or_else(|| ThumbnailMode::Strict),
+            format: field_format.unwrap_or(ThumbnailFormat::Jpeg),
+            size: field_size.unwrap_or(ThumbnailSize::W64h64),
+            mode: field_mode.unwrap_or(ThumbnailMode::Strict),
         };
         Ok(Some(result))
     }

--- a/src/generated/paper.rs
+++ b/src/generated/paper.rs
@@ -435,7 +435,7 @@ impl AddMember {
         }
         let result = AddMember {
             member: field_member.ok_or_else(|| ::serde::de::Error::missing_field("member"))?,
-            permission_level: field_permission_level.unwrap_or_else(|| PaperDocPermissionLevel::Edit),
+            permission_level: field_permission_level.unwrap_or(PaperDocPermissionLevel::Edit),
         };
         Ok(Some(result))
     }
@@ -1910,9 +1910,9 @@ impl ListPaperDocsArgs {
             }
         }
         let result = ListPaperDocsArgs {
-            filter_by: field_filter_by.unwrap_or_else(|| ListPaperDocsFilterBy::DocsAccessed),
-            sort_by: field_sort_by.unwrap_or_else(|| ListPaperDocsSortBy::Accessed),
-            sort_order: field_sort_order.unwrap_or_else(|| ListPaperDocsSortOrder::Ascending),
+            filter_by: field_filter_by.unwrap_or(ListPaperDocsFilterBy::DocsAccessed),
+            sort_by: field_sort_by.unwrap_or(ListPaperDocsSortBy::Accessed),
+            sort_order: field_sort_order.unwrap_or(ListPaperDocsSortOrder::Ascending),
             limit: field_limit.unwrap_or(1000),
         };
         Ok(result)
@@ -2936,7 +2936,7 @@ impl ListUsersOnPaperDocArgs {
         let result = ListUsersOnPaperDocArgs {
             doc_id: field_doc_id.ok_or_else(|| ::serde::de::Error::missing_field("doc_id"))?,
             limit: field_limit.unwrap_or(1000),
-            filter_by: field_filter_by.unwrap_or_else(|| UserOnPaperDocFilter::Shared),
+            filter_by: field_filter_by.unwrap_or(UserOnPaperDocFilter::Shared),
         };
         Ok(Some(result))
     }

--- a/src/generated/sharing.rs
+++ b/src/generated/sharing.rs
@@ -1061,7 +1061,7 @@ impl AddFileMemberArgs {
             members: field_members.ok_or_else(|| ::serde::de::Error::missing_field("members"))?,
             custom_message: field_custom_message,
             quiet: field_quiet.unwrap_or(false),
-            access_level: field_access_level.unwrap_or_else(|| AccessLevel::Viewer),
+            access_level: field_access_level.unwrap_or(AccessLevel::Viewer),
             add_message_as_comment: field_add_message_as_comment.unwrap_or(false),
         };
         Ok(Some(result))
@@ -1678,7 +1678,7 @@ impl AddMember {
         }
         let result = AddMember {
             member: field_member.ok_or_else(|| ::serde::de::Error::missing_field("member"))?,
-            access_level: field_access_level.unwrap_or_else(|| AccessLevel::Viewer),
+            access_level: field_access_level.unwrap_or(AccessLevel::Viewer),
         };
         Ok(Some(result))
     }
@@ -13463,7 +13463,7 @@ impl SetAccessInheritanceArg {
         }
         let result = SetAccessInheritanceArg {
             shared_folder_id: field_shared_folder_id.ok_or_else(|| ::serde::de::Error::missing_field("shared_folder_id"))?,
-            access_inheritance: field_access_inheritance.unwrap_or_else(|| AccessInheritance::Inherit),
+            access_inheritance: field_access_inheritance.unwrap_or(AccessInheritance::Inherit),
         };
         Ok(Some(result))
     }
@@ -13779,7 +13779,7 @@ impl ShareFolderArg {
             member_policy: field_member_policy,
             shared_link_policy: field_shared_link_policy,
             viewer_info_policy: field_viewer_info_policy,
-            access_inheritance: field_access_inheritance.unwrap_or_else(|| AccessInheritance::Inherit),
+            access_inheritance: field_access_inheritance.unwrap_or(AccessInheritance::Inherit),
             actions: field_actions,
             link_settings: field_link_settings,
         };
@@ -13983,7 +13983,7 @@ impl ShareFolderArgBase {
             member_policy: field_member_policy,
             shared_link_policy: field_shared_link_policy,
             viewer_info_policy: field_viewer_info_policy,
-            access_inheritance: field_access_inheritance.unwrap_or_else(|| AccessInheritance::Inherit),
+            access_inheritance: field_access_inheritance.unwrap_or(AccessInheritance::Inherit),
         };
         Ok(Some(result))
     }
@@ -16189,7 +16189,7 @@ impl SharedFolderMetadata {
             parent_folder_name: field_parent_folder_name,
             link_metadata: field_link_metadata,
             permissions: field_permissions,
-            access_inheritance: field_access_inheritance.unwrap_or_else(|| AccessInheritance::Inherit),
+            access_inheritance: field_access_inheritance.unwrap_or(AccessInheritance::Inherit),
         };
         Ok(Some(result))
     }

--- a/src/generated/team.rs
+++ b/src/generated/team.rs
@@ -14146,7 +14146,7 @@ impl MemberAddArg {
             member_external_id: field_member_external_id,
             member_persistent_id: field_member_persistent_id,
             send_welcome_email: field_send_welcome_email.unwrap_or(true),
-            role: field_role.unwrap_or_else(|| AdminTier::MemberOnly),
+            role: field_role.unwrap_or(AdminTier::MemberOnly),
             is_directory_restricted: field_is_directory_restricted,
         };
         Ok(Some(result))


### PR DESCRIPTION
If a default value contains no parenthesis, consider it "trivial" and emit it directly in a `.unwrap_or()` instead of in a closure with `.unwrap_or_else()`.

Otherwise, Clippy (on current nightly) warns of `unnecessary_lazy_evaluations` in these cases.

Unfortunately, Clippy has type information at its disposal and we do not, but this rough heuristic appears to be good enough.

<!--
Thank you for your pull request. Please provide a description below.
-->

## **Checklist**
<!-- For completed items, change [ ] to [x]. -->

**General Contributing**
- [x] Have you read the Code of Conduct and signed the [CLA](https://opensource.dropbox.com/cla/)?

**Validation**
Clippy (nightly) now passes for all targets; serialize/deserialize tests still pass. Manually inspected the handful of lines this changed.