### PR TITLE
change Error::RateLimited to show the reason and the retry time

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ readme = "README.md"
 hyper = { version = "0.10", optional = true }
 hyper-native-tls = { version = "0.3", optional = true }
 log = "0.4"
-serde = "1.0"
+serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 thiserror = "1.0"
 url = "2.1"

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -8,6 +8,7 @@ yyyy-mm-dd
   users of custom HTTP clients don't have to reinvent the wheel for OAuth2.
   * The `oauth2_token_from_authorization_code` now is in a different module, and takes a HTTP
     client implementation as a new first argument.
+* Changed the Error::RateLimited variant to include the requested backoff time.
 * very small API update
 
 # v0.6.0

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -23,8 +23,9 @@ pub enum Error {
     #[error("Dropbox API indicated that the access token is bad: {0}")]
     InvalidToken(String),
 
-    #[error("Dropbox API declined the request due to rate-limiting: {0}")]
-    RateLimited(String),
+    #[error("Dropbox API declined the request due to rate-limiting ({reason}), \
+        retry after {retry_after_seconds}s")]
+    RateLimited { reason: String, retry_after_seconds: u32 },
 
     #[error("Dropbox API had an internal server error: {0}")]
     ServerError(String),


### PR DESCRIPTION
Also while we're at it, stop doing manual `Deserialize` derives for the error structs. proc-macro2, quote, and syn are already pulled in by thiserror, so this doesn't actually impact our dependency tree. Having one manually-written implementation (for TopLevelError) wasn't bad, but now there's three of them that can use this.

The SDK types have manual implementations for Deserialize because of some aspects of Dropbox's serialization style which serde doesn't completely support, but these error types don't appear to ever hit those corner cases, so a derived implementation works fine.

<!--
Thank you for your pull request. Please provide a description below.
-->

## **Checklist**
<!-- For completed items, change [ ] to [x]. -->

**General Contributing**
- [x] Have you read the Code of Conduct and signed the [CLA](https://opensource.dropbox.com/cla/)?

**Validation**
Ran the examples and verified that they still work. Furthermore, an integration test I'm currently working on exercises this by making a lot of upload calls, which gets it rate-limited.