### PR TITLE
remove code change type section from the pull request template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -3,15 +3,12 @@ Thank you for your pull request. Please provide a description below.
 -->
 
 ## **Checklist**
-<!-- For completed items, change [ ] to [x]. -->
 
 **General Contributing**
+<!-- Change [ ] to [x] if you have: -->
 - [ ] Have you read the Code of Conduct and signed the [CLA](https://opensource.dropbox.com/cla/)?
 
-**Is This a Code Change?**
-- [ ] Non-code related change (markdown/git settings etc)
-- [ ] SDK Code Change
-- [ ] Example/Test Code Change
-
 **Validation**
-{Add language specific validation steps i.e. how to build/test/documentation/etc}
+<!-- Describe which tests cover the changes you've made, and any additional manual validation you
+     did to ensure the correctness of this change. Does this change warrant addition of new tests?
+     Does this change have performance implications? Etc. -->


### PR DESCRIPTION
The code change type section isn't very helpful and results in a
checklist for every PR that will never get to 100%.

Additionally, adding some examples of what we're looking for in the
Validation section. (I imagine this section to be similar to the Test
Plan section of Dropbox's Phabricator diffs.)

<!--
Thank you for your pull request. Please provide a description below.
-->

## **Checklist**
<!-- For completed items, change [ ] to [x]. -->

**General Contributing**
- [x] Have you read the Code of Conduct and signed the [CLA](https://opensource.dropbox.com/cla/)?

**Is This a Code Change?**
- [x] Non-code related change (markdown/git settings etc)
- [ ] SDK Code Change
- [ ] Example/Test Code Change

**Validation**
N/A: Purely repository metadata.