### PR TITLE
add two integration tests

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,7 @@ url = "2.1"
 [dev-dependencies]
 env_logger = "0.8"
 chrono = "0.4"
+threadpool = "1.8"
 
 [[example]]
 name = "demo"

--- a/tests/benchmark.rs
+++ b/tests/benchmark.rs
@@ -1,0 +1,75 @@
+use dropbox_sdk::files;
+use dropbox_sdk::hyper_client::UserAuthHyperClient;
+use std::sync::Arc;
+use std::thread;
+use std::time::{Duration, Instant};
+use threadpool::ThreadPool;
+
+mod common;
+
+/// This test should be run with --nocapture to see the timing info output.
+#[test]
+#[ignore] // very time-consuming to run; should be run separately
+fn fetch_files() {
+    let token = std::env::var("DBX_OAUTH_TOKEN").expect("DBX_OAUTH_TOKEN must be set");
+    let client = Arc::new(UserAuthHyperClient::new(token));
+    let threadpool = ThreadPool::new(20);
+
+    const FOLDER: &str = "/fetch_small_files";
+    const NUM_FILES: u32 = 100;
+    const NUM_TEST_RUNS: u32 = 4;
+    const FILE_SIZE: usize = 1024 * 1024; // 1 MiB
+
+    println!("Setting up test environment");
+
+    common::create_clean_folder(client.as_ref(), FOLDER);
+
+    let (file_path, file_bytes) = common::create_files(
+        client.clone(), FOLDER, NUM_FILES, FILE_SIZE);
+
+    threadpool.join();
+
+    println!("Test setup complete. Starting benchmark.");
+
+    let mut times = vec![];
+    for _ in 0 .. NUM_TEST_RUNS {
+        println!("sleeping 10 seconds before run");
+        thread::sleep(Duration::from_secs(10));
+        let start = Instant::now();
+        for i in 0 .. NUM_FILES {
+            let path = file_path(i);
+            let expected_bytes = file_bytes(i);
+            let c = client.clone();
+            threadpool.execute(move || {
+                loop {
+                    let arg = files::DownloadArg::new(path.clone());
+                    match files::download(c.as_ref(), &arg, None, None) {
+                        Ok(Ok(result)) => {
+                            let mut read_bytes = Vec::new();
+                            result.body.expect("result should have a body")
+                                .read_to_end(&mut read_bytes).expect("read_to_end");
+                            assert_eq!(&read_bytes, &expected_bytes);
+                        }
+                        Err(dropbox_sdk::Error::RateLimited { retry_after_seconds, .. }) => {
+                            eprintln!("WARNING: rate-limited {} seconds", retry_after_seconds);
+                            thread::sleep(Duration::from_secs(retry_after_seconds as u64));
+                            continue;
+                        }
+                        Ok(Err(e)) => panic!("{}: download failed: {:?}", path, e),
+                        Err(e) => panic!("{}: download failed: {:?}", path, e),
+                    }
+                    break;
+                }
+            });
+        }
+
+        threadpool.join();
+        let dur = start.elapsed();
+        println!("test finished in {} seconds", dur.as_secs_f64());
+        times.push(dur);
+    }
+
+    println!("{:?}", times);
+    println!("average: {} seconds",
+        times.iter().map(Duration::as_secs_f64).sum::<f64>() / times.len() as f64)
+}

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -1,0 +1,67 @@
+use dropbox_sdk::files;
+use dropbox_sdk::client_trait::UserAuthClient;
+use std::sync::Arc;
+use std::thread;
+use std::time::Duration;
+use threadpool::ThreadPool;
+
+pub fn create_files(
+    client: Arc<impl UserAuthClient + Send + Sync + 'static>,
+    path: &'static str,
+    num_files: u32,
+    size: usize,
+) -> (Box<impl Fn(u32) -> String>, Box<impl Fn(u32) -> Vec<u8>>) {
+    let threadpool = ThreadPool::new(20);
+
+    let file_bytes = move |i| format!("This is file {}.\n", i)
+        .into_bytes()
+        .into_iter()
+        .cycle()
+        .take(size)
+        .collect::<Vec<u8>>();
+    let file_path = move |i| format!("{}/file{}.txt", path, i);
+
+    println!("Creating {} files in {}", num_files, path);
+    for i in 0 .. num_files {
+        let c = client.clone();
+        threadpool.execute(move || {
+            let path = file_path(i);
+            let arg = files::CommitInfo::new(path.clone())
+                .with_mode(files::WriteMode::Overwrite);
+            loop {
+                println!("{}: writing", path);
+                match files::upload(c.as_ref(), &arg, &file_bytes(i)) {
+                    Ok(Ok(_)) => (),
+                    Err(dropbox_sdk::Error::RateLimited { retry_after_seconds, .. }) => {
+                        println!("{}: rate limited; sleeping {} seconds",
+                            path, retry_after_seconds);
+                        thread::sleep(Duration::from_secs(retry_after_seconds as u64));
+                        continue;
+                    }
+                    e => panic!("{}: upload failed: {:?}", path, e),
+                }
+                println!("{}: done", path);
+                break;
+            }
+        });
+    }
+
+    threadpool.join();
+    (Box::new(file_path), Box::new(file_bytes))
+}
+
+pub fn create_clean_folder(client: &impl UserAuthClient, path: &str) {
+    println!("Deleting any existing {} folder", path);
+    match files::delete_v2(client, &files::DeleteArg::new(path.to_owned())) {
+        Ok(Ok(_)) | Ok(Err(files::DeleteError::PathLookup(files::LookupError::NotFound))) => (),
+        e => panic!("unexpected result when deleting {}: {:?}", path, e),
+    }
+
+    println!("Creating folder {}", path);
+    match files::create_folder_v2(
+        client, &files::CreateFolderArg::new(path.to_owned()).with_autorename(false))
+    {
+        Ok(Ok(_)) => (),
+        e => panic!("unexpected result when creating {}: {:?}", path, e),
+    }
+}

--- a/tests/list_folder_recursive.rs
+++ b/tests/list_folder_recursive.rs
@@ -1,0 +1,82 @@
+use dropbox_sdk::files;
+use dropbox_sdk::hyper_client::UserAuthHyperClient;
+use std::collections::HashSet;
+use std::sync::Arc;
+
+mod common;
+
+#[test]
+#[ignore] // very time-consuming to run; should be run separately
+fn list_folder_recursive() {
+    let token = std::env::var("DBX_OAUTH_TOKEN").expect("DBX_OAUTH_TOKEN must be set");
+    let client = Arc::new(UserAuthHyperClient::new(token));
+
+    const FOLDER: &str = "/list_folder_recursive";
+    const FOLDER_INNER: &str = "/list_folder_recursive/subfolder";
+    const NUM_FILES: u32 = 30;
+    const FILE_SIZE: usize = 100;
+
+    common::create_clean_folder(client.as_ref(), FOLDER);
+    common::create_clean_folder(client.as_ref(), FOLDER_INNER);
+
+    let (files_a, _) = common::create_files(client.clone(), FOLDER, NUM_FILES, FILE_SIZE);
+    let (files_b, _) = common::create_files(client.clone(), FOLDER_INNER, NUM_FILES, FILE_SIZE);
+
+    let mut files = HashSet::new();
+    for i in 0 .. NUM_FILES {
+        files.insert(files_a(i));
+        files.insert(files_b(i));
+    }
+
+    println!("Created a bunch of files. Now listing them.");
+
+    let mut process_entries = |entries| {
+        for metadata in entries {
+            match metadata {
+                files::Metadata::File(files::FileMetadata { path_lower, .. }) => {
+                    let path_lower = path_lower.expect("missing path_lower in response");
+                    assert!(files.remove(&path_lower), "got unexpected path {}", path_lower);
+                }
+                files::Metadata::Folder(files::FolderMetadata { path_lower, .. }) => {
+                    let path_lower = path_lower.expect("missing path_lower in response");
+                    assert!(matches!(path_lower.as_str(), FOLDER | FOLDER_INNER));
+                }
+                other => panic!("unexpected {:?}", other),
+            }
+        }
+    };
+
+    println!("list_folder");
+    let (mut cursor, mut has_more) = match files::list_folder(
+        client.as_ref(),
+        &files::ListFolderArg::new(FOLDER.to_owned())
+            .with_recursive(true)
+            .with_limit(Some(10)))
+    {
+        Ok(Ok(files::ListFolderResult { entries, cursor, has_more })) => {
+            println!("{} entries", entries.len());
+            process_entries(entries);
+            assert!(has_more, "expected has_more from list_folder");
+            (cursor, has_more)
+        }
+        e => panic!("unexpected result from list_folder: {:?}", e),
+    };
+
+    while has_more {
+        println!("list_folder_continue");
+        let next = match files::list_folder_continue(
+            client.as_ref(), &files::ListFolderContinueArg::new(cursor.clone()))
+        {
+            Ok(Ok(files::ListFolderResult { entries, cursor, has_more })) => {
+                println!("{} entries", entries.len());
+                process_entries(entries);
+                (cursor, has_more)
+            }
+            e => panic!("unexpected result from list_folder_continue: {:?}", e),
+        };
+        cursor = next.0;
+        has_more = next.1;
+    }
+
+    assert!(files.is_empty(), "leftover unfound files: {:?}", files);
+}


### PR DESCRIPTION
list_folder_recursive: creates folders, deletes folders, uploads files,
lists folders recursively, and uses list_folder_continue with a cursor

fetch_files: uploads 100 1MiB files, then times how quickly it can
download them.

Requires an environment variable DBX_OAUTH_TOKEN be set in order to
function.  Both tests are marked #[ignore] because they're time
consuming to run, require network connectivity, an auth token, and so
they should probably only be run manually.

To run them, run `cargo test -- --ignored --nocapture <test name>`

<!--
Thank you for your pull request. Please provide a description below.
-->

## **Checklist**

**General Contributing**
<!-- Change [ ] to [x] if you have: -->
- [x] Have you read the Code of Conduct and signed the [CLA](https://opensource.dropbox.com/cla/)?

**Validation**
<!-- Describe which tests cover the changes you've made, and any additional manual validation you
     did to ensure the correctness of this change. Does this change warrant addition of new tests?
     Does this change have performance implications? Etc. -->
These *are* the tests :)