### PR TITLE
improvements to builder methods on structs

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,3 +1,11 @@
+# v0.8.0
+xxxx-yy-zz
+* Improvements to builder methods on structs (the `fn with_fieldname(self, ...) -> Self` methods)
+  * Generate builder methods for structs which have only optional fields. These were erroneously
+    missing.
+  * Change builder methods for `Optional<T>` fields to take the inner type `T` as the argument
+    directly. Users will need to remove `Some( ... )` from the current argument for these methods.
+
 # v0.7.1
 2020-11-05
 * Documentation updates only.

--- a/examples/large-file-upload.rs
+++ b/examples/large-file-upload.rs
@@ -339,7 +339,7 @@ fn main() {
         let finish = files::UploadSessionFinishArg::new(
             append_arg.cursor,
             files::CommitInfo::new(dest_path)
-                .with_client_modified(Some(iso8601(source_mtime))));
+                .with_client_modified(iso8601(source_mtime)));
 
         let mut retry = 0;
         succeeded = false;

--- a/generator/rust.stoneg.py
+++ b/generator/rust.stoneg.py
@@ -102,11 +102,9 @@ class RustBackend(RustHelperBackend):
             self._impl_default_for_struct(struct)
             self.emit()
 
-        if struct.all_required_fields:
+        if struct.all_required_fields or struct.all_optional_fields:
             with self._impl_struct(struct):
-                if struct.all_required_fields:
-                    self._emit_new_for_struct(struct)
-                self.emit()
+                self._emit_new_for_struct(struct)
             self.emit()
 
         self._impl_serde_for_struct(struct)
@@ -806,23 +804,31 @@ class RustBackend(RustHelperBackend):
 
     def _emit_new_for_struct(self, struct):
         struct_name = self.struct_name(struct)
-        with self.emit_rust_function_def(
-                u'new',
-                [u'{}: {}'.format(self.field_name(field), self._rust_type(field.data_type))
-                    for field in struct.all_required_fields],
-                u'Self',
-                access=u'pub'):
-            with self.block(struct_name):
-                for field in struct.all_required_fields:
-                    # shorthand assignment
-                    self.emit(u'{},'.format(self.field_name(field)))
-                for field in struct.all_optional_fields:
-                    self.emit(u'{}: {},'.format(
-                        self.field_name(field),
-                        self._default_value(field)))
+        first = True
+
+        if struct.all_required_fields:
+            with self.emit_rust_function_def(
+                    u'new',
+                    [u'{}: {}'.format(self.field_name(field), self._rust_type(field.data_type))
+                        for field in struct.all_required_fields],
+                    u'Self',
+                    access=u'pub'):
+                with self.block(struct_name):
+                    for field in struct.all_required_fields:
+                        # shorthand assignment
+                        self.emit(u'{},'.format(self.field_name(field)))
+                    for field in struct.all_optional_fields:
+                        self.emit(u'{}: {},'.format(
+                            self.field_name(field),
+                            self._default_value(field)))
+            first = False
 
         for field in struct.all_optional_fields:
-            self.emit()
+            if first:
+                first = False
+            else:
+                self.emit()
+
             field_name = self.field_name(field)
             with self.emit_rust_function_def(
                     u'with_{}'.format(field_name),

--- a/src/generated/account.rs
+++ b/src/generated/account.rs
@@ -95,7 +95,6 @@ impl SetProfilePhotoArg {
             photo,
         }
     }
-
 }
 
 const SET_PROFILE_PHOTO_ARG_FIELDS: &[&str] = &["photo"];
@@ -307,7 +306,6 @@ impl SetProfilePhotoResult {
             profile_photo_url,
         }
     }
-
 }
 
 const SET_PROFILE_PHOTO_RESULT_FIELDS: &[&str] = &["profile_photo_url"];

--- a/src/generated/auth.rs
+++ b/src/generated/auth.rs
@@ -460,7 +460,6 @@ impl RateLimitError {
         self.retry_after = value;
         self
     }
-
 }
 
 const RATE_LIMIT_ERROR_FIELDS: &[&str] = &["reason",
@@ -634,7 +633,6 @@ impl TokenFromOAuth1Arg {
             oauth1_token_secret,
         }
     }
-
 }
 
 const TOKEN_FROM_O_AUTH1_ARG_FIELDS: &[&str] = &["oauth1_token",
@@ -817,7 +815,6 @@ impl TokenFromOAuth1Result {
             oauth2_token,
         }
     }
-
 }
 
 const TOKEN_FROM_O_AUTH1_RESULT_FIELDS: &[&str] = &["oauth2_token"];
@@ -907,7 +904,6 @@ impl TokenScopeError {
             required_scope,
         }
     }
-
 }
 
 const TOKEN_SCOPE_ERROR_FIELDS: &[&str] = &["required_scope"];

--- a/src/generated/check.rs
+++ b/src/generated/check.rs
@@ -57,6 +57,13 @@ impl Default for EchoArg {
     }
 }
 
+impl EchoArg {
+    pub fn with_query(mut self, value: String) -> Self {
+        self.query = value;
+        self
+    }
+}
+
 const ECHO_ARG_FIELDS: &[&str] = &["query"];
 impl EchoArg {
     // no _opt deserializer
@@ -133,6 +140,13 @@ impl Default for EchoResult {
         EchoResult {
             result: String::new(),
         }
+    }
+}
+
+impl EchoResult {
+    pub fn with_result(mut self, value: String) -> Self {
+        self.result = value;
+        self
     }
 }
 

--- a/src/generated/common.rs
+++ b/src/generated/common.rs
@@ -293,7 +293,6 @@ impl TeamRootInfo {
             home_path,
         }
     }
-
 }
 
 const TEAM_ROOT_INFO_FIELDS: &[&str] = &["root_namespace_id",
@@ -410,7 +409,6 @@ impl UserRootInfo {
             home_namespace_id,
         }
     }
-
 }
 
 const USER_ROOT_INFO_FIELDS: &[&str] = &["root_namespace_id",

--- a/src/generated/contacts.rs
+++ b/src/generated/contacts.rs
@@ -47,7 +47,6 @@ impl DeleteManualContactsArg {
             email_addresses,
         }
     }
-
 }
 
 const DELETE_MANUAL_CONTACTS_ARG_FIELDS: &[&str] = &["email_addresses"];

--- a/src/generated/dbx_async.rs
+++ b/src/generated/dbx_async.rs
@@ -152,7 +152,6 @@ impl PollArg {
             async_job_id,
         }
     }
-
 }
 
 const POLL_ARG_FIELDS: &[&str] = &["async_job_id"];

--- a/src/generated/file_properties.rs
+++ b/src/generated/file_properties.rs
@@ -2513,8 +2513,8 @@ impl PropertiesSearchResult {
         }
     }
 
-    pub fn with_cursor(mut self, value: Option<PropertiesSearchCursor>) -> Self {
-        self.cursor = value;
+    pub fn with_cursor(mut self, value: PropertiesSearchCursor) -> Self {
+        self.cursor = Some(value);
         self
     }
 }
@@ -3071,13 +3071,13 @@ impl PropertyGroupUpdate {
         }
     }
 
-    pub fn with_add_or_update_fields(mut self, value: Option<Vec<PropertyField>>) -> Self {
-        self.add_or_update_fields = value;
+    pub fn with_add_or_update_fields(mut self, value: Vec<PropertyField>) -> Self {
+        self.add_or_update_fields = Some(value);
         self
     }
 
-    pub fn with_remove_fields(mut self, value: Option<Vec<String>>) -> Self {
-        self.remove_fields = value;
+    pub fn with_remove_fields(mut self, value: Vec<String>) -> Self {
+        self.remove_fields = Some(value);
         self
     }
 }
@@ -4157,18 +4157,18 @@ impl UpdateTemplateArg {
         }
     }
 
-    pub fn with_name(mut self, value: Option<String>) -> Self {
-        self.name = value;
+    pub fn with_name(mut self, value: String) -> Self {
+        self.name = Some(value);
         self
     }
 
-    pub fn with_description(mut self, value: Option<String>) -> Self {
-        self.description = value;
+    pub fn with_description(mut self, value: String) -> Self {
+        self.description = Some(value);
         self
     }
 
-    pub fn with_add_fields(mut self, value: Option<Vec<PropertyFieldTemplate>>) -> Self {
-        self.add_fields = value;
+    pub fn with_add_fields(mut self, value: Vec<PropertyFieldTemplate>) -> Self {
+        self.add_fields = Some(value);
         self
     }
 }

--- a/src/generated/file_properties.rs
+++ b/src/generated/file_properties.rs
@@ -311,7 +311,6 @@ impl AddPropertiesArg {
             property_groups,
         }
     }
-
 }
 
 const ADD_PROPERTIES_ARG_FIELDS: &[&str] = &["path",
@@ -586,7 +585,6 @@ impl AddTemplateArg {
             fields,
         }
     }
-
 }
 
 const ADD_TEMPLATE_ARG_FIELDS: &[&str] = &["name",
@@ -698,7 +696,6 @@ impl AddTemplateResult {
             template_id,
         }
     }
-
 }
 
 const ADD_TEMPLATE_RESULT_FIELDS: &[&str] = &["template_id"];
@@ -790,7 +787,6 @@ impl GetTemplateArg {
             template_id,
         }
     }
-
 }
 
 const GET_TEMPLATE_ARG_FIELDS: &[&str] = &["template_id"];
@@ -887,7 +883,6 @@ impl GetTemplateResult {
             fields,
         }
     }
-
 }
 
 const GET_TEMPLATE_RESULT_FIELDS: &[&str] = &["name",
@@ -1154,7 +1149,6 @@ impl ListTemplateResult {
             template_ids,
         }
     }
-
 }
 
 const LIST_TEMPLATE_RESULT_FIELDS: &[&str] = &["template_ids"];
@@ -1643,7 +1637,6 @@ impl OverwritePropertyGroupArg {
             property_groups,
         }
     }
-
 }
 
 const OVERWRITE_PROPERTY_GROUP_ARG_FIELDS: &[&str] = &["path",
@@ -1867,7 +1860,6 @@ impl PropertiesSearchArg {
         self.template_filter = value;
         self
     }
-
 }
 
 const PROPERTIES_SEARCH_ARG_FIELDS: &[&str] = &["queries",
@@ -1968,7 +1960,6 @@ impl PropertiesSearchContinueArg {
             cursor,
         }
     }
-
 }
 
 const PROPERTIES_SEARCH_CONTINUE_ARG_FIELDS: &[&str] = &["cursor"];
@@ -2216,7 +2207,6 @@ impl PropertiesSearchMatch {
             property_groups,
         }
     }
-
 }
 
 const PROPERTIES_SEARCH_MATCH_FIELDS: &[&str] = &["id",
@@ -2409,7 +2399,6 @@ impl PropertiesSearchQuery {
         self.logical_operator = value;
         self
     }
-
 }
 
 const PROPERTIES_SEARCH_QUERY_FIELDS: &[&str] = &["query",
@@ -2528,7 +2517,6 @@ impl PropertiesSearchResult {
         self.cursor = value;
         self
     }
-
 }
 
 const PROPERTIES_SEARCH_RESULT_FIELDS: &[&str] = &["matches",
@@ -2634,7 +2622,6 @@ impl PropertyField {
             value,
         }
     }
-
 }
 
 const PROPERTY_FIELD_FIELDS: &[&str] = &["name",
@@ -2743,7 +2730,6 @@ impl PropertyFieldTemplate {
             type_field,
         }
     }
-
 }
 
 const PROPERTY_FIELD_TEMPLATE_FIELDS: &[&str] = &["name",
@@ -2861,7 +2847,6 @@ impl PropertyGroup {
             fields,
         }
     }
-
 }
 
 const PROPERTY_GROUP_FIELDS: &[&str] = &["template_id",
@@ -2969,7 +2954,6 @@ impl PropertyGroupTemplate {
             fields,
         }
     }
-
 }
 
 const PROPERTY_GROUP_TEMPLATE_FIELDS: &[&str] = &["name",
@@ -3096,7 +3080,6 @@ impl PropertyGroupUpdate {
         self.remove_fields = value;
         self
     }
-
 }
 
 const PROPERTY_GROUP_UPDATE_FIELDS: &[&str] = &["template_id",
@@ -3270,7 +3253,6 @@ impl RemovePropertiesArg {
             property_template_ids,
         }
     }
-
 }
 
 const REMOVE_PROPERTIES_ARG_FIELDS: &[&str] = &["path",
@@ -3503,7 +3485,6 @@ impl RemoveTemplateArg {
             template_id,
         }
     }
-
 }
 
 const REMOVE_TEMPLATE_ARG_FIELDS: &[&str] = &["template_id"];
@@ -3893,7 +3874,6 @@ impl UpdatePropertiesArg {
             update_property_groups,
         }
     }
-
 }
 
 const UPDATE_PROPERTIES_ARG_FIELDS: &[&str] = &["path",
@@ -4191,7 +4171,6 @@ impl UpdateTemplateArg {
         self.add_fields = value;
         self
     }
-
 }
 
 const UPDATE_TEMPLATE_ARG_FIELDS: &[&str] = &["template_id",
@@ -4313,7 +4292,6 @@ impl UpdateTemplateResult {
             template_id,
         }
     }
-
 }
 
 const UPDATE_TEMPLATE_RESULT_FIELDS: &[&str] = &["template_id"];

--- a/src/generated/file_requests.rs
+++ b/src/generated/file_requests.rs
@@ -330,8 +330,8 @@ impl CreateFileRequestArgs {
         }
     }
 
-    pub fn with_deadline(mut self, value: Option<FileRequestDeadline>) -> Self {
-        self.deadline = value;
+    pub fn with_deadline(mut self, value: FileRequestDeadline) -> Self {
+        self.deadline = Some(value);
         self
     }
 
@@ -340,8 +340,8 @@ impl CreateFileRequestArgs {
         self
     }
 
-    pub fn with_description(mut self, value: Option<String>) -> Self {
-        self.description = value;
+    pub fn with_description(mut self, value: String) -> Self {
+        self.description = Some(value);
         self
     }
 }
@@ -1279,18 +1279,18 @@ impl FileRequest {
         }
     }
 
-    pub fn with_destination(mut self, value: Option<super::files::Path>) -> Self {
-        self.destination = value;
+    pub fn with_destination(mut self, value: super::files::Path) -> Self {
+        self.destination = Some(value);
         self
     }
 
-    pub fn with_deadline(mut self, value: Option<FileRequestDeadline>) -> Self {
-        self.deadline = value;
+    pub fn with_deadline(mut self, value: FileRequestDeadline) -> Self {
+        self.deadline = Some(value);
         self
     }
 
-    pub fn with_description(mut self, value: Option<String>) -> Self {
-        self.description = value;
+    pub fn with_description(mut self, value: String) -> Self {
+        self.description = Some(value);
         self
     }
 }
@@ -1467,8 +1467,8 @@ impl FileRequestDeadline {
         }
     }
 
-    pub fn with_allow_late_uploads(mut self, value: Option<GracePeriod>) -> Self {
-        self.allow_late_uploads = value;
+    pub fn with_allow_late_uploads(mut self, value: GracePeriod) -> Self {
+        self.allow_late_uploads = Some(value);
         self
     }
 }
@@ -2700,13 +2700,13 @@ impl UpdateFileRequestArgs {
         }
     }
 
-    pub fn with_title(mut self, value: Option<String>) -> Self {
-        self.title = value;
+    pub fn with_title(mut self, value: String) -> Self {
+        self.title = Some(value);
         self
     }
 
-    pub fn with_destination(mut self, value: Option<super::files::Path>) -> Self {
-        self.destination = value;
+    pub fn with_destination(mut self, value: super::files::Path) -> Self {
+        self.destination = Some(value);
         self
     }
 
@@ -2715,13 +2715,13 @@ impl UpdateFileRequestArgs {
         self
     }
 
-    pub fn with_open(mut self, value: Option<bool>) -> Self {
-        self.open = value;
+    pub fn with_open(mut self, value: bool) -> Self {
+        self.open = Some(value);
         self
     }
 
-    pub fn with_description(mut self, value: Option<String>) -> Self {
-        self.description = value;
+    pub fn with_description(mut self, value: String) -> Self {
+        self.description = Some(value);
         self
     }
 }

--- a/src/generated/file_requests.rs
+++ b/src/generated/file_requests.rs
@@ -224,7 +224,6 @@ impl CountFileRequestsResult {
             file_request_count,
         }
     }
-
 }
 
 const COUNT_FILE_REQUESTS_RESULT_FIELDS: &[&str] = &["file_request_count"];
@@ -345,7 +344,6 @@ impl CreateFileRequestArgs {
         self.description = value;
         self
     }
-
 }
 
 const CREATE_FILE_REQUEST_ARGS_FIELDS: &[&str] = &["title",
@@ -809,7 +807,6 @@ impl DeleteAllClosedFileRequestsResult {
             file_requests,
         }
     }
-
 }
 
 const DELETE_ALL_CLOSED_FILE_REQUESTS_RESULT_FIELDS: &[&str] = &["file_requests"];
@@ -900,7 +897,6 @@ impl DeleteFileRequestArgs {
             ids,
         }
     }
-
 }
 
 const DELETE_FILE_REQUEST_ARGS_FIELDS: &[&str] = &["ids"];
@@ -1157,7 +1153,6 @@ impl DeleteFileRequestsResult {
             file_requests,
         }
     }
-
 }
 
 const DELETE_FILE_REQUESTS_RESULT_FIELDS: &[&str] = &["file_requests"];
@@ -1298,7 +1293,6 @@ impl FileRequest {
         self.description = value;
         self
     }
-
 }
 
 const FILE_REQUEST_FIELDS: &[&str] = &["id",
@@ -1477,7 +1471,6 @@ impl FileRequestDeadline {
         self.allow_late_uploads = value;
         self
     }
-
 }
 
 const FILE_REQUEST_DEADLINE_FIELDS: &[&str] = &["deadline",
@@ -1802,7 +1795,6 @@ impl GetFileRequestArgs {
             id,
         }
     }
-
 }
 
 const GET_FILE_REQUEST_ARGS_FIELDS: &[&str] = &["id"];
@@ -2153,6 +2145,13 @@ impl Default for ListFileRequestsArg {
     }
 }
 
+impl ListFileRequestsArg {
+    pub fn with_limit(mut self, value: u64) -> Self {
+        self.limit = value;
+        self
+    }
+}
+
 const LIST_FILE_REQUESTS_ARG_FIELDS: &[&str] = &["limit"];
 impl ListFileRequestsArg {
     // no _opt deserializer
@@ -2229,7 +2228,6 @@ impl ListFileRequestsContinueArg {
             cursor,
         }
     }
-
 }
 
 const LIST_FILE_REQUESTS_CONTINUE_ARG_FIELDS: &[&str] = &["cursor"];
@@ -2476,7 +2474,6 @@ impl ListFileRequestsResult {
             file_requests,
         }
     }
-
 }
 
 const LIST_FILE_REQUESTS_RESULT_FIELDS: &[&str] = &["file_requests"];
@@ -2575,7 +2572,6 @@ impl ListFileRequestsV2Result {
             has_more,
         }
     }
-
 }
 
 const LIST_FILE_REQUESTS_V2_RESULT_FIELDS: &[&str] = &["file_requests",
@@ -2728,7 +2724,6 @@ impl UpdateFileRequestArgs {
         self.description = value;
         self
     }
-
 }
 
 const UPDATE_FILE_REQUEST_ARGS_FIELDS: &[&str] = &["id",

--- a/src/generated/files.rs
+++ b/src/generated/files.rs
@@ -1195,7 +1195,6 @@ impl AlphaGetMetadataArg {
         self.include_property_templates = value;
         self
     }
-
 }
 
 const ALPHA_GET_METADATA_ARG_FIELDS: &[&str] = &["path",
@@ -1477,7 +1476,6 @@ impl CommitInfo {
         self.strict_conflict = value;
         self
     }
-
 }
 
 const COMMIT_INFO_FIELDS: &[&str] = &["path",
@@ -1688,7 +1686,6 @@ impl CommitInfoWithProperties {
         self.strict_conflict = value;
         self
     }
-
 }
 
 const COMMIT_INFO_WITH_PROPERTIES_FIELDS: &[&str] = &["path",
@@ -1841,7 +1838,6 @@ impl ContentSyncSetting {
             sync_setting,
         }
     }
-
 }
 
 const CONTENT_SYNC_SETTING_FIELDS: &[&str] = &["id",
@@ -1944,7 +1940,6 @@ impl ContentSyncSettingArg {
             sync_setting,
         }
     }
-
 }
 
 const CONTENT_SYNC_SETTING_ARG_FIELDS: &[&str] = &["id",
@@ -2053,7 +2048,6 @@ impl CreateFolderArg {
         self.autorename = value;
         self
     }
-
 }
 
 const CREATE_FOLDER_ARG_FIELDS: &[&str] = &["path",
@@ -2171,7 +2165,6 @@ impl CreateFolderBatchArg {
         self.force_async = value;
         self
     }
-
 }
 
 const CREATE_FOLDER_BATCH_ARG_FIELDS: &[&str] = &["paths",
@@ -2513,7 +2506,6 @@ impl CreateFolderBatchResult {
             entries,
         }
     }
-
 }
 
 const CREATE_FOLDER_BATCH_RESULT_FIELDS: &[&str] = &["entries"];
@@ -2739,7 +2731,6 @@ impl CreateFolderEntryResult {
             metadata,
         }
     }
-
 }
 
 const CREATE_FOLDER_ENTRY_RESULT_FIELDS: &[&str] = &["metadata"];
@@ -2894,7 +2885,6 @@ impl CreateFolderResult {
             metadata,
         }
     }
-
 }
 
 const CREATE_FOLDER_RESULT_FIELDS: &[&str] = &["metadata"];
@@ -2993,7 +2983,6 @@ impl DeleteArg {
         self.parent_rev = value;
         self
     }
-
 }
 
 const DELETE_ARG_FIELDS: &[&str] = &["path",
@@ -3092,7 +3081,6 @@ impl DeleteBatchArg {
             entries,
         }
     }
-
 }
 
 const DELETE_BATCH_ARG_FIELDS: &[&str] = &["entries"];
@@ -3416,7 +3404,6 @@ impl DeleteBatchResult {
             entries,
         }
     }
-
 }
 
 const DELETE_BATCH_RESULT_FIELDS: &[&str] = &["entries"];
@@ -3506,7 +3493,6 @@ impl DeleteBatchResultData {
             metadata,
         }
     }
-
 }
 
 const DELETE_BATCH_RESULT_DATA_FIELDS: &[&str] = &["metadata"];
@@ -3774,7 +3760,6 @@ impl DeleteResult {
             metadata,
         }
     }
-
 }
 
 const DELETE_RESULT_FIELDS: &[&str] = &["metadata"];
@@ -3899,7 +3884,6 @@ impl DeletedMetadata {
         self.parent_shared_folder_id = value;
         self
     }
-
 }
 
 const DELETED_METADATA_FIELDS: &[&str] = &["name",
@@ -4023,7 +4007,6 @@ impl Dimensions {
             width,
         }
     }
-
 }
 
 const DIMENSIONS_FIELDS: &[&str] = &["height",
@@ -4131,7 +4114,6 @@ impl DownloadArg {
         self.rev = value;
         self
     }
-
 }
 
 const DOWNLOAD_ARG_FIELDS: &[&str] = &["path",
@@ -4317,7 +4299,6 @@ impl DownloadZipArg {
             path,
         }
     }
-
 }
 
 const DOWNLOAD_ZIP_ARG_FIELDS: &[&str] = &["path"];
@@ -4505,7 +4486,6 @@ impl DownloadZipResult {
             metadata,
         }
     }
-
 }
 
 const DOWNLOAD_ZIP_RESULT_FIELDS: &[&str] = &["metadata"];
@@ -4595,7 +4575,6 @@ impl ExportArg {
             path,
         }
     }
-
 }
 
 const EXPORT_ARG_FIELDS: &[&str] = &["path"];
@@ -4787,6 +4766,13 @@ impl Default for ExportInfo {
     }
 }
 
+impl ExportInfo {
+    pub fn with_export_as(mut self, value: Option<String>) -> Self {
+        self.export_as = value;
+        self
+    }
+}
+
 const EXPORT_INFO_FIELDS: &[&str] = &["export_as"];
 impl ExportInfo {
     // no _opt deserializer
@@ -4876,7 +4862,6 @@ impl ExportMetadata {
         self.export_hash = value;
         self
     }
-
 }
 
 const EXPORT_METADATA_FIELDS: &[&str] = &["name",
@@ -4989,7 +4974,6 @@ impl ExportResult {
             file_metadata,
         }
     }
-
 }
 
 const EXPORT_RESULT_FIELDS: &[&str] = &["export_metadata",
@@ -5264,7 +5248,6 @@ impl FileLock {
             content,
         }
     }
-
 }
 
 const FILE_LOCK_FIELDS: &[&str] = &["content"];
@@ -5431,6 +5414,31 @@ impl Default for FileLockMetadata {
             lockholder_account_id: None,
             created: None,
         }
+    }
+}
+
+impl FileLockMetadata {
+    pub fn with_is_lockholder(mut self, value: Option<bool>) -> Self {
+        self.is_lockholder = value;
+        self
+    }
+
+    pub fn with_lockholder_name(mut self, value: Option<String>) -> Self {
+        self.lockholder_name = value;
+        self
+    }
+
+    pub fn with_lockholder_account_id(
+        mut self,
+        value: Option<super::users_common::AccountId>,
+    ) -> Self {
+        self.lockholder_account_id = value;
+        self
+    }
+
+    pub fn with_created(mut self, value: Option<super::common::DropboxTimestamp>) -> Self {
+        self.created = value;
+        self
     }
 }
 
@@ -5686,7 +5694,6 @@ impl FileMetadata {
         self.file_lock_info = value;
         self
     }
-
 }
 
 const FILE_METADATA_FIELDS: &[&str] = &["name",
@@ -6008,7 +6015,6 @@ impl FileSharingInfo {
         self.modified_by = value;
         self
     }
-
 }
 
 const FILE_SHARING_INFO_FIELDS: &[&str] = &["read_only",
@@ -6253,7 +6259,6 @@ impl FolderMetadata {
         self.property_groups = value;
         self
     }
-
 }
 
 const FOLDER_METADATA_FIELDS: &[&str] = &["name",
@@ -6453,7 +6458,6 @@ impl FolderSharingInfo {
         self.no_access = value;
         self
     }
-
 }
 
 const FOLDER_SHARING_INFO_FIELDS: &[&str] = &["read_only",
@@ -6583,7 +6587,6 @@ impl GetCopyReferenceArg {
             path,
         }
     }
-
 }
 
 const GET_COPY_REFERENCE_ARG_FIELDS: &[&str] = &["path"];
@@ -6757,7 +6760,6 @@ impl GetCopyReferenceResult {
             expires,
         }
     }
-
 }
 
 const GET_COPY_REFERENCE_RESULT_FIELDS: &[&str] = &["metadata",
@@ -6905,7 +6907,6 @@ impl GetMetadataArg {
         self.include_property_groups = value;
         self
     }
-
 }
 
 const GET_METADATA_ARG_FIELDS: &[&str] = &["path",
@@ -7100,7 +7101,6 @@ impl GetTemporaryLinkArg {
             path,
         }
     }
-
 }
 
 const GET_TEMPORARY_LINK_ARG_FIELDS: &[&str] = &["path"];
@@ -7294,7 +7294,6 @@ impl GetTemporaryLinkResult {
             link,
         }
     }
-
 }
 
 const GET_TEMPORARY_LINK_RESULT_FIELDS: &[&str] = &["metadata",
@@ -7404,7 +7403,6 @@ impl GetTemporaryUploadLinkArg {
         self.duration = value;
         self
     }
-
 }
 
 const GET_TEMPORARY_UPLOAD_LINK_ARG_FIELDS: &[&str] = &["commit_info",
@@ -7504,7 +7502,6 @@ impl GetTemporaryUploadLinkResult {
             link,
         }
     }
-
 }
 
 const GET_TEMPORARY_UPLOAD_LINK_RESULT_FIELDS: &[&str] = &["link"];
@@ -7595,7 +7592,6 @@ impl GetThumbnailBatchArg {
             entries,
         }
     }
-
 }
 
 const GET_THUMBNAIL_BATCH_ARG_FIELDS: &[&str] = &["entries"];
@@ -7755,7 +7751,6 @@ impl GetThumbnailBatchResult {
             entries,
         }
     }
-
 }
 
 const GET_THUMBNAIL_BATCH_RESULT_FIELDS: &[&str] = &["entries"];
@@ -7847,7 +7842,6 @@ impl GetThumbnailBatchResultData {
             thumbnail,
         }
     }
-
 }
 
 const GET_THUMBNAIL_BATCH_RESULT_DATA_FIELDS: &[&str] = &["metadata",
@@ -8023,7 +8017,6 @@ impl GpsCoordinates {
             longitude,
         }
     }
-
 }
 
 const GPS_COORDINATES_FIELDS: &[&str] = &["latitude",
@@ -8126,7 +8119,6 @@ impl HighlightSpan {
             is_highlighted,
         }
     }
-
 }
 
 const HIGHLIGHT_SPAN_FIELDS: &[&str] = &["highlight_str",
@@ -8310,7 +8302,6 @@ impl ListFolderArg {
         self.include_non_downloadable_files = value;
         self
     }
-
 }
 
 const LIST_FOLDER_ARG_FIELDS: &[&str] = &["path",
@@ -8491,7 +8482,6 @@ impl ListFolderContinueArg {
             cursor,
         }
     }
-
 }
 
 const LIST_FOLDER_CONTINUE_ARG_FIELDS: &[&str] = &["cursor"];
@@ -8758,7 +8748,6 @@ impl ListFolderGetLatestCursorResult {
             cursor,
         }
     }
-
 }
 
 const LIST_FOLDER_GET_LATEST_CURSOR_RESULT_FIELDS: &[&str] = &["cursor"];
@@ -8860,7 +8849,6 @@ impl ListFolderLongpollArg {
         self.timeout = value;
         self
     }
-
 }
 
 const LIST_FOLDER_LONGPOLL_ARG_FIELDS: &[&str] = &["cursor",
@@ -9041,7 +9029,6 @@ impl ListFolderLongpollResult {
         self.backoff = value;
         self
     }
-
 }
 
 const LIST_FOLDER_LONGPOLL_RESULT_FIELDS: &[&str] = &["changes",
@@ -9149,7 +9136,6 @@ impl ListFolderResult {
             has_more,
         }
     }
-
 }
 
 const LIST_FOLDER_RESULT_FIELDS: &[&str] = &["entries",
@@ -9275,7 +9261,6 @@ impl ListRevisionsArg {
         self.limit = value;
         self
     }
-
 }
 
 const LIST_REVISIONS_ARG_FIELDS: &[&str] = &["path",
@@ -9542,7 +9527,6 @@ impl ListRevisionsResult {
         self.server_deleted = value;
         self
     }
-
 }
 
 const LIST_REVISIONS_RESULT_FIELDS: &[&str] = &["is_deleted",
@@ -9652,7 +9636,6 @@ impl LockConflictError {
             lock,
         }
     }
-
 }
 
 const LOCK_CONFLICT_ERROR_FIELDS: &[&str] = &["lock"];
@@ -9742,7 +9725,6 @@ impl LockFileArg {
             path,
         }
     }
-
 }
 
 const LOCK_FILE_ARG_FIELDS: &[&str] = &["path"];
@@ -9833,7 +9815,6 @@ impl LockFileBatchArg {
             entries,
         }
     }
-
 }
 
 const LOCK_FILE_BATCH_ARG_FIELDS: &[&str] = &["entries"];
@@ -9924,7 +9905,6 @@ impl LockFileBatchResult {
             entries,
         }
     }
-
 }
 
 const LOCK_FILE_BATCH_RESULT_FIELDS: &[&str] = &["entries"];
@@ -10181,7 +10161,6 @@ impl LockFileResult {
             lock,
         }
     }
-
 }
 
 const LOCK_FILE_RESULT_FIELDS: &[&str] = &["metadata",
@@ -10805,7 +10784,6 @@ impl MinimalFileLinkMetadata {
         self.path = value;
         self
     }
-
 }
 
 const MINIMAL_FILE_LINK_METADATA_FIELDS: &[&str] = &["url",
@@ -10943,7 +10921,6 @@ impl MoveBatchArg {
         self.allow_ownership_transfer = value;
         self
     }
-
 }
 
 const MOVE_BATCH_ARG_FIELDS: &[&str] = &["entries",
@@ -11203,6 +11180,23 @@ impl Default for PhotoMetadata {
     }
 }
 
+impl PhotoMetadata {
+    pub fn with_dimensions(mut self, value: Option<Dimensions>) -> Self {
+        self.dimensions = value;
+        self
+    }
+
+    pub fn with_location(mut self, value: Option<GpsCoordinates>) -> Self {
+        self.location = value;
+        self
+    }
+
+    pub fn with_time_taken(mut self, value: Option<super::common::DropboxTimestamp>) -> Self {
+        self.time_taken = value;
+        self
+    }
+}
+
 const PHOTO_METADATA_FIELDS: &[&str] = &["dimensions",
                                          "location",
                                          "time_taken"];
@@ -11307,7 +11301,6 @@ impl PreviewArg {
         self.rev = value;
         self
     }
-
 }
 
 const PREVIEW_ARG_FIELDS: &[&str] = &["path",
@@ -11519,6 +11512,18 @@ impl Default for PreviewResult {
     }
 }
 
+impl PreviewResult {
+    pub fn with_file_metadata(mut self, value: Option<FileMetadata>) -> Self {
+        self.file_metadata = value;
+        self
+    }
+
+    pub fn with_link_metadata(mut self, value: Option<MinimalFileLinkMetadata>) -> Self {
+        self.link_metadata = value;
+        self
+    }
+}
+
 const PREVIEW_RESULT_FIELDS: &[&str] = &["file_metadata",
                                          "link_metadata"];
 impl PreviewResult {
@@ -11634,7 +11639,6 @@ impl RelocationArg {
         self.allow_ownership_transfer = value;
         self
     }
-
 }
 
 const RELOCATION_ARG_FIELDS: &[&str] = &["from_path",
@@ -11790,7 +11794,6 @@ impl RelocationBatchArg {
         self.allow_ownership_transfer = value;
         self
     }
-
 }
 
 const RELOCATION_BATCH_ARG_FIELDS: &[&str] = &["entries",
@@ -11919,7 +11922,6 @@ impl RelocationBatchArgBase {
         self.autorename = value;
         self
     }
-
 }
 
 const RELOCATION_BATCH_ARG_BASE_FIELDS: &[&str] = &["entries",
@@ -12515,7 +12517,6 @@ impl RelocationBatchResult {
             entries,
         }
     }
-
 }
 
 const RELOCATION_BATCH_RESULT_FIELDS: &[&str] = &["entries"];
@@ -12605,7 +12606,6 @@ impl RelocationBatchResultData {
             metadata,
         }
     }
-
 }
 
 const RELOCATION_BATCH_RESULT_DATA_FIELDS: &[&str] = &["metadata"];
@@ -12904,7 +12904,6 @@ impl RelocationBatchV2Result {
             entries,
         }
     }
-
 }
 
 const RELOCATION_BATCH_V2_RESULT_FIELDS: &[&str] = &["entries"];
@@ -13239,7 +13238,6 @@ impl RelocationPath {
             to_path,
         }
     }
-
 }
 
 const RELOCATION_PATH_FIELDS: &[&str] = &["from_path",
@@ -13339,7 +13337,6 @@ impl RelocationResult {
             metadata,
         }
     }
-
 }
 
 const RELOCATION_RESULT_FIELDS: &[&str] = &["metadata"];
@@ -13432,7 +13429,6 @@ impl RestoreArg {
             rev,
         }
     }
-
 }
 
 const RESTORE_ARG_FIELDS: &[&str] = &["path",
@@ -13652,7 +13648,6 @@ impl SaveCopyReferenceArg {
             path,
         }
     }
-
 }
 
 const SAVE_COPY_REFERENCE_ARG_FIELDS: &[&str] = &["copy_reference",
@@ -13878,7 +13873,6 @@ impl SaveCopyReferenceResult {
             metadata,
         }
     }
-
 }
 
 const SAVE_COPY_REFERENCE_RESULT_FIELDS: &[&str] = &["metadata"];
@@ -13971,7 +13965,6 @@ impl SaveUrlArg {
             url,
         }
     }
-
 }
 
 const SAVE_URL_ARG_FIELDS: &[&str] = &["path",
@@ -14357,7 +14350,6 @@ impl SearchArg {
         self.mode = value;
         self
     }
-
 }
 
 const SEARCH_ARG_FIELDS: &[&str] = &["path",
@@ -14595,7 +14587,6 @@ impl SearchMatch {
             metadata,
         }
     }
-
 }
 
 const SEARCH_MATCH_FIELDS: &[&str] = &["match_type",
@@ -14694,6 +14685,13 @@ impl Default for SearchMatchFieldOptions {
         SearchMatchFieldOptions {
             include_highlights: false,
         }
+    }
+}
+
+impl SearchMatchFieldOptions {
+    pub fn with_include_highlights(mut self, value: bool) -> Self {
+        self.include_highlights = value;
+        self
     }
 }
 
@@ -14964,7 +14962,6 @@ impl SearchMatchV2 {
         self.highlight_spans = value;
         self
     }
-
 }
 
 const SEARCH_MATCH_V2_FIELDS: &[&str] = &["metadata",
@@ -15170,6 +15167,43 @@ impl Default for SearchOptions {
             file_extensions: None,
             file_categories: None,
         }
+    }
+}
+
+impl SearchOptions {
+    pub fn with_path(mut self, value: Option<PathROrId>) -> Self {
+        self.path = value;
+        self
+    }
+
+    pub fn with_max_results(mut self, value: u64) -> Self {
+        self.max_results = value;
+        self
+    }
+
+    pub fn with_order_by(mut self, value: Option<SearchOrderBy>) -> Self {
+        self.order_by = value;
+        self
+    }
+
+    pub fn with_file_status(mut self, value: FileStatus) -> Self {
+        self.file_status = value;
+        self
+    }
+
+    pub fn with_filename_only(mut self, value: bool) -> Self {
+        self.filename_only = value;
+        self
+    }
+
+    pub fn with_file_extensions(mut self, value: Option<Vec<String>>) -> Self {
+        self.file_extensions = value;
+        self
+    }
+
+    pub fn with_file_categories(mut self, value: Option<Vec<FileCategory>>) -> Self {
+        self.file_categories = value;
+        self
     }
 }
 
@@ -15386,7 +15420,6 @@ impl SearchResult {
             start,
         }
     }
-
 }
 
 const SEARCH_RESULT_FIELDS: &[&str] = &["matches",
@@ -15521,7 +15554,6 @@ impl SearchV2Arg {
         self.include_highlights = value;
         self
     }
-
 }
 
 const SEARCH_V2_ARG_FIELDS: &[&str] = &["query",
@@ -15642,7 +15674,6 @@ impl SearchV2ContinueArg {
             cursor,
         }
     }
-
 }
 
 const SEARCH_V2_CONTINUE_ARG_FIELDS: &[&str] = &["cursor"];
@@ -15745,7 +15776,6 @@ impl SearchV2Result {
         self.cursor = value;
         self
     }
-
 }
 
 const SEARCH_V2_RESULT_FIELDS: &[&str] = &["matches",
@@ -15863,7 +15893,6 @@ impl SharedLink {
         self.password = value;
         self
     }
-
 }
 
 const SHARED_LINK_FIELDS: &[&str] = &["url",
@@ -15983,7 +16012,6 @@ impl SharedLinkFileInfo {
         self.password = value;
         self
     }
-
 }
 
 const SHARED_LINK_FILE_INFO_FIELDS: &[&str] = &["url",
@@ -16094,7 +16122,6 @@ impl SharingInfo {
             read_only,
         }
     }
-
 }
 
 const SHARING_INFO_FIELDS: &[&str] = &["read_only"];
@@ -16198,7 +16225,6 @@ impl SingleUserLock {
         self.lock_holder_team_id = value;
         self
     }
-
 }
 
 const SINGLE_USER_LOCK_FIELDS: &[&str] = &["created",
@@ -16308,7 +16334,6 @@ impl SymlinkInfo {
             target,
         }
     }
-
 }
 
 const SYMLINK_INFO_FIELDS: &[&str] = &["target"];
@@ -16682,7 +16707,6 @@ impl ThumbnailArg {
         self.mode = value;
         self
     }
-
 }
 
 const THUMBNAIL_ARG_FIELDS: &[&str] = &["path",
@@ -17224,7 +17248,6 @@ impl ThumbnailV2Arg {
         self.mode = value;
         self
     }
-
 }
 
 const THUMBNAIL_V2_ARG_FIELDS: &[&str] = &["resource",
@@ -17483,7 +17506,6 @@ impl UnlockFileArg {
             path,
         }
     }
-
 }
 
 const UNLOCK_FILE_ARG_FIELDS: &[&str] = &["path"];
@@ -17574,7 +17596,6 @@ impl UnlockFileBatchArg {
             entries,
         }
     }
-
 }
 
 const UNLOCK_FILE_BATCH_ARG_FIELDS: &[&str] = &["entries"];
@@ -17831,7 +17852,6 @@ impl UploadSessionAppendArg {
         self.close = value;
         self
     }
-
 }
 
 const UPLOAD_SESSION_APPEND_ARG_FIELDS: &[&str] = &["cursor",
@@ -17935,7 +17955,6 @@ impl UploadSessionCursor {
             offset,
         }
     }
-
 }
 
 const UPLOAD_SESSION_CURSOR_FIELDS: &[&str] = &["session_id",
@@ -18038,7 +18057,6 @@ impl UploadSessionFinishArg {
             commit,
         }
     }
-
 }
 
 const UPLOAD_SESSION_FINISH_ARG_FIELDS: &[&str] = &["cursor",
@@ -18138,7 +18156,6 @@ impl UploadSessionFinishBatchArg {
             entries,
         }
     }
-
 }
 
 const UPLOAD_SESSION_FINISH_BATCH_ARG_FIELDS: &[&str] = &["entries"];
@@ -18366,7 +18383,6 @@ impl UploadSessionFinishBatchResult {
             entries,
         }
     }
-
 }
 
 const UPLOAD_SESSION_FINISH_BATCH_RESULT_FIELDS: &[&str] = &["entries"];
@@ -18780,7 +18796,6 @@ impl UploadSessionOffsetError {
             correct_offset,
         }
     }
-
 }
 
 const UPLOAD_SESSION_OFFSET_ERROR_FIELDS: &[&str] = &["correct_offset"];
@@ -18873,6 +18888,13 @@ impl Default for UploadSessionStartArg {
     }
 }
 
+impl UploadSessionStartArg {
+    pub fn with_close(mut self, value: bool) -> Self {
+        self.close = value;
+        self
+    }
+}
+
 const UPLOAD_SESSION_START_ARG_FIELDS: &[&str] = &["close"];
 impl UploadSessionStartArg {
     // no _opt deserializer
@@ -18951,7 +18973,6 @@ impl UploadSessionStartResult {
             session_id,
         }
     }
-
 }
 
 const UPLOAD_SESSION_START_RESULT_FIELDS: &[&str] = &["session_id"];
@@ -19046,7 +19067,6 @@ impl UploadWriteFailed {
             upload_session_id,
         }
     }
-
 }
 
 const UPLOAD_WRITE_FAILED_FIELDS: &[&str] = &["reason",
@@ -19155,6 +19175,28 @@ impl Default for VideoMetadata {
             time_taken: None,
             duration: None,
         }
+    }
+}
+
+impl VideoMetadata {
+    pub fn with_dimensions(mut self, value: Option<Dimensions>) -> Self {
+        self.dimensions = value;
+        self
+    }
+
+    pub fn with_location(mut self, value: Option<GpsCoordinates>) -> Self {
+        self.location = value;
+        self
+    }
+
+    pub fn with_time_taken(mut self, value: Option<super::common::DropboxTimestamp>) -> Self {
+        self.time_taken = value;
+        self
+    }
+
+    pub fn with_duration(mut self, value: Option<u64>) -> Self {
+        self.duration = value;
+        self
     }
 }
 

--- a/src/generated/files.rs
+++ b/src/generated/files.rs
@@ -1182,17 +1182,17 @@ impl AlphaGetMetadataArg {
 
     pub fn with_include_property_groups(
         mut self,
-        value: Option<super::file_properties::TemplateFilterBase>,
+        value: super::file_properties::TemplateFilterBase,
     ) -> Self {
-        self.include_property_groups = value;
+        self.include_property_groups = Some(value);
         self
     }
 
     pub fn with_include_property_templates(
         mut self,
-        value: Option<Vec<super::file_properties::TemplateId>>,
+        value: Vec<super::file_properties::TemplateId>,
     ) -> Self {
-        self.include_property_templates = value;
+        self.include_property_templates = Some(value);
         self
     }
 }
@@ -1454,8 +1454,8 @@ impl CommitInfo {
         self
     }
 
-    pub fn with_client_modified(mut self, value: Option<super::common::DropboxTimestamp>) -> Self {
-        self.client_modified = value;
+    pub fn with_client_modified(mut self, value: super::common::DropboxTimestamp) -> Self {
+        self.client_modified = Some(value);
         self
     }
 
@@ -1466,9 +1466,9 @@ impl CommitInfo {
 
     pub fn with_property_groups(
         mut self,
-        value: Option<Vec<super::file_properties::PropertyGroup>>,
+        value: Vec<super::file_properties::PropertyGroup>,
     ) -> Self {
-        self.property_groups = value;
+        self.property_groups = Some(value);
         self
     }
 
@@ -1664,8 +1664,8 @@ impl CommitInfoWithProperties {
         self
     }
 
-    pub fn with_client_modified(mut self, value: Option<super::common::DropboxTimestamp>) -> Self {
-        self.client_modified = value;
+    pub fn with_client_modified(mut self, value: super::common::DropboxTimestamp) -> Self {
+        self.client_modified = Some(value);
         self
     }
 
@@ -1676,9 +1676,9 @@ impl CommitInfoWithProperties {
 
     pub fn with_property_groups(
         mut self,
-        value: Option<Vec<super::file_properties::PropertyGroup>>,
+        value: Vec<super::file_properties::PropertyGroup>,
     ) -> Self {
-        self.property_groups = value;
+        self.property_groups = Some(value);
         self
     }
 
@@ -2979,8 +2979,8 @@ impl DeleteArg {
         }
     }
 
-    pub fn with_parent_rev(mut self, value: Option<Rev>) -> Self {
-        self.parent_rev = value;
+    pub fn with_parent_rev(mut self, value: Rev) -> Self {
+        self.parent_rev = Some(value);
         self
     }
 }
@@ -3867,21 +3867,18 @@ impl DeletedMetadata {
         }
     }
 
-    pub fn with_path_lower(mut self, value: Option<String>) -> Self {
-        self.path_lower = value;
+    pub fn with_path_lower(mut self, value: String) -> Self {
+        self.path_lower = Some(value);
         self
     }
 
-    pub fn with_path_display(mut self, value: Option<String>) -> Self {
-        self.path_display = value;
+    pub fn with_path_display(mut self, value: String) -> Self {
+        self.path_display = Some(value);
         self
     }
 
-    pub fn with_parent_shared_folder_id(
-        mut self,
-        value: Option<super::common::SharedFolderId>,
-    ) -> Self {
-        self.parent_shared_folder_id = value;
+    pub fn with_parent_shared_folder_id(mut self, value: super::common::SharedFolderId) -> Self {
+        self.parent_shared_folder_id = Some(value);
         self
     }
 }
@@ -4110,8 +4107,8 @@ impl DownloadArg {
         }
     }
 
-    pub fn with_rev(mut self, value: Option<Rev>) -> Self {
-        self.rev = value;
+    pub fn with_rev(mut self, value: Rev) -> Self {
+        self.rev = Some(value);
         self
     }
 }
@@ -4767,8 +4764,8 @@ impl Default for ExportInfo {
 }
 
 impl ExportInfo {
-    pub fn with_export_as(mut self, value: Option<String>) -> Self {
-        self.export_as = value;
+    pub fn with_export_as(mut self, value: String) -> Self {
+        self.export_as = Some(value);
         self
     }
 }
@@ -4858,8 +4855,8 @@ impl ExportMetadata {
         }
     }
 
-    pub fn with_export_hash(mut self, value: Option<Sha256HexHash>) -> Self {
-        self.export_hash = value;
+    pub fn with_export_hash(mut self, value: Sha256HexHash) -> Self {
+        self.export_hash = Some(value);
         self
     }
 }
@@ -5418,26 +5415,23 @@ impl Default for FileLockMetadata {
 }
 
 impl FileLockMetadata {
-    pub fn with_is_lockholder(mut self, value: Option<bool>) -> Self {
-        self.is_lockholder = value;
+    pub fn with_is_lockholder(mut self, value: bool) -> Self {
+        self.is_lockholder = Some(value);
         self
     }
 
-    pub fn with_lockholder_name(mut self, value: Option<String>) -> Self {
-        self.lockholder_name = value;
+    pub fn with_lockholder_name(mut self, value: String) -> Self {
+        self.lockholder_name = Some(value);
         self
     }
 
-    pub fn with_lockholder_account_id(
-        mut self,
-        value: Option<super::users_common::AccountId>,
-    ) -> Self {
-        self.lockholder_account_id = value;
+    pub fn with_lockholder_account_id(mut self, value: super::users_common::AccountId) -> Self {
+        self.lockholder_account_id = Some(value);
         self
     }
 
-    pub fn with_created(mut self, value: Option<super::common::DropboxTimestamp>) -> Self {
-        self.created = value;
+    pub fn with_created(mut self, value: super::common::DropboxTimestamp) -> Self {
+        self.created = Some(value);
         self
     }
 }
@@ -5629,36 +5623,33 @@ impl FileMetadata {
         }
     }
 
-    pub fn with_path_lower(mut self, value: Option<String>) -> Self {
-        self.path_lower = value;
+    pub fn with_path_lower(mut self, value: String) -> Self {
+        self.path_lower = Some(value);
         self
     }
 
-    pub fn with_path_display(mut self, value: Option<String>) -> Self {
-        self.path_display = value;
+    pub fn with_path_display(mut self, value: String) -> Self {
+        self.path_display = Some(value);
         self
     }
 
-    pub fn with_parent_shared_folder_id(
-        mut self,
-        value: Option<super::common::SharedFolderId>,
-    ) -> Self {
-        self.parent_shared_folder_id = value;
+    pub fn with_parent_shared_folder_id(mut self, value: super::common::SharedFolderId) -> Self {
+        self.parent_shared_folder_id = Some(value);
         self
     }
 
-    pub fn with_media_info(mut self, value: Option<MediaInfo>) -> Self {
-        self.media_info = value;
+    pub fn with_media_info(mut self, value: MediaInfo) -> Self {
+        self.media_info = Some(value);
         self
     }
 
-    pub fn with_symlink_info(mut self, value: Option<SymlinkInfo>) -> Self {
-        self.symlink_info = value;
+    pub fn with_symlink_info(mut self, value: SymlinkInfo) -> Self {
+        self.symlink_info = Some(value);
         self
     }
 
-    pub fn with_sharing_info(mut self, value: Option<FileSharingInfo>) -> Self {
-        self.sharing_info = value;
+    pub fn with_sharing_info(mut self, value: FileSharingInfo) -> Self {
+        self.sharing_info = Some(value);
         self
     }
 
@@ -5667,31 +5658,31 @@ impl FileMetadata {
         self
     }
 
-    pub fn with_export_info(mut self, value: Option<ExportInfo>) -> Self {
-        self.export_info = value;
+    pub fn with_export_info(mut self, value: ExportInfo) -> Self {
+        self.export_info = Some(value);
         self
     }
 
     pub fn with_property_groups(
         mut self,
-        value: Option<Vec<super::file_properties::PropertyGroup>>,
+        value: Vec<super::file_properties::PropertyGroup>,
     ) -> Self {
-        self.property_groups = value;
+        self.property_groups = Some(value);
         self
     }
 
-    pub fn with_has_explicit_shared_members(mut self, value: Option<bool>) -> Self {
-        self.has_explicit_shared_members = value;
+    pub fn with_has_explicit_shared_members(mut self, value: bool) -> Self {
+        self.has_explicit_shared_members = Some(value);
         self
     }
 
-    pub fn with_content_hash(mut self, value: Option<Sha256HexHash>) -> Self {
-        self.content_hash = value;
+    pub fn with_content_hash(mut self, value: Sha256HexHash) -> Self {
+        self.content_hash = Some(value);
         self
     }
 
-    pub fn with_file_lock_info(mut self, value: Option<FileLockMetadata>) -> Self {
-        self.file_lock_info = value;
+    pub fn with_file_lock_info(mut self, value: FileLockMetadata) -> Self {
+        self.file_lock_info = Some(value);
         self
     }
 }
@@ -6011,8 +6002,8 @@ impl FileSharingInfo {
         }
     }
 
-    pub fn with_modified_by(mut self, value: Option<super::users_common::AccountId>) -> Self {
-        self.modified_by = value;
+    pub fn with_modified_by(mut self, value: super::users_common::AccountId) -> Self {
+        self.modified_by = Some(value);
         self
     }
 }
@@ -6224,39 +6215,36 @@ impl FolderMetadata {
         }
     }
 
-    pub fn with_path_lower(mut self, value: Option<String>) -> Self {
-        self.path_lower = value;
+    pub fn with_path_lower(mut self, value: String) -> Self {
+        self.path_lower = Some(value);
         self
     }
 
-    pub fn with_path_display(mut self, value: Option<String>) -> Self {
-        self.path_display = value;
+    pub fn with_path_display(mut self, value: String) -> Self {
+        self.path_display = Some(value);
         self
     }
 
-    pub fn with_parent_shared_folder_id(
-        mut self,
-        value: Option<super::common::SharedFolderId>,
-    ) -> Self {
-        self.parent_shared_folder_id = value;
+    pub fn with_parent_shared_folder_id(mut self, value: super::common::SharedFolderId) -> Self {
+        self.parent_shared_folder_id = Some(value);
         self
     }
 
-    pub fn with_shared_folder_id(mut self, value: Option<super::common::SharedFolderId>) -> Self {
-        self.shared_folder_id = value;
+    pub fn with_shared_folder_id(mut self, value: super::common::SharedFolderId) -> Self {
+        self.shared_folder_id = Some(value);
         self
     }
 
-    pub fn with_sharing_info(mut self, value: Option<FolderSharingInfo>) -> Self {
-        self.sharing_info = value;
+    pub fn with_sharing_info(mut self, value: FolderSharingInfo) -> Self {
+        self.sharing_info = Some(value);
         self
     }
 
     pub fn with_property_groups(
         mut self,
-        value: Option<Vec<super::file_properties::PropertyGroup>>,
+        value: Vec<super::file_properties::PropertyGroup>,
     ) -> Self {
-        self.property_groups = value;
+        self.property_groups = Some(value);
         self
     }
 }
@@ -6436,16 +6424,13 @@ impl FolderSharingInfo {
         }
     }
 
-    pub fn with_parent_shared_folder_id(
-        mut self,
-        value: Option<super::common::SharedFolderId>,
-    ) -> Self {
-        self.parent_shared_folder_id = value;
+    pub fn with_parent_shared_folder_id(mut self, value: super::common::SharedFolderId) -> Self {
+        self.parent_shared_folder_id = Some(value);
         self
     }
 
-    pub fn with_shared_folder_id(mut self, value: Option<super::common::SharedFolderId>) -> Self {
-        self.shared_folder_id = value;
+    pub fn with_shared_folder_id(mut self, value: super::common::SharedFolderId) -> Self {
+        self.shared_folder_id = Some(value);
         self
     }
 
@@ -6902,9 +6887,9 @@ impl GetMetadataArg {
 
     pub fn with_include_property_groups(
         mut self,
-        value: Option<super::file_properties::TemplateFilterBase>,
+        value: super::file_properties::TemplateFilterBase,
     ) -> Self {
-        self.include_property_groups = value;
+        self.include_property_groups = Some(value);
         self
     }
 }
@@ -8280,21 +8265,21 @@ impl ListFolderArg {
         self
     }
 
-    pub fn with_limit(mut self, value: Option<u32>) -> Self {
-        self.limit = value;
+    pub fn with_limit(mut self, value: u32) -> Self {
+        self.limit = Some(value);
         self
     }
 
-    pub fn with_shared_link(mut self, value: Option<SharedLink>) -> Self {
-        self.shared_link = value;
+    pub fn with_shared_link(mut self, value: SharedLink) -> Self {
+        self.shared_link = Some(value);
         self
     }
 
     pub fn with_include_property_groups(
         mut self,
-        value: Option<super::file_properties::TemplateFilterBase>,
+        value: super::file_properties::TemplateFilterBase,
     ) -> Self {
-        self.include_property_groups = value;
+        self.include_property_groups = Some(value);
         self
     }
 
@@ -9025,8 +9010,8 @@ impl ListFolderLongpollResult {
         }
     }
 
-    pub fn with_backoff(mut self, value: Option<u64>) -> Self {
-        self.backoff = value;
+    pub fn with_backoff(mut self, value: u64) -> Self {
+        self.backoff = Some(value);
         self
     }
 }
@@ -9523,8 +9508,8 @@ impl ListRevisionsResult {
         }
     }
 
-    pub fn with_server_deleted(mut self, value: Option<super::common::DropboxTimestamp>) -> Self {
-        self.server_deleted = value;
+    pub fn with_server_deleted(mut self, value: super::common::DropboxTimestamp) -> Self {
+        self.server_deleted = Some(value);
         self
     }
 }
@@ -10775,13 +10760,13 @@ impl MinimalFileLinkMetadata {
         }
     }
 
-    pub fn with_id(mut self, value: Option<Id>) -> Self {
-        self.id = value;
+    pub fn with_id(mut self, value: Id) -> Self {
+        self.id = Some(value);
         self
     }
 
-    pub fn with_path(mut self, value: Option<String>) -> Self {
-        self.path = value;
+    pub fn with_path(mut self, value: String) -> Self {
+        self.path = Some(value);
         self
     }
 }
@@ -11181,18 +11166,18 @@ impl Default for PhotoMetadata {
 }
 
 impl PhotoMetadata {
-    pub fn with_dimensions(mut self, value: Option<Dimensions>) -> Self {
-        self.dimensions = value;
+    pub fn with_dimensions(mut self, value: Dimensions) -> Self {
+        self.dimensions = Some(value);
         self
     }
 
-    pub fn with_location(mut self, value: Option<GpsCoordinates>) -> Self {
-        self.location = value;
+    pub fn with_location(mut self, value: GpsCoordinates) -> Self {
+        self.location = Some(value);
         self
     }
 
-    pub fn with_time_taken(mut self, value: Option<super::common::DropboxTimestamp>) -> Self {
-        self.time_taken = value;
+    pub fn with_time_taken(mut self, value: super::common::DropboxTimestamp) -> Self {
+        self.time_taken = Some(value);
         self
     }
 }
@@ -11297,8 +11282,8 @@ impl PreviewArg {
         }
     }
 
-    pub fn with_rev(mut self, value: Option<Rev>) -> Self {
-        self.rev = value;
+    pub fn with_rev(mut self, value: Rev) -> Self {
+        self.rev = Some(value);
         self
     }
 }
@@ -11513,13 +11498,13 @@ impl Default for PreviewResult {
 }
 
 impl PreviewResult {
-    pub fn with_file_metadata(mut self, value: Option<FileMetadata>) -> Self {
-        self.file_metadata = value;
+    pub fn with_file_metadata(mut self, value: FileMetadata) -> Self {
+        self.file_metadata = Some(value);
         self
     }
 
-    pub fn with_link_metadata(mut self, value: Option<MinimalFileLinkMetadata>) -> Self {
-        self.link_metadata = value;
+    pub fn with_link_metadata(mut self, value: MinimalFileLinkMetadata) -> Self {
+        self.link_metadata = Some(value);
         self
     }
 }
@@ -14953,13 +14938,13 @@ impl SearchMatchV2 {
         }
     }
 
-    pub fn with_match_type(mut self, value: Option<SearchMatchTypeV2>) -> Self {
-        self.match_type = value;
+    pub fn with_match_type(mut self, value: SearchMatchTypeV2) -> Self {
+        self.match_type = Some(value);
         self
     }
 
-    pub fn with_highlight_spans(mut self, value: Option<Vec<HighlightSpan>>) -> Self {
-        self.highlight_spans = value;
+    pub fn with_highlight_spans(mut self, value: Vec<HighlightSpan>) -> Self {
+        self.highlight_spans = Some(value);
         self
     }
 }
@@ -15171,8 +15156,8 @@ impl Default for SearchOptions {
 }
 
 impl SearchOptions {
-    pub fn with_path(mut self, value: Option<PathROrId>) -> Self {
-        self.path = value;
+    pub fn with_path(mut self, value: PathROrId) -> Self {
+        self.path = Some(value);
         self
     }
 
@@ -15181,8 +15166,8 @@ impl SearchOptions {
         self
     }
 
-    pub fn with_order_by(mut self, value: Option<SearchOrderBy>) -> Self {
-        self.order_by = value;
+    pub fn with_order_by(mut self, value: SearchOrderBy) -> Self {
+        self.order_by = Some(value);
         self
     }
 
@@ -15196,13 +15181,13 @@ impl SearchOptions {
         self
     }
 
-    pub fn with_file_extensions(mut self, value: Option<Vec<String>>) -> Self {
-        self.file_extensions = value;
+    pub fn with_file_extensions(mut self, value: Vec<String>) -> Self {
+        self.file_extensions = Some(value);
         self
     }
 
-    pub fn with_file_categories(mut self, value: Option<Vec<FileCategory>>) -> Self {
-        self.file_categories = value;
+    pub fn with_file_categories(mut self, value: Vec<FileCategory>) -> Self {
+        self.file_categories = Some(value);
         self
     }
 }
@@ -15540,18 +15525,18 @@ impl SearchV2Arg {
         }
     }
 
-    pub fn with_options(mut self, value: Option<SearchOptions>) -> Self {
-        self.options = value;
+    pub fn with_options(mut self, value: SearchOptions) -> Self {
+        self.options = Some(value);
         self
     }
 
-    pub fn with_match_field_options(mut self, value: Option<SearchMatchFieldOptions>) -> Self {
-        self.match_field_options = value;
+    pub fn with_match_field_options(mut self, value: SearchMatchFieldOptions) -> Self {
+        self.match_field_options = Some(value);
         self
     }
 
-    pub fn with_include_highlights(mut self, value: Option<bool>) -> Self {
-        self.include_highlights = value;
+    pub fn with_include_highlights(mut self, value: bool) -> Self {
+        self.include_highlights = Some(value);
         self
     }
 }
@@ -15772,8 +15757,8 @@ impl SearchV2Result {
         }
     }
 
-    pub fn with_cursor(mut self, value: Option<SearchV2Cursor>) -> Self {
-        self.cursor = value;
+    pub fn with_cursor(mut self, value: SearchV2Cursor) -> Self {
+        self.cursor = Some(value);
         self
     }
 }
@@ -15889,8 +15874,8 @@ impl SharedLink {
         }
     }
 
-    pub fn with_password(mut self, value: Option<String>) -> Self {
-        self.password = value;
+    pub fn with_password(mut self, value: String) -> Self {
+        self.password = Some(value);
         self
     }
 }
@@ -16003,13 +15988,13 @@ impl SharedLinkFileInfo {
         }
     }
 
-    pub fn with_path(mut self, value: Option<String>) -> Self {
-        self.path = value;
+    pub fn with_path(mut self, value: String) -> Self {
+        self.path = Some(value);
         self
     }
 
-    pub fn with_password(mut self, value: Option<String>) -> Self {
-        self.password = value;
+    pub fn with_password(mut self, value: String) -> Self {
+        self.password = Some(value);
         self
     }
 }
@@ -16221,8 +16206,8 @@ impl SingleUserLock {
         }
     }
 
-    pub fn with_lock_holder_team_id(mut self, value: Option<String>) -> Self {
-        self.lock_holder_team_id = value;
+    pub fn with_lock_holder_team_id(mut self, value: String) -> Self {
+        self.lock_holder_team_id = Some(value);
         self
     }
 }
@@ -19179,23 +19164,23 @@ impl Default for VideoMetadata {
 }
 
 impl VideoMetadata {
-    pub fn with_dimensions(mut self, value: Option<Dimensions>) -> Self {
-        self.dimensions = value;
+    pub fn with_dimensions(mut self, value: Dimensions) -> Self {
+        self.dimensions = Some(value);
         self
     }
 
-    pub fn with_location(mut self, value: Option<GpsCoordinates>) -> Self {
-        self.location = value;
+    pub fn with_location(mut self, value: GpsCoordinates) -> Self {
+        self.location = Some(value);
         self
     }
 
-    pub fn with_time_taken(mut self, value: Option<super::common::DropboxTimestamp>) -> Self {
-        self.time_taken = value;
+    pub fn with_time_taken(mut self, value: super::common::DropboxTimestamp) -> Self {
+        self.time_taken = Some(value);
         self
     }
 
-    pub fn with_duration(mut self, value: Option<u64>) -> Self {
-        self.duration = value;
+    pub fn with_duration(mut self, value: u64) -> Self {
+        self.duration = Some(value);
         self
     }
 }

--- a/src/generated/paper.rs
+++ b/src/generated/paper.rs
@@ -500,8 +500,8 @@ impl AddPaperDocUser {
         }
     }
 
-    pub fn with_custom_message(mut self, value: Option<String>) -> Self {
-        self.custom_message = value;
+    pub fn with_custom_message(mut self, value: String) -> Self {
+        self.custom_message = Some(value);
         self
     }
 
@@ -880,8 +880,8 @@ impl Cursor {
         }
     }
 
-    pub fn with_expiration(mut self, value: Option<super::common::DropboxTimestamp>) -> Self {
-        self.expiration = value;
+    pub fn with_expiration(mut self, value: super::common::DropboxTimestamp) -> Self {
+        self.expiration = Some(value);
         self
     }
 }
@@ -1496,16 +1496,13 @@ impl Default for FoldersContainingPaperDoc {
 }
 
 impl FoldersContainingPaperDoc {
-    pub fn with_folder_sharing_policy_type(
-        mut self,
-        value: Option<FolderSharingPolicyType>,
-    ) -> Self {
-        self.folder_sharing_policy_type = value;
+    pub fn with_folder_sharing_policy_type(mut self, value: FolderSharingPolicyType) -> Self {
+        self.folder_sharing_policy_type = Some(value);
         self
     }
 
-    pub fn with_folders(mut self, value: Option<Vec<Folder>>) -> Self {
-        self.folders = value;
+    pub fn with_folders(mut self, value: Vec<Folder>) -> Self {
+        self.folders = Some(value);
         self
     }
 }
@@ -3461,8 +3458,8 @@ impl PaperDocCreateArgs {
         }
     }
 
-    pub fn with_parent_folder_id(mut self, value: Option<String>) -> Self {
-        self.parent_folder_id = value;
+    pub fn with_parent_folder_id(mut self, value: String) -> Self {
+        self.parent_folder_id = Some(value);
         self
     }
 }
@@ -4603,13 +4600,13 @@ impl PaperFolderCreateArg {
         }
     }
 
-    pub fn with_parent_folder_id(mut self, value: Option<String>) -> Self {
-        self.parent_folder_id = value;
+    pub fn with_parent_folder_id(mut self, value: String) -> Self {
+        self.parent_folder_id = Some(value);
         self
     }
 
-    pub fn with_is_team_folder(mut self, value: Option<bool>) -> Self {
-        self.is_team_folder = value;
+    pub fn with_is_team_folder(mut self, value: bool) -> Self {
+        self.is_team_folder = Some(value);
         self
     }
 }
@@ -5108,13 +5105,13 @@ impl Default for SharingPolicy {
 }
 
 impl SharingPolicy {
-    pub fn with_public_sharing_policy(mut self, value: Option<SharingPublicPolicyType>) -> Self {
-        self.public_sharing_policy = value;
+    pub fn with_public_sharing_policy(mut self, value: SharingPublicPolicyType) -> Self {
+        self.public_sharing_policy = Some(value);
         self
     }
 
-    pub fn with_team_sharing_policy(mut self, value: Option<SharingTeamPolicyType>) -> Self {
-        self.team_sharing_policy = value;
+    pub fn with_team_sharing_policy(mut self, value: SharingTeamPolicyType) -> Self {
+        self.team_sharing_policy = Some(value);
         self
     }
 }

--- a/src/generated/paper.rs
+++ b/src/generated/paper.rs
@@ -390,7 +390,6 @@ impl AddMember {
         self.permission_level = value;
         self
     }
-
 }
 
 const ADD_MEMBER_FIELDS: &[&str] = &["member",
@@ -510,7 +509,6 @@ impl AddPaperDocUser {
         self.quiet = value;
         self
     }
-
 }
 
 const ADD_PAPER_DOC_USER_FIELDS: &[&str] = &["doc_id",
@@ -634,7 +632,6 @@ impl AddPaperDocUserMemberResult {
             result,
         }
     }
-
 }
 
 const ADD_PAPER_DOC_USER_MEMBER_RESULT_FIELDS: &[&str] = &["member",
@@ -887,7 +884,6 @@ impl Cursor {
         self.expiration = value;
         self
     }
-
 }
 
 const CURSOR_FIELDS: &[&str] = &["value",
@@ -1239,7 +1235,6 @@ impl Folder {
             name,
         }
     }
-
 }
 
 const FOLDER_FIELDS: &[&str] = &["id",
@@ -1500,6 +1495,21 @@ impl Default for FoldersContainingPaperDoc {
     }
 }
 
+impl FoldersContainingPaperDoc {
+    pub fn with_folder_sharing_policy_type(
+        mut self,
+        value: Option<FolderSharingPolicyType>,
+    ) -> Self {
+        self.folder_sharing_policy_type = value;
+        self
+    }
+
+    pub fn with_folders(mut self, value: Option<Vec<Folder>>) -> Self {
+        self.folders = value;
+        self
+    }
+}
+
 const FOLDERS_CONTAINING_PAPER_DOC_FIELDS: &[&str] = &["folder_sharing_policy_type",
                                                        "folders"];
 impl FoldersContainingPaperDoc {
@@ -1679,7 +1689,6 @@ impl InviteeInfoWithPermissionLevel {
             permission_level,
         }
     }
-
 }
 
 const INVITEE_INFO_WITH_PERMISSION_LEVEL_FIELDS: &[&str] = &["invitee",
@@ -1864,6 +1873,28 @@ impl Default for ListPaperDocsArgs {
     }
 }
 
+impl ListPaperDocsArgs {
+    pub fn with_filter_by(mut self, value: ListPaperDocsFilterBy) -> Self {
+        self.filter_by = value;
+        self
+    }
+
+    pub fn with_sort_by(mut self, value: ListPaperDocsSortBy) -> Self {
+        self.sort_by = value;
+        self
+    }
+
+    pub fn with_sort_order(mut self, value: ListPaperDocsSortOrder) -> Self {
+        self.sort_order = value;
+        self
+    }
+
+    pub fn with_limit(mut self, value: i32) -> Self {
+        self.limit = value;
+        self
+    }
+}
+
 const LIST_PAPER_DOCS_ARGS_FIELDS: &[&str] = &["filter_by",
                                                "sort_by",
                                                "sort_order",
@@ -1971,7 +2002,6 @@ impl ListPaperDocsContinueArgs {
             cursor,
         }
     }
-
 }
 
 const LIST_PAPER_DOCS_CONTINUE_ARGS_FIELDS: &[&str] = &["cursor"];
@@ -2145,7 +2175,6 @@ impl ListPaperDocsResponse {
             has_more,
         }
     }
-
 }
 
 const LIST_PAPER_DOCS_RESPONSE_FIELDS: &[&str] = &["doc_ids",
@@ -2521,7 +2550,6 @@ impl ListUsersOnFolderArgs {
         self.limit = value;
         self
     }
-
 }
 
 const LIST_USERS_ON_FOLDER_ARGS_FIELDS: &[&str] = &["doc_id",
@@ -2626,7 +2654,6 @@ impl ListUsersOnFolderContinueArgs {
             cursor,
         }
     }
-
 }
 
 const LIST_USERS_ON_FOLDER_CONTINUE_ARGS_FIELDS: &[&str] = &["doc_id",
@@ -2745,7 +2772,6 @@ impl ListUsersOnFolderResponse {
             has_more,
         }
     }
-
 }
 
 const LIST_USERS_ON_FOLDER_RESPONSE_FIELDS: &[&str] = &["invitees",
@@ -2882,7 +2908,6 @@ impl ListUsersOnPaperDocArgs {
         self.filter_by = value;
         self
     }
-
 }
 
 const LIST_USERS_ON_PAPER_DOC_ARGS_FIELDS: &[&str] = &["doc_id",
@@ -2996,7 +3021,6 @@ impl ListUsersOnPaperDocContinueArgs {
             cursor,
         }
     }
-
 }
 
 const LIST_USERS_ON_PAPER_DOC_CONTINUE_ARGS_FIELDS: &[&str] = &["doc_id",
@@ -3120,7 +3144,6 @@ impl ListUsersOnPaperDocResponse {
             has_more,
         }
     }
-
 }
 
 const LIST_USERS_ON_PAPER_DOC_RESPONSE_FIELDS: &[&str] = &["invitees",
@@ -3442,7 +3465,6 @@ impl PaperDocCreateArgs {
         self.parent_folder_id = value;
         self
     }
-
 }
 
 const PAPER_DOC_CREATE_ARGS_FIELDS: &[&str] = &["import_format",
@@ -3674,7 +3696,6 @@ impl PaperDocCreateUpdateResult {
             title,
         }
     }
-
 }
 
 const PAPER_DOC_CREATE_UPDATE_RESULT_FIELDS: &[&str] = &["doc_id",
@@ -3786,7 +3807,6 @@ impl PaperDocExport {
             export_format,
         }
     }
-
 }
 
 const PAPER_DOC_EXPORT_FIELDS: &[&str] = &["doc_id",
@@ -3896,7 +3916,6 @@ impl PaperDocExportResult {
             mime_type,
         }
     }
-
 }
 
 const PAPER_DOC_EXPORT_RESULT_FIELDS: &[&str] = &["owner",
@@ -4090,7 +4109,6 @@ impl PaperDocSharingPolicy {
             sharing_policy,
         }
     }
-
 }
 
 const PAPER_DOC_SHARING_POLICY_FIELDS: &[&str] = &["doc_id",
@@ -4205,7 +4223,6 @@ impl PaperDocUpdateArgs {
             import_format,
         }
     }
-
 }
 
 const PAPER_DOC_UPDATE_ARGS_FIELDS: &[&str] = &["doc_id",
@@ -4595,7 +4612,6 @@ impl PaperFolderCreateArg {
         self.is_team_folder = value;
         self
     }
-
 }
 
 const PAPER_FOLDER_CREATE_ARG_FIELDS: &[&str] = &["name",
@@ -4804,7 +4820,6 @@ impl PaperFolderCreateResult {
             folder_id,
         }
     }
-
 }
 
 const PAPER_FOLDER_CREATE_RESULT_FIELDS: &[&str] = &["folder_id"];
@@ -4894,7 +4909,6 @@ impl RefPaperDoc {
             doc_id,
         }
     }
-
 }
 
 const REF_PAPER_DOC_FIELDS: &[&str] = &["doc_id"];
@@ -4988,7 +5002,6 @@ impl RemovePaperDocUser {
             member,
         }
     }
-
 }
 
 const REMOVE_PAPER_DOC_USER_FIELDS: &[&str] = &["doc_id",
@@ -5091,6 +5104,18 @@ impl Default for SharingPolicy {
             public_sharing_policy: None,
             team_sharing_policy: None,
         }
+    }
+}
+
+impl SharingPolicy {
+    pub fn with_public_sharing_policy(mut self, value: Option<SharingPublicPolicyType>) -> Self {
+        self.public_sharing_policy = value;
+        self
+    }
+
+    pub fn with_team_sharing_policy(mut self, value: Option<SharingTeamPolicyType>) -> Self {
+        self.team_sharing_policy = value;
+        self
     }
 }
 
@@ -5349,7 +5374,6 @@ impl UserInfoWithPermissionLevel {
             permission_level,
         }
     }
-
 }
 
 const USER_INFO_WITH_PERMISSION_LEVEL_FIELDS: &[&str] = &["user",

--- a/src/generated/secondary_emails.rs
+++ b/src/generated/secondary_emails.rs
@@ -22,7 +22,6 @@ impl SecondaryEmail {
             is_verified,
         }
     }
-
 }
 
 const SECONDARY_EMAIL_FIELDS: &[&str] = &["email",

--- a/src/generated/sharing.rs
+++ b/src/generated/sharing.rs
@@ -981,7 +981,6 @@ impl AddFileMemberArgs {
         self.add_message_as_comment = value;
         self
     }
-
 }
 
 const ADD_FILE_MEMBER_ARGS_FIELDS: &[&str] = &["file",
@@ -1257,7 +1256,6 @@ impl AddFolderMemberArg {
         self.custom_message = value;
         self
     }
-
 }
 
 const ADD_FOLDER_MEMBER_ARG_FIELDS: &[&str] = &["shared_folder_id",
@@ -1633,7 +1631,6 @@ impl AddMember {
         self.access_level = value;
         self
     }
-
 }
 
 const ADD_MEMBER_FIELDS: &[&str] = &["member",
@@ -1883,7 +1880,6 @@ impl AudienceExceptionContentInfo {
             name,
         }
     }
-
 }
 
 const AUDIENCE_EXCEPTION_CONTENT_INFO_FIELDS: &[&str] = &["name"];
@@ -1979,7 +1975,6 @@ impl AudienceExceptions {
             exceptions,
         }
     }
-
 }
 
 const AUDIENCE_EXCEPTIONS_FIELDS: &[&str] = &["count",
@@ -2091,7 +2086,6 @@ impl AudienceRestrictingSharedFolder {
             audience,
         }
     }
-
 }
 
 const AUDIENCE_RESTRICTING_SHARED_FOLDER_FIELDS: &[&str] = &["shared_folder_id",
@@ -2208,7 +2202,6 @@ impl ChangeFileMemberAccessArgs {
             access_level,
         }
     }
-
 }
 
 const CHANGE_FILE_MEMBER_ACCESS_ARGS_FIELDS: &[&str] = &["file",
@@ -2330,7 +2323,6 @@ impl CollectionLinkMetadata {
         self.expires = value;
         self
     }
-
 }
 
 const COLLECTION_LINK_METADATA_FIELDS: &[&str] = &["url",
@@ -2459,7 +2451,6 @@ impl CreateSharedLinkArg {
         self.pending_upload = value;
         self
     }
-
 }
 
 const CREATE_SHARED_LINK_ARG_FIELDS: &[&str] = &["path",
@@ -2650,7 +2641,6 @@ impl CreateSharedLinkWithSettingsArg {
         self.settings = value;
         self
     }
-
 }
 
 const CREATE_SHARED_LINK_WITH_SETTINGS_ARG_FIELDS: &[&str] = &["path",
@@ -2925,7 +2915,6 @@ impl ExpectedSharedContentLinkMetadata {
         self.expiry = value;
         self
     }
-
 }
 
 const EXPECTED_SHARED_CONTENT_LINK_METADATA_FIELDS: &[&str] = &["audience_options",
@@ -3448,7 +3437,6 @@ impl FileLinkMetadata {
         self.content_owner_team_info = value;
         self
     }
-
 }
 
 const FILE_LINK_METADATA_FIELDS: &[&str] = &["url",
@@ -3838,7 +3826,6 @@ impl FileMemberActionResult {
             result,
         }
     }
-
 }
 
 const FILE_MEMBER_ACTION_RESULT_FIELDS: &[&str] = &["member",
@@ -4023,7 +4010,6 @@ impl FilePermission {
         self.reason = value;
         self
     }
-
 }
 
 const FILE_PERMISSION_FIELDS: &[&str] = &["action",
@@ -4412,7 +4398,6 @@ impl FolderLinkMetadata {
         self.content_owner_team_info = value;
         self
     }
-
 }
 
 const FOLDER_LINK_METADATA_FIELDS: &[&str] = &["url",
@@ -4585,7 +4570,6 @@ impl FolderPermission {
         self.reason = value;
         self
     }
-
 }
 
 const FOLDER_PERMISSION_FIELDS: &[&str] = &["action",
@@ -4727,7 +4711,6 @@ impl FolderPolicy {
         self.viewer_info_policy = value;
         self
     }
-
 }
 
 const FOLDER_POLICY_FIELDS: &[&str] = &["acl_update_policy",
@@ -4868,7 +4851,6 @@ impl GetFileMetadataArg {
         self.actions = value;
         self
     }
-
 }
 
 const GET_FILE_METADATA_ARG_FIELDS: &[&str] = &["file",
@@ -4979,7 +4961,6 @@ impl GetFileMetadataBatchArg {
         self.actions = value;
         self
     }
-
 }
 
 const GET_FILE_METADATA_BATCH_ARG_FIELDS: &[&str] = &["files",
@@ -5084,7 +5065,6 @@ impl GetFileMetadataBatchResult {
             result,
         }
     }
-
 }
 
 const GET_FILE_METADATA_BATCH_RESULT_FIELDS: &[&str] = &["file",
@@ -5357,7 +5337,6 @@ impl GetMetadataArgs {
         self.actions = value;
         self
     }
-
 }
 
 const GET_METADATA_ARGS_FIELDS: &[&str] = &["shared_folder_id",
@@ -5583,7 +5562,6 @@ impl GetSharedLinkMetadataArg {
         self.link_password = value;
         self
     }
-
 }
 
 const GET_SHARED_LINK_METADATA_ARG_FIELDS: &[&str] = &["url",
@@ -5692,6 +5670,13 @@ impl Default for GetSharedLinksArg {
         GetSharedLinksArg {
             path: None,
         }
+    }
+}
+
+impl GetSharedLinksArg {
+    pub fn with_path(mut self, value: Option<String>) -> Self {
+        self.path = value;
+        self
     }
 }
 
@@ -5847,7 +5832,6 @@ impl GetSharedLinksResult {
             links,
         }
     }
-
 }
 
 const GET_SHARED_LINKS_RESULT_FIELDS: &[&str] = &["links"];
@@ -5982,7 +5966,6 @@ impl GroupInfo {
         self.member_count = value;
         self
     }
-
 }
 
 const GROUP_INFO_FIELDS: &[&str] = &["group_name",
@@ -6182,7 +6165,6 @@ impl GroupMembershipInfo {
         self.is_inherited = value;
         self
     }
-
 }
 
 const GROUP_MEMBERSHIP_INFO_FIELDS: &[&str] = &["access_type",
@@ -6321,7 +6303,6 @@ impl InsufficientPlan {
         self.upsell_url = value;
         self
     }
-
 }
 
 const INSUFFICIENT_PLAN_FIELDS: &[&str] = &["message",
@@ -6427,7 +6408,6 @@ impl InsufficientQuotaAmounts {
             space_left,
         }
     }
-
 }
 
 const INSUFFICIENT_QUOTA_AMOUNTS_FIELDS: &[&str] = &["space_needed",
@@ -6638,7 +6618,6 @@ impl InviteeMembershipInfo {
         self.user = value;
         self
     }
-
 }
 
 const INVITEE_MEMBERSHIP_INFO_FIELDS: &[&str] = &["access_type",
@@ -7502,7 +7481,6 @@ impl LinkPermission {
         self.reason = value;
         self
     }
-
 }
 
 const LINK_PERMISSION_FIELDS: &[&str] = &["action",
@@ -7669,7 +7647,6 @@ impl LinkPermissions {
         self.link_access_level = value;
         self
     }
-
 }
 
 const LINK_PERMISSIONS_FIELDS: &[&str] = &["can_revoke",
@@ -7822,6 +7799,28 @@ impl Default for LinkSettings {
     }
 }
 
+impl LinkSettings {
+    pub fn with_access_level(mut self, value: Option<AccessLevel>) -> Self {
+        self.access_level = value;
+        self
+    }
+
+    pub fn with_audience(mut self, value: Option<LinkAudience>) -> Self {
+        self.audience = value;
+        self
+    }
+
+    pub fn with_expiry(mut self, value: Option<LinkExpiry>) -> Self {
+        self.expiry = value;
+        self
+    }
+
+    pub fn with_password(mut self, value: Option<LinkPassword>) -> Self {
+        self.password = value;
+        self
+    }
+}
+
 const LINK_SETTINGS_FIELDS: &[&str] = &["access_level",
                                         "audience",
                                         "expiry",
@@ -7953,7 +7952,6 @@ impl ListFileMembersArg {
         self.limit = value;
         self
     }
-
 }
 
 const LIST_FILE_MEMBERS_ARG_FIELDS: &[&str] = &["file",
@@ -8082,7 +8080,6 @@ impl ListFileMembersBatchArg {
         self.limit = value;
         self
     }
-
 }
 
 const LIST_FILE_MEMBERS_BATCH_ARG_FIELDS: &[&str] = &["files",
@@ -8186,7 +8183,6 @@ impl ListFileMembersBatchResult {
             result,
         }
     }
-
 }
 
 const LIST_FILE_MEMBERS_BATCH_RESULT_FIELDS: &[&str] = &["file",
@@ -8289,7 +8285,6 @@ impl ListFileMembersContinueArg {
             cursor,
         }
     }
-
 }
 
 const LIST_FILE_MEMBERS_CONTINUE_ARG_FIELDS: &[&str] = &["cursor"];
@@ -8485,7 +8480,6 @@ impl ListFileMembersCountResult {
             member_count,
         }
     }
-
 }
 
 const LIST_FILE_MEMBERS_COUNT_RESULT_FIELDS: &[&str] = &["members",
@@ -8756,6 +8750,18 @@ impl Default for ListFilesArg {
     }
 }
 
+impl ListFilesArg {
+    pub fn with_limit(mut self, value: u32) -> Self {
+        self.limit = value;
+        self
+    }
+
+    pub fn with_actions(mut self, value: Option<Vec<FileAction>>) -> Self {
+        self.actions = value;
+        self
+    }
+}
+
 const LIST_FILES_ARG_FIELDS: &[&str] = &["limit",
                                          "actions"];
 impl ListFilesArg {
@@ -8843,7 +8849,6 @@ impl ListFilesContinueArg {
             cursor,
         }
     }
-
 }
 
 const LIST_FILES_CONTINUE_ARG_FIELDS: &[&str] = &["cursor"];
@@ -9030,7 +9035,6 @@ impl ListFilesResult {
         self.cursor = value;
         self
     }
-
 }
 
 const LIST_FILES_RESULT_FIELDS: &[&str] = &["entries",
@@ -9149,7 +9153,6 @@ impl ListFolderMembersArgs {
         self.limit = value;
         self
     }
-
 }
 
 const LIST_FOLDER_MEMBERS_ARGS_FIELDS: &[&str] = &["shared_folder_id",
@@ -9260,7 +9263,6 @@ impl ListFolderMembersContinueArg {
             cursor,
         }
     }
-
 }
 
 const LIST_FOLDER_MEMBERS_CONTINUE_ARG_FIELDS: &[&str] = &["cursor"];
@@ -9444,6 +9446,18 @@ impl Default for ListFolderMembersCursorArg {
     }
 }
 
+impl ListFolderMembersCursorArg {
+    pub fn with_actions(mut self, value: Option<Vec<MemberAction>>) -> Self {
+        self.actions = value;
+        self
+    }
+
+    pub fn with_limit(mut self, value: u32) -> Self {
+        self.limit = value;
+        self
+    }
+}
+
 const LIST_FOLDER_MEMBERS_CURSOR_ARG_FIELDS: &[&str] = &["actions",
                                                          "limit"];
 impl ListFolderMembersCursorArg {
@@ -9537,6 +9551,18 @@ impl Default for ListFoldersArgs {
     }
 }
 
+impl ListFoldersArgs {
+    pub fn with_limit(mut self, value: u32) -> Self {
+        self.limit = value;
+        self
+    }
+
+    pub fn with_actions(mut self, value: Option<Vec<FolderAction>>) -> Self {
+        self.actions = value;
+        self
+    }
+}
+
 const LIST_FOLDERS_ARGS_FIELDS: &[&str] = &["limit",
                                             "actions"];
 impl ListFoldersArgs {
@@ -9623,7 +9649,6 @@ impl ListFoldersContinueArg {
             cursor,
         }
     }
-
 }
 
 const LIST_FOLDERS_CONTINUE_ARG_FIELDS: &[&str] = &["cursor"];
@@ -9799,7 +9824,6 @@ impl ListFoldersResult {
         self.cursor = value;
         self
     }
-
 }
 
 const LIST_FOLDERS_RESULT_FIELDS: &[&str] = &["entries",
@@ -9904,6 +9928,23 @@ impl Default for ListSharedLinksArg {
             cursor: None,
             direct_only: None,
         }
+    }
+}
+
+impl ListSharedLinksArg {
+    pub fn with_path(mut self, value: Option<ReadPath>) -> Self {
+        self.path = value;
+        self
+    }
+
+    pub fn with_cursor(mut self, value: Option<String>) -> Self {
+        self.cursor = value;
+        self
+    }
+
+    pub fn with_direct_only(mut self, value: Option<bool>) -> Self {
+        self.direct_only = value;
+        self
     }
 }
 
@@ -10103,7 +10144,6 @@ impl ListSharedLinksResult {
         self.cursor = value;
         self
     }
-
 }
 
 const LIST_SHARED_LINKS_RESULT_FIELDS: &[&str] = &["links",
@@ -10221,6 +10261,23 @@ impl Default for MemberAccessLevelResult {
             warning: None,
             access_details: None,
         }
+    }
+}
+
+impl MemberAccessLevelResult {
+    pub fn with_access_level(mut self, value: Option<AccessLevel>) -> Self {
+        self.access_level = value;
+        self
+    }
+
+    pub fn with_warning(mut self, value: Option<String>) -> Self {
+        self.warning = value;
+        self
+    }
+
+    pub fn with_access_details(mut self, value: Option<Vec<ParentFolderAccessInfo>>) -> Self {
+        self.access_details = value;
+        self
     }
 }
 
@@ -10456,7 +10513,6 @@ impl MemberPermission {
         self.reason = value;
         self
     }
-
 }
 
 const MEMBER_PERMISSION_FIELDS: &[&str] = &["action",
@@ -10746,7 +10802,6 @@ impl MembershipInfo {
         self.is_inherited = value;
         self
     }
-
 }
 
 const MEMBERSHIP_INFO_FIELDS: &[&str] = &["access_type",
@@ -10877,7 +10932,6 @@ impl ModifySharedLinkSettingsArgs {
         self.remove_expiration = value;
         self
     }
-
 }
 
 const MODIFY_SHARED_LINK_SETTINGS_ARGS_FIELDS: &[&str] = &["url",
@@ -11115,7 +11169,6 @@ impl MountFolderArg {
             shared_folder_id,
         }
     }
-
 }
 
 const MOUNT_FOLDER_ARG_FIELDS: &[&str] = &["shared_folder_id"];
@@ -11357,7 +11410,6 @@ impl ParentFolderAccessInfo {
             path,
         }
     }
-
 }
 
 const PARENT_FOLDER_ACCESS_INFO_FIELDS: &[&str] = &["folder_name",
@@ -11492,7 +11544,6 @@ impl PathLinkMetadata {
         self.expires = value;
         self
     }
-
 }
 
 const PATH_LINK_METADATA_FIELDS: &[&str] = &["url",
@@ -11914,7 +11965,6 @@ impl RelinquishFileMembershipArg {
             file,
         }
     }
-
 }
 
 const RELINQUISH_FILE_MEMBERSHIP_ARG_FIELDS: &[&str] = &["file"];
@@ -12112,7 +12162,6 @@ impl RelinquishFolderMembershipArg {
         self.leave_a_copy = value;
         self
     }
-
 }
 
 const RELINQUISH_FOLDER_MEMBERSHIP_ARG_FIELDS: &[&str] = &["shared_folder_id",
@@ -12373,7 +12422,6 @@ impl RemoveFileMemberArg {
             member,
         }
     }
-
 }
 
 const REMOVE_FILE_MEMBER_ARG_FIELDS: &[&str] = &["file",
@@ -12587,7 +12635,6 @@ impl RemoveFolderMemberArg {
             leave_a_copy,
         }
     }
-
 }
 
 const REMOVE_FOLDER_MEMBER_ARG_FIELDS: &[&str] = &["shared_folder_id",
@@ -13211,7 +13258,6 @@ impl RevokeSharedLinkArg {
             url,
         }
     }
-
 }
 
 const REVOKE_SHARED_LINK_ARG_FIELDS: &[&str] = &["url"];
@@ -13418,7 +13464,6 @@ impl SetAccessInheritanceArg {
         self.access_inheritance = value;
         self
     }
-
 }
 
 const SET_ACCESS_INHERITANCE_ARG_FIELDS: &[&str] = &["shared_folder_id",
@@ -13673,7 +13718,6 @@ impl ShareFolderArg {
         self.link_settings = value;
         self
     }
-
 }
 
 const SHARE_FOLDER_ARG_FIELDS: &[&str] = &["path",
@@ -13893,7 +13937,6 @@ impl ShareFolderArgBase {
         self.access_inheritance = value;
         self
     }
-
 }
 
 const SHARE_FOLDER_ARG_BASE_FIELDS: &[&str] = &["path",
@@ -14728,7 +14771,6 @@ impl SharedContentLinkMetadata {
         self.audience_exceptions = value;
         self
     }
-
 }
 
 const SHARED_CONTENT_LINK_METADATA_FIELDS: &[&str] = &["audience_options",
@@ -14943,7 +14985,6 @@ impl SharedContentLinkMetadataBase {
         self.expiry = value;
         self
     }
-
 }
 
 const SHARED_CONTENT_LINK_METADATA_BASE_FIELDS: &[&str] = &["audience_options",
@@ -15117,7 +15158,6 @@ impl SharedFileMembers {
         self.cursor = value;
         self
     }
-
 }
 
 const SHARED_FILE_MEMBERS_FIELDS: &[&str] = &["users",
@@ -15349,7 +15389,6 @@ impl SharedFileMetadata {
         self.time_invited = value;
         self
     }
-
 }
 
 const SHARED_FILE_METADATA_FIELDS: &[&str] = &["id",
@@ -15794,7 +15833,6 @@ impl SharedFolderMembers {
         self.cursor = value;
         self
     }
-
 }
 
 const SHARED_FOLDER_MEMBERS_FIELDS: &[&str] = &["users",
@@ -16018,7 +16056,6 @@ impl SharedFolderMetadata {
         self.access_inheritance = value;
         self
     }
-
 }
 
 const SHARED_FOLDER_METADATA_FIELDS: &[&str] = &["access_type",
@@ -16316,7 +16353,6 @@ impl SharedFolderMetadataBase {
         self.parent_folder_name = value;
         self
     }
-
 }
 
 const SHARED_FOLDER_METADATA_BASE_FIELDS: &[&str] = &["access_type",
@@ -16930,6 +16966,33 @@ impl Default for SharedLinkSettings {
     }
 }
 
+impl SharedLinkSettings {
+    pub fn with_requested_visibility(mut self, value: Option<RequestedVisibility>) -> Self {
+        self.requested_visibility = value;
+        self
+    }
+
+    pub fn with_link_password(mut self, value: Option<String>) -> Self {
+        self.link_password = value;
+        self
+    }
+
+    pub fn with_expires(mut self, value: Option<super::common::DropboxTimestamp>) -> Self {
+        self.expires = value;
+        self
+    }
+
+    pub fn with_audience(mut self, value: Option<LinkAudience>) -> Self {
+        self.audience = value;
+        self
+    }
+
+    pub fn with_access(mut self, value: Option<RequestedLinkAccessLevel>) -> Self {
+        self.access = value;
+        self
+    }
+}
+
 const SHARED_LINK_SETTINGS_FIELDS: &[&str] = &["requested_visibility",
                                                "link_password",
                                                "expires",
@@ -17337,7 +17400,6 @@ impl TeamMemberInfo {
         self.member_id = value;
         self
     }
-
 }
 
 const TEAM_MEMBER_INFO_FIELDS: &[&str] = &["team_info",
@@ -17450,7 +17512,6 @@ impl TransferFolderArg {
             to_dropbox_id,
         }
     }
-
 }
 
 const TRANSFER_FOLDER_ARG_FIELDS: &[&str] = &["shared_folder_id",
@@ -17703,7 +17764,6 @@ impl UnmountFolderArg {
             shared_folder_id,
         }
     }
-
 }
 
 const UNMOUNT_FOLDER_ARG_FIELDS: &[&str] = &["shared_folder_id"];
@@ -17894,7 +17954,6 @@ impl UnshareFileArg {
             file,
         }
     }
-
 }
 
 const UNSHARE_FILE_ARG_FIELDS: &[&str] = &["file"];
@@ -18084,7 +18143,6 @@ impl UnshareFolderArg {
         self.leave_a_copy = value;
         self
     }
-
 }
 
 const UNSHARE_FOLDER_ARG_FIELDS: &[&str] = &["shared_folder_id",
@@ -18303,7 +18361,6 @@ impl UpdateFileMemberArgs {
             access_level,
         }
     }
-
 }
 
 const UPDATE_FILE_MEMBER_ARGS_FIELDS: &[&str] = &["file",
@@ -18424,7 +18481,6 @@ impl UpdateFolderMemberArg {
             access_level,
         }
     }
-
 }
 
 const UPDATE_FOLDER_MEMBER_ARG_FIELDS: &[&str] = &["shared_folder_id",
@@ -18722,7 +18778,6 @@ impl UpdateFolderPolicyArg {
         self.actions = value;
         self
     }
-
 }
 
 const UPDATE_FOLDER_POLICY_ARG_FIELDS: &[&str] = &["shared_folder_id",
@@ -19058,7 +19113,6 @@ impl UserFileMembershipInfo {
         self.platform_type = value;
         self
     }
-
 }
 
 const USER_FILE_MEMBERSHIP_INFO_FIELDS: &[&str] = &["access_type",
@@ -19233,7 +19287,6 @@ impl UserInfo {
         self.team_member_id = value;
         self
     }
-
 }
 
 const USER_INFO_FIELDS: &[&str] = &["account_id",
@@ -19393,7 +19446,6 @@ impl UserMembershipInfo {
         self.is_inherited = value;
         self
     }
-
 }
 
 const USER_MEMBERSHIP_INFO_FIELDS: &[&str] = &["access_type",

--- a/src/generated/sharing.rs
+++ b/src/generated/sharing.rs
@@ -962,8 +962,8 @@ impl AddFileMemberArgs {
         }
     }
 
-    pub fn with_custom_message(mut self, value: Option<String>) -> Self {
-        self.custom_message = value;
+    pub fn with_custom_message(mut self, value: String) -> Self {
+        self.custom_message = Some(value);
         self
     }
 
@@ -1252,8 +1252,8 @@ impl AddFolderMemberArg {
         self
     }
 
-    pub fn with_custom_message(mut self, value: Option<String>) -> Self {
-        self.custom_message = value;
+    pub fn with_custom_message(mut self, value: String) -> Self {
+        self.custom_message = Some(value);
         self
     }
 }
@@ -2319,8 +2319,8 @@ impl CollectionLinkMetadata {
         }
     }
 
-    pub fn with_expires(mut self, value: Option<super::common::DropboxTimestamp>) -> Self {
-        self.expires = value;
+    pub fn with_expires(mut self, value: super::common::DropboxTimestamp) -> Self {
+        self.expires = Some(value);
         self
     }
 }
@@ -2447,8 +2447,8 @@ impl CreateSharedLinkArg {
         self
     }
 
-    pub fn with_pending_upload(mut self, value: Option<PendingUploadMode>) -> Self {
-        self.pending_upload = value;
+    pub fn with_pending_upload(mut self, value: PendingUploadMode) -> Self {
+        self.pending_upload = Some(value);
         self
     }
 }
@@ -2637,8 +2637,8 @@ impl CreateSharedLinkWithSettingsArg {
         }
     }
 
-    pub fn with_settings(mut self, value: Option<SharedLinkSettings>) -> Self {
-        self.settings = value;
+    pub fn with_settings(mut self, value: SharedLinkSettings) -> Self {
+        self.settings = Some(value);
         self
     }
 }
@@ -2898,21 +2898,21 @@ impl ExpectedSharedContentLinkMetadata {
         }
     }
 
-    pub fn with_access_level(mut self, value: Option<AccessLevel>) -> Self {
-        self.access_level = value;
+    pub fn with_access_level(mut self, value: AccessLevel) -> Self {
+        self.access_level = Some(value);
         self
     }
 
     pub fn with_audience_restricting_shared_folder(
         mut self,
-        value: Option<AudienceRestrictingSharedFolder>,
+        value: AudienceRestrictingSharedFolder,
     ) -> Self {
-        self.audience_restricting_shared_folder = value;
+        self.audience_restricting_shared_folder = Some(value);
         self
     }
 
-    pub fn with_expiry(mut self, value: Option<super::common::DropboxTimestamp>) -> Self {
-        self.expiry = value;
+    pub fn with_expiry(mut self, value: super::common::DropboxTimestamp) -> Self {
+        self.expiry = Some(value);
         self
     }
 }
@@ -3413,28 +3413,28 @@ impl FileLinkMetadata {
         }
     }
 
-    pub fn with_id(mut self, value: Option<Id>) -> Self {
-        self.id = value;
+    pub fn with_id(mut self, value: Id) -> Self {
+        self.id = Some(value);
         self
     }
 
-    pub fn with_expires(mut self, value: Option<super::common::DropboxTimestamp>) -> Self {
-        self.expires = value;
+    pub fn with_expires(mut self, value: super::common::DropboxTimestamp) -> Self {
+        self.expires = Some(value);
         self
     }
 
-    pub fn with_path_lower(mut self, value: Option<String>) -> Self {
-        self.path_lower = value;
+    pub fn with_path_lower(mut self, value: String) -> Self {
+        self.path_lower = Some(value);
         self
     }
 
-    pub fn with_team_member_info(mut self, value: Option<TeamMemberInfo>) -> Self {
-        self.team_member_info = value;
+    pub fn with_team_member_info(mut self, value: TeamMemberInfo) -> Self {
+        self.team_member_info = Some(value);
         self
     }
 
-    pub fn with_content_owner_team_info(mut self, value: Option<TeamInfo>) -> Self {
-        self.content_owner_team_info = value;
+    pub fn with_content_owner_team_info(mut self, value: TeamInfo) -> Self {
+        self.content_owner_team_info = Some(value);
         self
     }
 }
@@ -4006,8 +4006,8 @@ impl FilePermission {
         }
     }
 
-    pub fn with_reason(mut self, value: Option<PermissionDeniedReason>) -> Self {
-        self.reason = value;
+    pub fn with_reason(mut self, value: PermissionDeniedReason) -> Self {
+        self.reason = Some(value);
         self
     }
 }
@@ -4374,28 +4374,28 @@ impl FolderLinkMetadata {
         }
     }
 
-    pub fn with_id(mut self, value: Option<Id>) -> Self {
-        self.id = value;
+    pub fn with_id(mut self, value: Id) -> Self {
+        self.id = Some(value);
         self
     }
 
-    pub fn with_expires(mut self, value: Option<super::common::DropboxTimestamp>) -> Self {
-        self.expires = value;
+    pub fn with_expires(mut self, value: super::common::DropboxTimestamp) -> Self {
+        self.expires = Some(value);
         self
     }
 
-    pub fn with_path_lower(mut self, value: Option<String>) -> Self {
-        self.path_lower = value;
+    pub fn with_path_lower(mut self, value: String) -> Self {
+        self.path_lower = Some(value);
         self
     }
 
-    pub fn with_team_member_info(mut self, value: Option<TeamMemberInfo>) -> Self {
-        self.team_member_info = value;
+    pub fn with_team_member_info(mut self, value: TeamMemberInfo) -> Self {
+        self.team_member_info = Some(value);
         self
     }
 
-    pub fn with_content_owner_team_info(mut self, value: Option<TeamInfo>) -> Self {
-        self.content_owner_team_info = value;
+    pub fn with_content_owner_team_info(mut self, value: TeamInfo) -> Self {
+        self.content_owner_team_info = Some(value);
         self
     }
 }
@@ -4566,8 +4566,8 @@ impl FolderPermission {
         }
     }
 
-    pub fn with_reason(mut self, value: Option<PermissionDeniedReason>) -> Self {
-        self.reason = value;
+    pub fn with_reason(mut self, value: PermissionDeniedReason) -> Self {
+        self.reason = Some(value);
         self
     }
 }
@@ -4697,18 +4697,18 @@ impl FolderPolicy {
         }
     }
 
-    pub fn with_member_policy(mut self, value: Option<MemberPolicy>) -> Self {
-        self.member_policy = value;
+    pub fn with_member_policy(mut self, value: MemberPolicy) -> Self {
+        self.member_policy = Some(value);
         self
     }
 
-    pub fn with_resolved_member_policy(mut self, value: Option<MemberPolicy>) -> Self {
-        self.resolved_member_policy = value;
+    pub fn with_resolved_member_policy(mut self, value: MemberPolicy) -> Self {
+        self.resolved_member_policy = Some(value);
         self
     }
 
-    pub fn with_viewer_info_policy(mut self, value: Option<ViewerInfoPolicy>) -> Self {
-        self.viewer_info_policy = value;
+    pub fn with_viewer_info_policy(mut self, value: ViewerInfoPolicy) -> Self {
+        self.viewer_info_policy = Some(value);
         self
     }
 }
@@ -4847,8 +4847,8 @@ impl GetFileMetadataArg {
         }
     }
 
-    pub fn with_actions(mut self, value: Option<Vec<FileAction>>) -> Self {
-        self.actions = value;
+    pub fn with_actions(mut self, value: Vec<FileAction>) -> Self {
+        self.actions = Some(value);
         self
     }
 }
@@ -4957,8 +4957,8 @@ impl GetFileMetadataBatchArg {
         }
     }
 
-    pub fn with_actions(mut self, value: Option<Vec<FileAction>>) -> Self {
-        self.actions = value;
+    pub fn with_actions(mut self, value: Vec<FileAction>) -> Self {
+        self.actions = Some(value);
         self
     }
 }
@@ -5333,8 +5333,8 @@ impl GetMetadataArgs {
         }
     }
 
-    pub fn with_actions(mut self, value: Option<Vec<FolderAction>>) -> Self {
-        self.actions = value;
+    pub fn with_actions(mut self, value: Vec<FolderAction>) -> Self {
+        self.actions = Some(value);
         self
     }
 }
@@ -5553,13 +5553,13 @@ impl GetSharedLinkMetadataArg {
         }
     }
 
-    pub fn with_path(mut self, value: Option<Path>) -> Self {
-        self.path = value;
+    pub fn with_path(mut self, value: Path) -> Self {
+        self.path = Some(value);
         self
     }
 
-    pub fn with_link_password(mut self, value: Option<String>) -> Self {
-        self.link_password = value;
+    pub fn with_link_password(mut self, value: String) -> Self {
+        self.link_password = Some(value);
         self
     }
 }
@@ -5674,8 +5674,8 @@ impl Default for GetSharedLinksArg {
 }
 
 impl GetSharedLinksArg {
-    pub fn with_path(mut self, value: Option<String>) -> Self {
-        self.path = value;
+    pub fn with_path(mut self, value: String) -> Self {
+        self.path = Some(value);
         self
     }
 }
@@ -5954,16 +5954,13 @@ impl GroupInfo {
         }
     }
 
-    pub fn with_group_external_id(
-        mut self,
-        value: Option<super::team_common::GroupExternalId>,
-    ) -> Self {
-        self.group_external_id = value;
+    pub fn with_group_external_id(mut self, value: super::team_common::GroupExternalId) -> Self {
+        self.group_external_id = Some(value);
         self
     }
 
-    pub fn with_member_count(mut self, value: Option<u32>) -> Self {
-        self.member_count = value;
+    pub fn with_member_count(mut self, value: u32) -> Self {
+        self.member_count = Some(value);
         self
     }
 }
@@ -6151,13 +6148,13 @@ impl GroupMembershipInfo {
         }
     }
 
-    pub fn with_permissions(mut self, value: Option<Vec<MemberPermission>>) -> Self {
-        self.permissions = value;
+    pub fn with_permissions(mut self, value: Vec<MemberPermission>) -> Self {
+        self.permissions = Some(value);
         self
     }
 
-    pub fn with_initials(mut self, value: Option<String>) -> Self {
-        self.initials = value;
+    pub fn with_initials(mut self, value: String) -> Self {
+        self.initials = Some(value);
         self
     }
 
@@ -6299,8 +6296,8 @@ impl InsufficientPlan {
         }
     }
 
-    pub fn with_upsell_url(mut self, value: Option<String>) -> Self {
-        self.upsell_url = value;
+    pub fn with_upsell_url(mut self, value: String) -> Self {
+        self.upsell_url = Some(value);
         self
     }
 }
@@ -6599,13 +6596,13 @@ impl InviteeMembershipInfo {
         }
     }
 
-    pub fn with_permissions(mut self, value: Option<Vec<MemberPermission>>) -> Self {
-        self.permissions = value;
+    pub fn with_permissions(mut self, value: Vec<MemberPermission>) -> Self {
+        self.permissions = Some(value);
         self
     }
 
-    pub fn with_initials(mut self, value: Option<String>) -> Self {
-        self.initials = value;
+    pub fn with_initials(mut self, value: String) -> Self {
+        self.initials = Some(value);
         self
     }
 
@@ -6614,8 +6611,8 @@ impl InviteeMembershipInfo {
         self
     }
 
-    pub fn with_user(mut self, value: Option<UserInfo>) -> Self {
-        self.user = value;
+    pub fn with_user(mut self, value: UserInfo) -> Self {
+        self.user = Some(value);
         self
     }
 }
@@ -7477,8 +7474,8 @@ impl LinkPermission {
         }
     }
 
-    pub fn with_reason(mut self, value: Option<PermissionDeniedReason>) -> Self {
-        self.reason = value;
+    pub fn with_reason(mut self, value: PermissionDeniedReason) -> Self {
+        self.reason = Some(value);
         self
     }
 }
@@ -7620,31 +7617,28 @@ impl LinkPermissions {
         }
     }
 
-    pub fn with_resolved_visibility(mut self, value: Option<ResolvedVisibility>) -> Self {
-        self.resolved_visibility = value;
+    pub fn with_resolved_visibility(mut self, value: ResolvedVisibility) -> Self {
+        self.resolved_visibility = Some(value);
         self
     }
 
-    pub fn with_requested_visibility(mut self, value: Option<RequestedVisibility>) -> Self {
-        self.requested_visibility = value;
+    pub fn with_requested_visibility(mut self, value: RequestedVisibility) -> Self {
+        self.requested_visibility = Some(value);
         self
     }
 
-    pub fn with_revoke_failure_reason(
-        mut self,
-        value: Option<SharedLinkAccessFailureReason>,
-    ) -> Self {
-        self.revoke_failure_reason = value;
+    pub fn with_revoke_failure_reason(mut self, value: SharedLinkAccessFailureReason) -> Self {
+        self.revoke_failure_reason = Some(value);
         self
     }
 
-    pub fn with_effective_audience(mut self, value: Option<LinkAudience>) -> Self {
-        self.effective_audience = value;
+    pub fn with_effective_audience(mut self, value: LinkAudience) -> Self {
+        self.effective_audience = Some(value);
         self
     }
 
-    pub fn with_link_access_level(mut self, value: Option<LinkAccessLevel>) -> Self {
-        self.link_access_level = value;
+    pub fn with_link_access_level(mut self, value: LinkAccessLevel) -> Self {
+        self.link_access_level = Some(value);
         self
     }
 }
@@ -7800,23 +7794,23 @@ impl Default for LinkSettings {
 }
 
 impl LinkSettings {
-    pub fn with_access_level(mut self, value: Option<AccessLevel>) -> Self {
-        self.access_level = value;
+    pub fn with_access_level(mut self, value: AccessLevel) -> Self {
+        self.access_level = Some(value);
         self
     }
 
-    pub fn with_audience(mut self, value: Option<LinkAudience>) -> Self {
-        self.audience = value;
+    pub fn with_audience(mut self, value: LinkAudience) -> Self {
+        self.audience = Some(value);
         self
     }
 
-    pub fn with_expiry(mut self, value: Option<LinkExpiry>) -> Self {
-        self.expiry = value;
+    pub fn with_expiry(mut self, value: LinkExpiry) -> Self {
+        self.expiry = Some(value);
         self
     }
 
-    pub fn with_password(mut self, value: Option<LinkPassword>) -> Self {
-        self.password = value;
+    pub fn with_password(mut self, value: LinkPassword) -> Self {
+        self.password = Some(value);
         self
     }
 }
@@ -7938,8 +7932,8 @@ impl ListFileMembersArg {
         }
     }
 
-    pub fn with_actions(mut self, value: Option<Vec<MemberAction>>) -> Self {
-        self.actions = value;
+    pub fn with_actions(mut self, value: Vec<MemberAction>) -> Self {
+        self.actions = Some(value);
         self
     }
 
@@ -8756,8 +8750,8 @@ impl ListFilesArg {
         self
     }
 
-    pub fn with_actions(mut self, value: Option<Vec<FileAction>>) -> Self {
-        self.actions = value;
+    pub fn with_actions(mut self, value: Vec<FileAction>) -> Self {
+        self.actions = Some(value);
         self
     }
 }
@@ -9031,8 +9025,8 @@ impl ListFilesResult {
         }
     }
 
-    pub fn with_cursor(mut self, value: Option<String>) -> Self {
-        self.cursor = value;
+    pub fn with_cursor(mut self, value: String) -> Self {
+        self.cursor = Some(value);
         self
     }
 }
@@ -9144,8 +9138,8 @@ impl ListFolderMembersArgs {
         }
     }
 
-    pub fn with_actions(mut self, value: Option<Vec<MemberAction>>) -> Self {
-        self.actions = value;
+    pub fn with_actions(mut self, value: Vec<MemberAction>) -> Self {
+        self.actions = Some(value);
         self
     }
 
@@ -9447,8 +9441,8 @@ impl Default for ListFolderMembersCursorArg {
 }
 
 impl ListFolderMembersCursorArg {
-    pub fn with_actions(mut self, value: Option<Vec<MemberAction>>) -> Self {
-        self.actions = value;
+    pub fn with_actions(mut self, value: Vec<MemberAction>) -> Self {
+        self.actions = Some(value);
         self
     }
 
@@ -9557,8 +9551,8 @@ impl ListFoldersArgs {
         self
     }
 
-    pub fn with_actions(mut self, value: Option<Vec<FolderAction>>) -> Self {
-        self.actions = value;
+    pub fn with_actions(mut self, value: Vec<FolderAction>) -> Self {
+        self.actions = Some(value);
         self
     }
 }
@@ -9820,8 +9814,8 @@ impl ListFoldersResult {
         }
     }
 
-    pub fn with_cursor(mut self, value: Option<String>) -> Self {
-        self.cursor = value;
+    pub fn with_cursor(mut self, value: String) -> Self {
+        self.cursor = Some(value);
         self
     }
 }
@@ -9932,18 +9926,18 @@ impl Default for ListSharedLinksArg {
 }
 
 impl ListSharedLinksArg {
-    pub fn with_path(mut self, value: Option<ReadPath>) -> Self {
-        self.path = value;
+    pub fn with_path(mut self, value: ReadPath) -> Self {
+        self.path = Some(value);
         self
     }
 
-    pub fn with_cursor(mut self, value: Option<String>) -> Self {
-        self.cursor = value;
+    pub fn with_cursor(mut self, value: String) -> Self {
+        self.cursor = Some(value);
         self
     }
 
-    pub fn with_direct_only(mut self, value: Option<bool>) -> Self {
-        self.direct_only = value;
+    pub fn with_direct_only(mut self, value: bool) -> Self {
+        self.direct_only = Some(value);
         self
     }
 }
@@ -10140,8 +10134,8 @@ impl ListSharedLinksResult {
         }
     }
 
-    pub fn with_cursor(mut self, value: Option<String>) -> Self {
-        self.cursor = value;
+    pub fn with_cursor(mut self, value: String) -> Self {
+        self.cursor = Some(value);
         self
     }
 }
@@ -10265,18 +10259,18 @@ impl Default for MemberAccessLevelResult {
 }
 
 impl MemberAccessLevelResult {
-    pub fn with_access_level(mut self, value: Option<AccessLevel>) -> Self {
-        self.access_level = value;
+    pub fn with_access_level(mut self, value: AccessLevel) -> Self {
+        self.access_level = Some(value);
         self
     }
 
-    pub fn with_warning(mut self, value: Option<String>) -> Self {
-        self.warning = value;
+    pub fn with_warning(mut self, value: String) -> Self {
+        self.warning = Some(value);
         self
     }
 
-    pub fn with_access_details(mut self, value: Option<Vec<ParentFolderAccessInfo>>) -> Self {
-        self.access_details = value;
+    pub fn with_access_details(mut self, value: Vec<ParentFolderAccessInfo>) -> Self {
+        self.access_details = Some(value);
         self
     }
 }
@@ -10509,8 +10503,8 @@ impl MemberPermission {
         }
     }
 
-    pub fn with_reason(mut self, value: Option<PermissionDeniedReason>) -> Self {
-        self.reason = value;
+    pub fn with_reason(mut self, value: PermissionDeniedReason) -> Self {
+        self.reason = Some(value);
         self
     }
 }
@@ -10788,13 +10782,13 @@ impl MembershipInfo {
         }
     }
 
-    pub fn with_permissions(mut self, value: Option<Vec<MemberPermission>>) -> Self {
-        self.permissions = value;
+    pub fn with_permissions(mut self, value: Vec<MemberPermission>) -> Self {
+        self.permissions = Some(value);
         self
     }
 
-    pub fn with_initials(mut self, value: Option<String>) -> Self {
-        self.initials = value;
+    pub fn with_initials(mut self, value: String) -> Self {
+        self.initials = Some(value);
         self
     }
 
@@ -11540,8 +11534,8 @@ impl PathLinkMetadata {
         }
     }
 
-    pub fn with_expires(mut self, value: Option<super::common::DropboxTimestamp>) -> Self {
-        self.expires = value;
+    pub fn with_expires(mut self, value: super::common::DropboxTimestamp) -> Self {
+        self.expires = Some(value);
         self
     }
 }
@@ -13679,8 +13673,8 @@ impl ShareFolderArg {
         }
     }
 
-    pub fn with_acl_update_policy(mut self, value: Option<AclUpdatePolicy>) -> Self {
-        self.acl_update_policy = value;
+    pub fn with_acl_update_policy(mut self, value: AclUpdatePolicy) -> Self {
+        self.acl_update_policy = Some(value);
         self
     }
 
@@ -13689,18 +13683,18 @@ impl ShareFolderArg {
         self
     }
 
-    pub fn with_member_policy(mut self, value: Option<MemberPolicy>) -> Self {
-        self.member_policy = value;
+    pub fn with_member_policy(mut self, value: MemberPolicy) -> Self {
+        self.member_policy = Some(value);
         self
     }
 
-    pub fn with_shared_link_policy(mut self, value: Option<SharedLinkPolicy>) -> Self {
-        self.shared_link_policy = value;
+    pub fn with_shared_link_policy(mut self, value: SharedLinkPolicy) -> Self {
+        self.shared_link_policy = Some(value);
         self
     }
 
-    pub fn with_viewer_info_policy(mut self, value: Option<ViewerInfoPolicy>) -> Self {
-        self.viewer_info_policy = value;
+    pub fn with_viewer_info_policy(mut self, value: ViewerInfoPolicy) -> Self {
+        self.viewer_info_policy = Some(value);
         self
     }
 
@@ -13709,13 +13703,13 @@ impl ShareFolderArg {
         self
     }
 
-    pub fn with_actions(mut self, value: Option<Vec<FolderAction>>) -> Self {
-        self.actions = value;
+    pub fn with_actions(mut self, value: Vec<FolderAction>) -> Self {
+        self.actions = Some(value);
         self
     }
 
-    pub fn with_link_settings(mut self, value: Option<LinkSettings>) -> Self {
-        self.link_settings = value;
+    pub fn with_link_settings(mut self, value: LinkSettings) -> Self {
+        self.link_settings = Some(value);
         self
     }
 }
@@ -13908,8 +13902,8 @@ impl ShareFolderArgBase {
         }
     }
 
-    pub fn with_acl_update_policy(mut self, value: Option<AclUpdatePolicy>) -> Self {
-        self.acl_update_policy = value;
+    pub fn with_acl_update_policy(mut self, value: AclUpdatePolicy) -> Self {
+        self.acl_update_policy = Some(value);
         self
     }
 
@@ -13918,18 +13912,18 @@ impl ShareFolderArgBase {
         self
     }
 
-    pub fn with_member_policy(mut self, value: Option<MemberPolicy>) -> Self {
-        self.member_policy = value;
+    pub fn with_member_policy(mut self, value: MemberPolicy) -> Self {
+        self.member_policy = Some(value);
         self
     }
 
-    pub fn with_shared_link_policy(mut self, value: Option<SharedLinkPolicy>) -> Self {
-        self.shared_link_policy = value;
+    pub fn with_shared_link_policy(mut self, value: SharedLinkPolicy) -> Self {
+        self.shared_link_policy = Some(value);
         self
     }
 
-    pub fn with_viewer_info_policy(mut self, value: Option<ViewerInfoPolicy>) -> Self {
-        self.viewer_info_policy = value;
+    pub fn with_viewer_info_policy(mut self, value: ViewerInfoPolicy) -> Self {
+        self.viewer_info_policy = Some(value);
         self
     }
 
@@ -14749,26 +14743,26 @@ impl SharedContentLinkMetadata {
         }
     }
 
-    pub fn with_access_level(mut self, value: Option<AccessLevel>) -> Self {
-        self.access_level = value;
+    pub fn with_access_level(mut self, value: AccessLevel) -> Self {
+        self.access_level = Some(value);
         self
     }
 
     pub fn with_audience_restricting_shared_folder(
         mut self,
-        value: Option<AudienceRestrictingSharedFolder>,
+        value: AudienceRestrictingSharedFolder,
     ) -> Self {
-        self.audience_restricting_shared_folder = value;
+        self.audience_restricting_shared_folder = Some(value);
         self
     }
 
-    pub fn with_expiry(mut self, value: Option<super::common::DropboxTimestamp>) -> Self {
-        self.expiry = value;
+    pub fn with_expiry(mut self, value: super::common::DropboxTimestamp) -> Self {
+        self.expiry = Some(value);
         self
     }
 
-    pub fn with_audience_exceptions(mut self, value: Option<AudienceExceptions>) -> Self {
-        self.audience_exceptions = value;
+    pub fn with_audience_exceptions(mut self, value: AudienceExceptions) -> Self {
+        self.audience_exceptions = Some(value);
         self
     }
 }
@@ -14968,21 +14962,21 @@ impl SharedContentLinkMetadataBase {
         }
     }
 
-    pub fn with_access_level(mut self, value: Option<AccessLevel>) -> Self {
-        self.access_level = value;
+    pub fn with_access_level(mut self, value: AccessLevel) -> Self {
+        self.access_level = Some(value);
         self
     }
 
     pub fn with_audience_restricting_shared_folder(
         mut self,
-        value: Option<AudienceRestrictingSharedFolder>,
+        value: AudienceRestrictingSharedFolder,
     ) -> Self {
-        self.audience_restricting_shared_folder = value;
+        self.audience_restricting_shared_folder = Some(value);
         self
     }
 
-    pub fn with_expiry(mut self, value: Option<super::common::DropboxTimestamp>) -> Self {
-        self.expiry = value;
+    pub fn with_expiry(mut self, value: super::common::DropboxTimestamp) -> Self {
+        self.expiry = Some(value);
         self
     }
 }
@@ -15154,8 +15148,8 @@ impl SharedFileMembers {
         }
     }
 
-    pub fn with_cursor(mut self, value: Option<String>) -> Self {
-        self.cursor = value;
+    pub fn with_cursor(mut self, value: String) -> Self {
+        self.cursor = Some(value);
         self
     }
 }
@@ -15334,59 +15328,56 @@ impl SharedFileMetadata {
         }
     }
 
-    pub fn with_access_type(mut self, value: Option<AccessLevel>) -> Self {
-        self.access_type = value;
+    pub fn with_access_type(mut self, value: AccessLevel) -> Self {
+        self.access_type = Some(value);
         self
     }
 
     pub fn with_expected_link_metadata(
         mut self,
-        value: Option<ExpectedSharedContentLinkMetadata>,
+        value: ExpectedSharedContentLinkMetadata,
     ) -> Self {
-        self.expected_link_metadata = value;
+        self.expected_link_metadata = Some(value);
         self
     }
 
-    pub fn with_link_metadata(mut self, value: Option<SharedContentLinkMetadata>) -> Self {
-        self.link_metadata = value;
+    pub fn with_link_metadata(mut self, value: SharedContentLinkMetadata) -> Self {
+        self.link_metadata = Some(value);
         self
     }
 
-    pub fn with_owner_display_names(mut self, value: Option<Vec<String>>) -> Self {
-        self.owner_display_names = value;
+    pub fn with_owner_display_names(mut self, value: Vec<String>) -> Self {
+        self.owner_display_names = Some(value);
         self
     }
 
-    pub fn with_owner_team(mut self, value: Option<super::users::Team>) -> Self {
-        self.owner_team = value;
+    pub fn with_owner_team(mut self, value: super::users::Team) -> Self {
+        self.owner_team = Some(value);
         self
     }
 
-    pub fn with_parent_shared_folder_id(
-        mut self,
-        value: Option<super::common::SharedFolderId>,
-    ) -> Self {
-        self.parent_shared_folder_id = value;
+    pub fn with_parent_shared_folder_id(mut self, value: super::common::SharedFolderId) -> Self {
+        self.parent_shared_folder_id = Some(value);
         self
     }
 
-    pub fn with_path_display(mut self, value: Option<String>) -> Self {
-        self.path_display = value;
+    pub fn with_path_display(mut self, value: String) -> Self {
+        self.path_display = Some(value);
         self
     }
 
-    pub fn with_path_lower(mut self, value: Option<String>) -> Self {
-        self.path_lower = value;
+    pub fn with_path_lower(mut self, value: String) -> Self {
+        self.path_lower = Some(value);
         self
     }
 
-    pub fn with_permissions(mut self, value: Option<Vec<FilePermission>>) -> Self {
-        self.permissions = value;
+    pub fn with_permissions(mut self, value: Vec<FilePermission>) -> Self {
+        self.permissions = Some(value);
         self
     }
 
-    pub fn with_time_invited(mut self, value: Option<super::common::DropboxTimestamp>) -> Self {
-        self.time_invited = value;
+    pub fn with_time_invited(mut self, value: super::common::DropboxTimestamp) -> Self {
+        self.time_invited = Some(value);
         self
     }
 }
@@ -15829,8 +15820,8 @@ impl SharedFolderMembers {
         }
     }
 
-    pub fn with_cursor(mut self, value: Option<String>) -> Self {
-        self.cursor = value;
+    pub fn with_cursor(mut self, value: String) -> Self {
+        self.cursor = Some(value);
         self
     }
 }
@@ -16014,41 +16005,38 @@ impl SharedFolderMetadata {
         }
     }
 
-    pub fn with_owner_display_names(mut self, value: Option<Vec<String>>) -> Self {
-        self.owner_display_names = value;
+    pub fn with_owner_display_names(mut self, value: Vec<String>) -> Self {
+        self.owner_display_names = Some(value);
         self
     }
 
-    pub fn with_owner_team(mut self, value: Option<super::users::Team>) -> Self {
-        self.owner_team = value;
+    pub fn with_owner_team(mut self, value: super::users::Team) -> Self {
+        self.owner_team = Some(value);
         self
     }
 
-    pub fn with_parent_shared_folder_id(
-        mut self,
-        value: Option<super::common::SharedFolderId>,
-    ) -> Self {
-        self.parent_shared_folder_id = value;
+    pub fn with_parent_shared_folder_id(mut self, value: super::common::SharedFolderId) -> Self {
+        self.parent_shared_folder_id = Some(value);
         self
     }
 
-    pub fn with_path_lower(mut self, value: Option<String>) -> Self {
-        self.path_lower = value;
+    pub fn with_path_lower(mut self, value: String) -> Self {
+        self.path_lower = Some(value);
         self
     }
 
-    pub fn with_parent_folder_name(mut self, value: Option<String>) -> Self {
-        self.parent_folder_name = value;
+    pub fn with_parent_folder_name(mut self, value: String) -> Self {
+        self.parent_folder_name = Some(value);
         self
     }
 
-    pub fn with_link_metadata(mut self, value: Option<SharedContentLinkMetadata>) -> Self {
-        self.link_metadata = value;
+    pub fn with_link_metadata(mut self, value: SharedContentLinkMetadata) -> Self {
+        self.link_metadata = Some(value);
         self
     }
 
-    pub fn with_permissions(mut self, value: Option<Vec<FolderPermission>>) -> Self {
-        self.permissions = value;
+    pub fn with_permissions(mut self, value: Vec<FolderPermission>) -> Self {
+        self.permissions = Some(value);
         self
     }
 
@@ -16326,31 +16314,28 @@ impl SharedFolderMetadataBase {
         }
     }
 
-    pub fn with_owner_display_names(mut self, value: Option<Vec<String>>) -> Self {
-        self.owner_display_names = value;
+    pub fn with_owner_display_names(mut self, value: Vec<String>) -> Self {
+        self.owner_display_names = Some(value);
         self
     }
 
-    pub fn with_owner_team(mut self, value: Option<super::users::Team>) -> Self {
-        self.owner_team = value;
+    pub fn with_owner_team(mut self, value: super::users::Team) -> Self {
+        self.owner_team = Some(value);
         self
     }
 
-    pub fn with_parent_shared_folder_id(
-        mut self,
-        value: Option<super::common::SharedFolderId>,
-    ) -> Self {
-        self.parent_shared_folder_id = value;
+    pub fn with_parent_shared_folder_id(mut self, value: super::common::SharedFolderId) -> Self {
+        self.parent_shared_folder_id = Some(value);
         self
     }
 
-    pub fn with_path_lower(mut self, value: Option<String>) -> Self {
-        self.path_lower = value;
+    pub fn with_path_lower(mut self, value: String) -> Self {
+        self.path_lower = Some(value);
         self
     }
 
-    pub fn with_parent_folder_name(mut self, value: Option<String>) -> Self {
-        self.parent_folder_name = value;
+    pub fn with_parent_folder_name(mut self, value: String) -> Self {
+        self.parent_folder_name = Some(value);
         self
     }
 }
@@ -16967,28 +16952,28 @@ impl Default for SharedLinkSettings {
 }
 
 impl SharedLinkSettings {
-    pub fn with_requested_visibility(mut self, value: Option<RequestedVisibility>) -> Self {
-        self.requested_visibility = value;
+    pub fn with_requested_visibility(mut self, value: RequestedVisibility) -> Self {
+        self.requested_visibility = Some(value);
         self
     }
 
-    pub fn with_link_password(mut self, value: Option<String>) -> Self {
-        self.link_password = value;
+    pub fn with_link_password(mut self, value: String) -> Self {
+        self.link_password = Some(value);
         self
     }
 
-    pub fn with_expires(mut self, value: Option<super::common::DropboxTimestamp>) -> Self {
-        self.expires = value;
+    pub fn with_expires(mut self, value: super::common::DropboxTimestamp) -> Self {
+        self.expires = Some(value);
         self
     }
 
-    pub fn with_audience(mut self, value: Option<LinkAudience>) -> Self {
-        self.audience = value;
+    pub fn with_audience(mut self, value: LinkAudience) -> Self {
+        self.audience = Some(value);
         self
     }
 
-    pub fn with_access(mut self, value: Option<RequestedLinkAccessLevel>) -> Self {
-        self.access = value;
+    pub fn with_access(mut self, value: RequestedLinkAccessLevel) -> Self {
+        self.access = Some(value);
         self
     }
 }
@@ -17396,8 +17381,8 @@ impl TeamMemberInfo {
         }
     }
 
-    pub fn with_member_id(mut self, value: Option<String>) -> Self {
-        self.member_id = value;
+    pub fn with_member_id(mut self, value: String) -> Self {
+        self.member_id = Some(value);
         self
     }
 }
@@ -18749,33 +18734,33 @@ impl UpdateFolderPolicyArg {
         }
     }
 
-    pub fn with_member_policy(mut self, value: Option<MemberPolicy>) -> Self {
-        self.member_policy = value;
+    pub fn with_member_policy(mut self, value: MemberPolicy) -> Self {
+        self.member_policy = Some(value);
         self
     }
 
-    pub fn with_acl_update_policy(mut self, value: Option<AclUpdatePolicy>) -> Self {
-        self.acl_update_policy = value;
+    pub fn with_acl_update_policy(mut self, value: AclUpdatePolicy) -> Self {
+        self.acl_update_policy = Some(value);
         self
     }
 
-    pub fn with_viewer_info_policy(mut self, value: Option<ViewerInfoPolicy>) -> Self {
-        self.viewer_info_policy = value;
+    pub fn with_viewer_info_policy(mut self, value: ViewerInfoPolicy) -> Self {
+        self.viewer_info_policy = Some(value);
         self
     }
 
-    pub fn with_shared_link_policy(mut self, value: Option<SharedLinkPolicy>) -> Self {
-        self.shared_link_policy = value;
+    pub fn with_shared_link_policy(mut self, value: SharedLinkPolicy) -> Self {
+        self.shared_link_policy = Some(value);
         self
     }
 
-    pub fn with_link_settings(mut self, value: Option<LinkSettings>) -> Self {
-        self.link_settings = value;
+    pub fn with_link_settings(mut self, value: LinkSettings) -> Self {
+        self.link_settings = Some(value);
         self
     }
 
-    pub fn with_actions(mut self, value: Option<Vec<FolderAction>>) -> Self {
-        self.actions = value;
+    pub fn with_actions(mut self, value: Vec<FolderAction>) -> Self {
+        self.actions = Some(value);
         self
     }
 }
@@ -19089,13 +19074,13 @@ impl UserFileMembershipInfo {
         }
     }
 
-    pub fn with_permissions(mut self, value: Option<Vec<MemberPermission>>) -> Self {
-        self.permissions = value;
+    pub fn with_permissions(mut self, value: Vec<MemberPermission>) -> Self {
+        self.permissions = Some(value);
         self
     }
 
-    pub fn with_initials(mut self, value: Option<String>) -> Self {
-        self.initials = value;
+    pub fn with_initials(mut self, value: String) -> Self {
+        self.initials = Some(value);
         self
     }
 
@@ -19104,13 +19089,13 @@ impl UserFileMembershipInfo {
         self
     }
 
-    pub fn with_time_last_seen(mut self, value: Option<super::common::DropboxTimestamp>) -> Self {
-        self.time_last_seen = value;
+    pub fn with_time_last_seen(mut self, value: super::common::DropboxTimestamp) -> Self {
+        self.time_last_seen = Some(value);
         self
     }
 
-    pub fn with_platform_type(mut self, value: Option<super::seen_state::PlatformType>) -> Self {
-        self.platform_type = value;
+    pub fn with_platform_type(mut self, value: super::seen_state::PlatformType) -> Self {
+        self.platform_type = Some(value);
         self
     }
 }
@@ -19283,8 +19268,8 @@ impl UserInfo {
         }
     }
 
-    pub fn with_team_member_id(mut self, value: Option<String>) -> Self {
-        self.team_member_id = value;
+    pub fn with_team_member_id(mut self, value: String) -> Self {
+        self.team_member_id = Some(value);
         self
     }
 }
@@ -19432,13 +19417,13 @@ impl UserMembershipInfo {
         }
     }
 
-    pub fn with_permissions(mut self, value: Option<Vec<MemberPermission>>) -> Self {
-        self.permissions = value;
+    pub fn with_permissions(mut self, value: Vec<MemberPermission>) -> Self {
+        self.permissions = Some(value);
         self
     }
 
-    pub fn with_initials(mut self, value: Option<String>) -> Self {
-        self.initials = value;
+    pub fn with_initials(mut self, value: String) -> Self {
+        self.initials = Some(value);
         self
     }
 

--- a/src/generated/team.rs
+++ b/src/generated/team.rs
@@ -1260,7 +1260,6 @@ impl ActiveWebSession {
         self.expires = value;
         self
     }
-
 }
 
 const ACTIVE_WEB_SESSION_FIELDS: &[&str] = &["session_id",
@@ -1625,7 +1624,6 @@ impl AddSecondaryEmailsArg {
             new_secondary_emails,
         }
     }
-
 }
 
 const ADD_SECONDARY_EMAILS_ARG_FIELDS: &[&str] = &["new_secondary_emails"];
@@ -1799,7 +1797,6 @@ impl AddSecondaryEmailsResult {
             results,
         }
     }
-
 }
 
 const ADD_SECONDARY_EMAILS_RESULT_FIELDS: &[&str] = &["results"];
@@ -2010,7 +2007,6 @@ impl ApiApp {
         self.linked = value;
         self
     }
-
 }
 
 const API_APP_FIELDS: &[&str] = &["app_id",
@@ -2151,7 +2147,6 @@ impl BaseDfbReport {
             start_date,
         }
     }
-
 }
 
 const BASE_DFB_REPORT_FIELDS: &[&str] = &["start_date"];
@@ -2492,7 +2487,6 @@ impl CustomQuotaUsersArg {
             users,
         }
     }
-
 }
 
 const CUSTOM_QUOTA_USERS_ARG_FIELDS: &[&str] = &["users"];
@@ -2586,6 +2580,18 @@ impl Default for DateRange {
             start_date: None,
             end_date: None,
         }
+    }
+}
+
+impl DateRange {
+    pub fn with_start_date(mut self, value: Option<super::common::Date>) -> Self {
+        self.start_date = value;
+        self
+    }
+
+    pub fn with_end_date(mut self, value: Option<super::common::Date>) -> Self {
+        self.end_date = value;
+        self
     }
 }
 
@@ -2828,7 +2834,6 @@ impl DeleteSecondaryEmailsArg {
             emails_to_delete,
         }
     }
-
 }
 
 const DELETE_SECONDARY_EMAILS_ARG_FIELDS: &[&str] = &["emails_to_delete"];
@@ -2917,7 +2922,6 @@ impl DeleteSecondaryEmailsResult {
             results,
         }
     }
-
 }
 
 const DELETE_SECONDARY_EMAILS_RESULT_FIELDS: &[&str] = &["results"];
@@ -3062,7 +3066,6 @@ impl DesktopClientSession {
         self.updated = value;
         self
     }
-
 }
 
 const DESKTOP_CLIENT_SESSION_FIELDS: &[&str] = &["session_id",
@@ -3358,7 +3361,6 @@ impl DeviceSession {
         self.updated = value;
         self
     }
-
 }
 
 const DEVICE_SESSION_FIELDS: &[&str] = &["session_id",
@@ -3491,7 +3493,6 @@ impl DeviceSessionArg {
             team_member_id,
         }
     }
-
 }
 
 const DEVICE_SESSION_ARG_FIELDS: &[&str] = &["session_id",
@@ -3620,7 +3621,6 @@ impl DevicesActive {
             total,
         }
     }
-
 }
 
 const DEVICES_ACTIVE_FIELDS: &[&str] = &["windows",
@@ -3773,6 +3773,13 @@ impl Default for ExcludedUsersListArg {
     }
 }
 
+impl ExcludedUsersListArg {
+    pub fn with_limit(mut self, value: u32) -> Self {
+        self.limit = value;
+        self
+    }
+}
+
 const EXCLUDED_USERS_LIST_ARG_FIELDS: &[&str] = &["limit"];
 impl ExcludedUsersListArg {
     // no _opt deserializer
@@ -3850,7 +3857,6 @@ impl ExcludedUsersListContinueArg {
             cursor,
         }
     }
-
 }
 
 const EXCLUDED_USERS_LIST_CONTINUE_ARG_FIELDS: &[&str] = &["cursor"];
@@ -4098,7 +4104,6 @@ impl ExcludedUsersListResult {
         self.cursor = value;
         self
     }
-
 }
 
 const EXCLUDED_USERS_LIST_RESULT_FIELDS: &[&str] = &["users",
@@ -4209,6 +4214,13 @@ impl Default for ExcludedUsersUpdateArg {
         ExcludedUsersUpdateArg {
             users: None,
         }
+    }
+}
+
+impl ExcludedUsersUpdateArg {
+    pub fn with_users(mut self, value: Option<Vec<UserSelectorArg>>) -> Self {
+        self.users = value;
+        self
     }
 }
 
@@ -4373,7 +4385,6 @@ impl ExcludedUsersUpdateResult {
             status,
         }
     }
-
 }
 
 const EXCLUDED_USERS_UPDATE_RESULT_FIELDS: &[&str] = &["status"];
@@ -4732,7 +4743,6 @@ impl FeaturesGetValuesBatchArg {
             features,
         }
     }
-
 }
 
 const FEATURES_GET_VALUES_BATCH_ARG_FIELDS: &[&str] = &["features"];
@@ -4892,7 +4902,6 @@ impl FeaturesGetValuesBatchResult {
             values,
         }
     }
-
 }
 
 const FEATURES_GET_VALUES_BATCH_RESULT_FIELDS: &[&str] = &["values"];
@@ -5044,7 +5053,6 @@ impl GetActivityReport {
             shared_links_viewed_total,
         }
     }
-
 }
 
 const GET_ACTIVITY_REPORT_FIELDS: &[&str] = &["start_date",
@@ -5291,7 +5299,6 @@ impl GetDevicesReport {
             active_28_day,
         }
     }
-
 }
 
 const GET_DEVICES_REPORT_FIELDS: &[&str] = &["start_date",
@@ -5435,7 +5442,6 @@ impl GetMembershipReport {
             licenses,
         }
     }
-
 }
 
 const GET_MEMBERSHIP_REPORT_FIELDS: &[&str] = &["start_date",
@@ -5602,7 +5608,6 @@ impl GetStorageReport {
             member_storage_map,
         }
     }
-
 }
 
 const GET_STORAGE_REPORT_FIELDS: &[&str] = &["start_date",
@@ -5836,7 +5841,6 @@ impl GroupCreateArg {
         self.group_management_type = value;
         self
     }
-
 }
 
 const GROUP_CREATE_ARG_FIELDS: &[&str] = &["group_name",
@@ -6201,7 +6205,6 @@ impl GroupFullInfo {
         self.members = value;
         self
     }
-
 }
 
 const GROUP_FULL_INFO_FIELDS: &[&str] = &["group_name",
@@ -6355,7 +6358,6 @@ impl GroupMemberInfo {
             access_type,
         }
     }
-
 }
 
 const GROUP_MEMBER_INFO_FIELDS: &[&str] = &["profile",
@@ -6459,7 +6461,6 @@ impl GroupMemberSelector {
             user,
         }
     }
-
 }
 
 const GROUP_MEMBER_SELECTOR_FIELDS: &[&str] = &["group",
@@ -6779,7 +6780,6 @@ impl GroupMembersAddArg {
         self.return_members = value;
         self
     }
-
 }
 
 const GROUP_MEMBERS_ADD_ARG_FIELDS: &[&str] = &["group",
@@ -7073,7 +7073,6 @@ impl GroupMembersChangeResult {
             async_job_id,
         }
     }
-
 }
 
 const GROUP_MEMBERS_CHANGE_RESULT_FIELDS: &[&str] = &["group_info",
@@ -7186,7 +7185,6 @@ impl GroupMembersRemoveArg {
         self.return_members = value;
         self
     }
-
 }
 
 const GROUP_MEMBERS_REMOVE_ARG_FIELDS: &[&str] = &["group",
@@ -7444,7 +7442,6 @@ impl GroupMembersSelector {
             users,
         }
     }
-
 }
 
 const GROUP_MEMBERS_SELECTOR_FIELDS: &[&str] = &["group",
@@ -7658,7 +7655,6 @@ impl GroupMembersSetAccessTypeArg {
         self.return_members = value;
         self
     }
-
 }
 
 const GROUP_MEMBERS_SET_ACCESS_TYPE_ARG_FIELDS: &[&str] = &["group",
@@ -8047,7 +8043,6 @@ impl GroupUpdateArgs {
         self.new_group_management_type = value;
         self
     }
-
 }
 
 const GROUP_UPDATE_ARGS_FIELDS: &[&str] = &["group",
@@ -8438,6 +8433,13 @@ impl Default for GroupsListArg {
     }
 }
 
+impl GroupsListArg {
+    pub fn with_limit(mut self, value: u32) -> Self {
+        self.limit = value;
+        self
+    }
+}
+
 const GROUPS_LIST_ARG_FIELDS: &[&str] = &["limit"];
 impl GroupsListArg {
     // no _opt deserializer
@@ -8514,7 +8516,6 @@ impl GroupsListContinueArg {
             cursor,
         }
     }
-
 }
 
 const GROUPS_LIST_CONTINUE_ARG_FIELDS: &[&str] = &["cursor"];
@@ -8685,7 +8686,6 @@ impl GroupsListResult {
             has_more,
         }
     }
-
 }
 
 const GROUPS_LIST_RESULT_FIELDS: &[&str] = &["groups",
@@ -8803,7 +8803,6 @@ impl GroupsMembersListArg {
         self.limit = value;
         self
     }
-
 }
 
 const GROUPS_MEMBERS_LIST_ARG_FIELDS: &[&str] = &["group",
@@ -8903,7 +8902,6 @@ impl GroupsMembersListContinueArg {
             cursor,
         }
     }
-
 }
 
 const GROUPS_MEMBERS_LIST_CONTINUE_ARG_FIELDS: &[&str] = &["cursor"];
@@ -9070,7 +9068,6 @@ impl GroupsMembersListResult {
             has_more,
         }
     }
-
 }
 
 const GROUPS_MEMBERS_LIST_RESULT_FIELDS: &[&str] = &["members",
@@ -9542,6 +9539,13 @@ impl Default for IncludeMembersArg {
     }
 }
 
+impl IncludeMembersArg {
+    pub fn with_return_members(mut self, value: bool) -> Self {
+        self.return_members = value;
+        self
+    }
+}
+
 const INCLUDE_MEMBERS_ARG_FIELDS: &[&str] = &["return_members"];
 impl IncludeMembersArg {
     // no _opt deserializer
@@ -9658,7 +9662,6 @@ impl LegalHoldHeldRevisionMetadata {
             content_hash,
         }
     }
-
 }
 
 const LEGAL_HOLD_HELD_REVISION_METADATA_FIELDS: &[&str] = &["new_filename",
@@ -9880,7 +9883,6 @@ impl LegalHoldPolicy {
         self.end_date = value;
         self
     }
-
 }
 
 const LEGAL_HOLD_POLICY_FIELDS: &[&str] = &["id",
@@ -10246,7 +10248,6 @@ impl LegalHoldsGetPolicyArg {
             id,
         }
     }
-
 }
 
 const LEGAL_HOLDS_GET_POLICY_ARG_FIELDS: &[&str] = &["id"];
@@ -10446,7 +10447,6 @@ impl LegalHoldsListHeldRevisionResult {
         self.cursor = value;
         self
     }
-
 }
 
 const LEGAL_HOLDS_LIST_HELD_REVISION_RESULT_FIELDS: &[&str] = &["entries",
@@ -10556,7 +10556,6 @@ impl LegalHoldsListHeldRevisionsArg {
             id,
         }
     }
-
 }
 
 const LEGAL_HOLDS_LIST_HELD_REVISIONS_ARG_FIELDS: &[&str] = &["id"];
@@ -10655,7 +10654,6 @@ impl LegalHoldsListHeldRevisionsContinueArg {
         self.cursor = value;
         self
     }
-
 }
 
 const LEGAL_HOLDS_LIST_HELD_REVISIONS_CONTINUE_ARG_FIELDS: &[&str] = &["id",
@@ -10977,6 +10975,13 @@ impl Default for LegalHoldsListPoliciesArg {
     }
 }
 
+impl LegalHoldsListPoliciesArg {
+    pub fn with_include_released(mut self, value: bool) -> Self {
+        self.include_released = value;
+        self
+    }
+}
+
 const LEGAL_HOLDS_LIST_POLICIES_ARG_FIELDS: &[&str] = &["include_released"];
 impl LegalHoldsListPoliciesArg {
     // no _opt deserializer
@@ -11148,7 +11153,6 @@ impl LegalHoldsListPoliciesResult {
             policies,
         }
     }
-
 }
 
 const LEGAL_HOLDS_LIST_POLICIES_RESULT_FIELDS: &[&str] = &["policies"];
@@ -11265,7 +11269,6 @@ impl LegalHoldsPolicyCreateArg {
         self.end_date = value;
         self
     }
-
 }
 
 const LEGAL_HOLDS_POLICY_CREATE_ARG_FIELDS: &[&str] = &["name",
@@ -11582,7 +11585,6 @@ impl LegalHoldsPolicyReleaseArg {
             id,
         }
     }
-
 }
 
 const LEGAL_HOLDS_POLICY_RELEASE_ARG_FIELDS: &[&str] = &["id"];
@@ -11819,7 +11821,6 @@ impl LegalHoldsPolicyUpdateArg {
         self.members = value;
         self
     }
-
 }
 
 const LEGAL_HOLDS_POLICY_UPDATE_ARG_FIELDS: &[&str] = &["id",
@@ -12114,7 +12115,6 @@ impl ListMemberAppsArg {
             team_member_id,
         }
     }
-
 }
 
 const LIST_MEMBER_APPS_ARG_FIELDS: &[&str] = &["team_member_id"];
@@ -12276,7 +12276,6 @@ impl ListMemberAppsResult {
             linked_api_apps,
         }
     }
-
 }
 
 const LIST_MEMBER_APPS_RESULT_FIELDS: &[&str] = &["linked_api_apps"];
@@ -12390,7 +12389,6 @@ impl ListMemberDevicesArg {
         self.include_mobile_clients = value;
         self
     }
-
 }
 
 const LIST_MEMBER_DEVICES_ARG_FIELDS: &[&str] = &["team_member_id",
@@ -12588,6 +12586,26 @@ impl Default for ListMemberDevicesResult {
     }
 }
 
+impl ListMemberDevicesResult {
+    pub fn with_active_web_sessions(mut self, value: Option<Vec<ActiveWebSession>>) -> Self {
+        self.active_web_sessions = value;
+        self
+    }
+
+    pub fn with_desktop_client_sessions(
+        mut self,
+        value: Option<Vec<DesktopClientSession>>,
+    ) -> Self {
+        self.desktop_client_sessions = value;
+        self
+    }
+
+    pub fn with_mobile_client_sessions(mut self, value: Option<Vec<MobileClientSession>>) -> Self {
+        self.mobile_client_sessions = value;
+        self
+    }
+}
+
 const LIST_MEMBER_DEVICES_RESULT_FIELDS: &[&str] = &["active_web_sessions",
                                                      "desktop_client_sessions",
                                                      "mobile_client_sessions"];
@@ -12688,6 +12706,13 @@ impl Default for ListMembersAppsArg {
         ListMembersAppsArg {
             cursor: None,
         }
+    }
+}
+
+impl ListMembersAppsArg {
+    pub fn with_cursor(mut self, value: Option<String>) -> Self {
+        self.cursor = value;
+        self
     }
 }
 
@@ -12858,7 +12883,6 @@ impl ListMembersAppsResult {
         self.cursor = value;
         self
     }
-
 }
 
 const LIST_MEMBERS_APPS_RESULT_FIELDS: &[&str] = &["apps",
@@ -12979,6 +13003,28 @@ impl Default for ListMembersDevicesArg {
             include_desktop_clients: true,
             include_mobile_clients: true,
         }
+    }
+}
+
+impl ListMembersDevicesArg {
+    pub fn with_cursor(mut self, value: Option<String>) -> Self {
+        self.cursor = value;
+        self
+    }
+
+    pub fn with_include_web_sessions(mut self, value: bool) -> Self {
+        self.include_web_sessions = value;
+        self
+    }
+
+    pub fn with_include_desktop_clients(mut self, value: bool) -> Self {
+        self.include_desktop_clients = value;
+        self
+    }
+
+    pub fn with_include_mobile_clients(mut self, value: bool) -> Self {
+        self.include_mobile_clients = value;
+        self
     }
 }
 
@@ -13173,7 +13219,6 @@ impl ListMembersDevicesResult {
         self.cursor = value;
         self
     }
-
 }
 
 const LIST_MEMBERS_DEVICES_RESULT_FIELDS: &[&str] = &["devices",
@@ -13287,6 +13332,13 @@ impl Default for ListTeamAppsArg {
         ListTeamAppsArg {
             cursor: None,
         }
+    }
+}
+
+impl ListTeamAppsArg {
+    pub fn with_cursor(mut self, value: Option<String>) -> Self {
+        self.cursor = value;
+        self
     }
 }
 
@@ -13456,7 +13508,6 @@ impl ListTeamAppsResult {
         self.cursor = value;
         self
     }
-
 }
 
 const LIST_TEAM_APPS_RESULT_FIELDS: &[&str] = &["apps",
@@ -13577,6 +13628,28 @@ impl Default for ListTeamDevicesArg {
             include_desktop_clients: true,
             include_mobile_clients: true,
         }
+    }
+}
+
+impl ListTeamDevicesArg {
+    pub fn with_cursor(mut self, value: Option<String>) -> Self {
+        self.cursor = value;
+        self
+    }
+
+    pub fn with_include_web_sessions(mut self, value: bool) -> Self {
+        self.include_web_sessions = value;
+        self
+    }
+
+    pub fn with_include_desktop_clients(mut self, value: bool) -> Self {
+        self.include_desktop_clients = value;
+        self
+    }
+
+    pub fn with_include_mobile_clients(mut self, value: bool) -> Self {
+        self.include_mobile_clients = value;
+        self
     }
 }
 
@@ -13771,7 +13844,6 @@ impl ListTeamDevicesResult {
         self.cursor = value;
         self
     }
-
 }
 
 const LIST_TEAM_DEVICES_RESULT_FIELDS: &[&str] = &["devices",
@@ -13885,7 +13957,6 @@ impl MemberAccess {
             access_type,
         }
     }
-
 }
 
 const MEMBER_ACCESS_FIELDS: &[&str] = &["user",
@@ -14048,7 +14119,6 @@ impl MemberAddArg {
         self.is_directory_restricted = value;
         self
     }
-
 }
 
 const MEMBER_ADD_ARG_FIELDS: &[&str] = &["member_email",
@@ -14459,7 +14529,6 @@ impl MemberDevices {
         self.mobile_clients = value;
         self
     }
-
 }
 
 const MEMBER_DEVICES_FIELDS: &[&str] = &["team_member_id",
@@ -14583,7 +14652,6 @@ impl MemberLinkedApps {
             linked_api_apps,
         }
     }
-
 }
 
 const MEMBER_LINKED_APPS_FIELDS: &[&str] = &["team_member_id",
@@ -14786,7 +14854,6 @@ impl MemberProfile {
         self.profile_photo_url = value;
         self
     }
-
 }
 
 const MEMBER_PROFILE_FIELDS: &[&str] = &["team_member_id",
@@ -15100,7 +15167,6 @@ impl MembersAddArg {
         self.force_async = value;
         self
     }
-
 }
 
 const MEMBERS_ADD_ARG_FIELDS: &[&str] = &["new_members",
@@ -15367,7 +15433,6 @@ impl MembersDataTransferArg {
             transfer_admin_id,
         }
     }
-
 }
 
 const MEMBERS_DATA_TRANSFER_ARG_FIELDS: &[&str] = &["user",
@@ -15485,7 +15550,6 @@ impl MembersDeactivateArg {
         self.wipe_data = value;
         self
     }
-
 }
 
 const MEMBERS_DEACTIVATE_ARG_FIELDS: &[&str] = &["user",
@@ -15587,7 +15651,6 @@ impl MembersDeactivateBaseArg {
             user,
         }
     }
-
 }
 
 const MEMBERS_DEACTIVATE_BASE_ARG_FIELDS: &[&str] = &["user"];
@@ -15761,7 +15824,6 @@ impl MembersDeleteProfilePhotoArg {
             user,
         }
     }
-
 }
 
 const MEMBERS_DELETE_PROFILE_PHOTO_ARG_FIELDS: &[&str] = &["user"];
@@ -15948,7 +16010,6 @@ impl MembersGetInfoArgs {
             members,
         }
     }
-
 }
 
 const MEMBERS_GET_INFO_ARGS_FIELDS: &[&str] = &["members"];
@@ -16167,7 +16228,6 @@ impl MembersInfo {
             permanently_deleted_users,
         }
     }
-
 }
 
 const MEMBERS_INFO_FIELDS: &[&str] = &["team_member_ids",
@@ -16272,6 +16332,18 @@ impl Default for MembersListArg {
     }
 }
 
+impl MembersListArg {
+    pub fn with_limit(mut self, value: u32) -> Self {
+        self.limit = value;
+        self
+    }
+
+    pub fn with_include_removed(mut self, value: bool) -> Self {
+        self.include_removed = value;
+        self
+    }
+}
+
 const MEMBERS_LIST_ARG_FIELDS: &[&str] = &["limit",
                                            "include_removed"];
 impl MembersListArg {
@@ -16358,7 +16430,6 @@ impl MembersListContinueArg {
             cursor,
         }
     }
-
 }
 
 const MEMBERS_LIST_CONTINUE_ARG_FIELDS: &[&str] = &["cursor"];
@@ -16580,7 +16651,6 @@ impl MembersListResult {
             has_more,
         }
     }
-
 }
 
 const MEMBERS_LIST_RESULT_FIELDS: &[&str] = &["members",
@@ -16692,7 +16762,6 @@ impl MembersRecoverArg {
             user,
         }
     }
-
 }
 
 const MEMBERS_RECOVER_ARG_FIELDS: &[&str] = &["user"];
@@ -16939,7 +17008,6 @@ impl MembersRemoveArg {
         self.retain_team_shares = value;
         self
     }
-
 }
 
 const MEMBERS_REMOVE_ARG_FIELDS: &[&str] = &["user",
@@ -17519,7 +17587,6 @@ impl MembersSetPermissionsArg {
             new_role,
         }
     }
-
 }
 
 const MEMBERS_SET_PERMISSIONS_ARG_FIELDS: &[&str] = &["user",
@@ -17745,7 +17812,6 @@ impl MembersSetPermissionsResult {
             role,
         }
     }
-
 }
 
 const MEMBERS_SET_PERMISSIONS_RESULT_FIELDS: &[&str] = &["team_member_id",
@@ -17900,7 +17966,6 @@ impl MembersSetProfileArg {
         self.new_is_directory_restricted = value;
         self
     }
-
 }
 
 const MEMBERS_SET_PROFILE_ARG_FIELDS: &[&str] = &["user",
@@ -18255,7 +18320,6 @@ impl MembersSetProfilePhotoArg {
             photo,
         }
     }
-
 }
 
 const MEMBERS_SET_PROFILE_PHOTO_ARG_FIELDS: &[&str] = &["user",
@@ -19047,7 +19111,6 @@ impl MembersUnsuspendArg {
             user,
         }
     }
-
 }
 
 const MEMBERS_UNSUSPEND_ARG_FIELDS: &[&str] = &["user"];
@@ -19424,7 +19487,6 @@ impl MobileClientSession {
         self.last_carrier = value;
         self
     }
-
 }
 
 const MOBILE_CLIENT_SESSION_FIELDS: &[&str] = &["session_id",
@@ -19624,7 +19686,6 @@ impl NamespaceMetadata {
         self.team_member_id = value;
         self
     }
-
 }
 
 const NAMESPACE_METADATA_FIELDS: &[&str] = &["name",
@@ -19924,7 +19985,6 @@ impl RemovedStatus {
             is_disconnected,
         }
     }
-
 }
 
 const REMOVED_STATUS_FIELDS: &[&str] = &["is_recoverable",
@@ -20123,7 +20183,6 @@ impl ResendVerificationEmailArg {
             emails_to_resend,
         }
     }
-
 }
 
 const RESEND_VERIFICATION_EMAIL_ARG_FIELDS: &[&str] = &["emails_to_resend"];
@@ -20213,7 +20272,6 @@ impl ResendVerificationEmailResult {
             results,
         }
     }
-
 }
 
 const RESEND_VERIFICATION_EMAIL_RESULT_FIELDS: &[&str] = &["results"];
@@ -20315,7 +20373,6 @@ impl RevokeDesktopClientArg {
         self.delete_on_unlink = value;
         self
     }
-
 }
 
 const REVOKE_DESKTOP_CLIENT_ARG_FIELDS: &[&str] = &["session_id",
@@ -20494,7 +20551,6 @@ impl RevokeDeviceSessionBatchArg {
             revoke_devices,
         }
     }
-
 }
 
 const REVOKE_DEVICE_SESSION_BATCH_ARG_FIELDS: &[&str] = &["revoke_devices"];
@@ -20637,7 +20693,6 @@ impl RevokeDeviceSessionBatchResult {
             revoke_devices_status,
         }
     }
-
 }
 
 const REVOKE_DEVICE_SESSION_BATCH_RESULT_FIELDS: &[&str] = &["revoke_devices_status"];
@@ -20818,7 +20873,6 @@ impl RevokeDeviceSessionStatus {
         self.error_type = value;
         self
     }
-
 }
 
 const REVOKE_DEVICE_SESSION_STATUS_FIELDS: &[&str] = &["success",
@@ -20930,7 +20984,6 @@ impl RevokeLinkedApiAppArg {
         self.keep_app_folder = value;
         self
     }
-
 }
 
 const REVOKE_LINKED_API_APP_ARG_FIELDS: &[&str] = &["app_id",
@@ -21039,7 +21092,6 @@ impl RevokeLinkedApiAppBatchArg {
             revoke_linked_app,
         }
     }
-
 }
 
 const REVOKE_LINKED_API_APP_BATCH_ARG_FIELDS: &[&str] = &["revoke_linked_app"];
@@ -21183,7 +21235,6 @@ impl RevokeLinkedAppBatchResult {
             revoke_linked_app_status,
         }
     }
-
 }
 
 const REVOKE_LINKED_APP_BATCH_RESULT_FIELDS: &[&str] = &["revoke_linked_app_status"];
@@ -21378,7 +21429,6 @@ impl RevokeLinkedAppStatus {
         self.error_type = value;
         self
     }
-
 }
 
 const REVOKE_LINKED_APP_STATUS_FIELDS: &[&str] = &["success",
@@ -21478,7 +21528,6 @@ impl SetCustomQuotaArg {
             users_and_quotas,
         }
     }
-
 }
 
 const SET_CUSTOM_QUOTA_ARG_FIELDS: &[&str] = &["users_and_quotas"];
@@ -21657,7 +21706,6 @@ impl StorageBucket {
             users,
         }
     }
-
 }
 
 const STORAGE_BUCKET_FIELDS: &[&str] = &["bucket",
@@ -21954,7 +22002,6 @@ impl TeamFolderArchiveArg {
         self.force_async_off = value;
         self
     }
-
 }
 
 const TEAM_FOLDER_ARCHIVE_ARG_FIELDS: &[&str] = &["team_folder_id",
@@ -22313,7 +22360,6 @@ impl TeamFolderCreateArg {
         self.sync_setting = value;
         self
     }
-
 }
 
 const TEAM_FOLDER_CREATE_ARG_FIELDS: &[&str] = &["name",
@@ -22592,7 +22638,6 @@ impl TeamFolderIdArg {
             team_folder_id,
         }
     }
-
 }
 
 const TEAM_FOLDER_ID_ARG_FIELDS: &[&str] = &["team_folder_id"];
@@ -22682,7 +22727,6 @@ impl TeamFolderIdListArg {
             team_folder_ids,
         }
     }
-
 }
 
 const TEAM_FOLDER_ID_LIST_ARG_FIELDS: &[&str] = &["team_folder_ids"];
@@ -22870,6 +22914,13 @@ impl Default for TeamFolderListArg {
     }
 }
 
+impl TeamFolderListArg {
+    pub fn with_limit(mut self, value: u32) -> Self {
+        self.limit = value;
+        self
+    }
+}
+
 const TEAM_FOLDER_LIST_ARG_FIELDS: &[&str] = &["limit"];
 impl TeamFolderListArg {
     // no _opt deserializer
@@ -22946,7 +22997,6 @@ impl TeamFolderListContinueArg {
             cursor,
         }
     }
-
 }
 
 const TEAM_FOLDER_LIST_CONTINUE_ARG_FIELDS: &[&str] = &["cursor"];
@@ -23105,7 +23155,6 @@ impl TeamFolderListError {
             access_error,
         }
     }
-
 }
 
 const TEAM_FOLDER_LIST_ERROR_FIELDS: &[&str] = &["access_error"];
@@ -23205,7 +23254,6 @@ impl TeamFolderListResult {
             has_more,
         }
     }
-
 }
 
 const TEAM_FOLDER_LIST_RESULT_FIELDS: &[&str] = &["team_folders",
@@ -23338,7 +23386,6 @@ impl TeamFolderMetadata {
             content_sync_settings,
         }
     }
-
 }
 
 const TEAM_FOLDER_METADATA_FIELDS: &[&str] = &["team_folder_id",
@@ -23587,7 +23634,6 @@ impl TeamFolderRenameArg {
             name,
         }
     }
-
 }
 
 const TEAM_FOLDER_RENAME_ARG_FIELDS: &[&str] = &["team_folder_id",
@@ -24005,7 +24051,6 @@ impl TeamFolderUpdateSyncSettingsArg {
         self.content_sync_settings = value;
         self
     }
-
 }
 
 const TEAM_FOLDER_UPDATE_SYNC_SETTINGS_ARG_FIELDS: &[&str] = &["team_folder_id",
@@ -24254,7 +24299,6 @@ impl TeamGetInfoResult {
             policies,
         }
     }
-
 }
 
 const TEAM_GET_INFO_RESULT_FIELDS: &[&str] = &["name",
@@ -24388,7 +24432,6 @@ impl TeamMemberInfo {
             role,
         }
     }
-
 }
 
 const TEAM_MEMBER_INFO_FIELDS: &[&str] = &["profile",
@@ -24599,7 +24642,6 @@ impl TeamMemberProfile {
         self.profile_photo_url = value;
         self
     }
-
 }
 
 const TEAM_MEMBER_PROFILE_FIELDS: &[&str] = &["team_member_id",
@@ -25005,6 +25047,13 @@ impl Default for TeamNamespacesListArg {
     }
 }
 
+impl TeamNamespacesListArg {
+    pub fn with_limit(mut self, value: u32) -> Self {
+        self.limit = value;
+        self
+    }
+}
+
 const TEAM_NAMESPACES_LIST_ARG_FIELDS: &[&str] = &["limit"];
 impl TeamNamespacesListArg {
     // no _opt deserializer
@@ -25081,7 +25130,6 @@ impl TeamNamespacesListContinueArg {
             cursor,
         }
     }
-
 }
 
 const TEAM_NAMESPACES_LIST_CONTINUE_ARG_FIELDS: &[&str] = &["cursor"];
@@ -25332,7 +25380,6 @@ impl TeamNamespacesListResult {
             has_more,
         }
     }
-
 }
 
 const TEAM_NAMESPACES_LIST_RESULT_FIELDS: &[&str] = &["namespaces",
@@ -25616,7 +25663,6 @@ impl TokenGetAuthenticatedAdminResult {
             admin_profile,
         }
     }
-
 }
 
 const TOKEN_GET_AUTHENTICATED_ADMIN_RESULT_FIELDS: &[&str] = &["admin_profile"];
@@ -25895,7 +25941,6 @@ impl UserCustomQuotaArg {
             quota_gb,
         }
     }
-
 }
 
 const USER_CUSTOM_QUOTA_ARG_FIELDS: &[&str] = &["user",
@@ -26003,7 +26048,6 @@ impl UserCustomQuotaResult {
         self.quota_gb = value;
         self
     }
-
 }
 
 const USER_CUSTOM_QUOTA_RESULT_FIELDS: &[&str] = &["user",
@@ -26104,7 +26148,6 @@ impl UserDeleteEmailsResult {
             results,
         }
     }
-
 }
 
 const USER_DELETE_EMAILS_RESULT_FIELDS: &[&str] = &["user",
@@ -26281,7 +26324,6 @@ impl UserResendEmailsResult {
             results,
         }
     }
-
 }
 
 const USER_RESEND_EMAILS_RESULT_FIELDS: &[&str] = &["user",
@@ -26459,7 +26501,6 @@ impl UserSecondaryEmailsArg {
             secondary_emails,
         }
     }
-
 }
 
 const USER_SECONDARY_EMAILS_ARG_FIELDS: &[&str] = &["user",
@@ -26560,7 +26601,6 @@ impl UserSecondaryEmailsResult {
             results,
         }
     }
-
 }
 
 const USER_SECONDARY_EMAILS_RESULT_FIELDS: &[&str] = &["user",

--- a/src/generated/team.rs
+++ b/src/generated/team.rs
@@ -1236,28 +1236,28 @@ impl ActiveWebSession {
         }
     }
 
-    pub fn with_ip_address(mut self, value: Option<String>) -> Self {
-        self.ip_address = value;
+    pub fn with_ip_address(mut self, value: String) -> Self {
+        self.ip_address = Some(value);
         self
     }
 
-    pub fn with_country(mut self, value: Option<String>) -> Self {
-        self.country = value;
+    pub fn with_country(mut self, value: String) -> Self {
+        self.country = Some(value);
         self
     }
 
-    pub fn with_created(mut self, value: Option<super::common::DropboxTimestamp>) -> Self {
-        self.created = value;
+    pub fn with_created(mut self, value: super::common::DropboxTimestamp) -> Self {
+        self.created = Some(value);
         self
     }
 
-    pub fn with_updated(mut self, value: Option<super::common::DropboxTimestamp>) -> Self {
-        self.updated = value;
+    pub fn with_updated(mut self, value: super::common::DropboxTimestamp) -> Self {
+        self.updated = Some(value);
         self
     }
 
-    pub fn with_expires(mut self, value: Option<super::common::DropboxTimestamp>) -> Self {
-        self.expires = value;
+    pub fn with_expires(mut self, value: super::common::DropboxTimestamp) -> Self {
+        self.expires = Some(value);
         self
     }
 }
@@ -1993,18 +1993,18 @@ impl ApiApp {
         }
     }
 
-    pub fn with_publisher(mut self, value: Option<String>) -> Self {
-        self.publisher = value;
+    pub fn with_publisher(mut self, value: String) -> Self {
+        self.publisher = Some(value);
         self
     }
 
-    pub fn with_publisher_url(mut self, value: Option<String>) -> Self {
-        self.publisher_url = value;
+    pub fn with_publisher_url(mut self, value: String) -> Self {
+        self.publisher_url = Some(value);
         self
     }
 
-    pub fn with_linked(mut self, value: Option<super::common::DropboxTimestamp>) -> Self {
-        self.linked = value;
+    pub fn with_linked(mut self, value: super::common::DropboxTimestamp) -> Self {
+        self.linked = Some(value);
         self
     }
 }
@@ -2584,13 +2584,13 @@ impl Default for DateRange {
 }
 
 impl DateRange {
-    pub fn with_start_date(mut self, value: Option<super::common::Date>) -> Self {
-        self.start_date = value;
+    pub fn with_start_date(mut self, value: super::common::Date) -> Self {
+        self.start_date = Some(value);
         self
     }
 
-    pub fn with_end_date(mut self, value: Option<super::common::Date>) -> Self {
-        self.end_date = value;
+    pub fn with_end_date(mut self, value: super::common::Date) -> Self {
+        self.end_date = Some(value);
         self
     }
 }
@@ -3047,23 +3047,23 @@ impl DesktopClientSession {
         }
     }
 
-    pub fn with_ip_address(mut self, value: Option<String>) -> Self {
-        self.ip_address = value;
+    pub fn with_ip_address(mut self, value: String) -> Self {
+        self.ip_address = Some(value);
         self
     }
 
-    pub fn with_country(mut self, value: Option<String>) -> Self {
-        self.country = value;
+    pub fn with_country(mut self, value: String) -> Self {
+        self.country = Some(value);
         self
     }
 
-    pub fn with_created(mut self, value: Option<super::common::DropboxTimestamp>) -> Self {
-        self.created = value;
+    pub fn with_created(mut self, value: super::common::DropboxTimestamp) -> Self {
+        self.created = Some(value);
         self
     }
 
-    pub fn with_updated(mut self, value: Option<super::common::DropboxTimestamp>) -> Self {
-        self.updated = value;
+    pub fn with_updated(mut self, value: super::common::DropboxTimestamp) -> Self {
+        self.updated = Some(value);
         self
     }
 }
@@ -3342,23 +3342,23 @@ impl DeviceSession {
         }
     }
 
-    pub fn with_ip_address(mut self, value: Option<String>) -> Self {
-        self.ip_address = value;
+    pub fn with_ip_address(mut self, value: String) -> Self {
+        self.ip_address = Some(value);
         self
     }
 
-    pub fn with_country(mut self, value: Option<String>) -> Self {
-        self.country = value;
+    pub fn with_country(mut self, value: String) -> Self {
+        self.country = Some(value);
         self
     }
 
-    pub fn with_created(mut self, value: Option<super::common::DropboxTimestamp>) -> Self {
-        self.created = value;
+    pub fn with_created(mut self, value: super::common::DropboxTimestamp) -> Self {
+        self.created = Some(value);
         self
     }
 
-    pub fn with_updated(mut self, value: Option<super::common::DropboxTimestamp>) -> Self {
-        self.updated = value;
+    pub fn with_updated(mut self, value: super::common::DropboxTimestamp) -> Self {
+        self.updated = Some(value);
         self
     }
 }
@@ -4100,8 +4100,8 @@ impl ExcludedUsersListResult {
         }
     }
 
-    pub fn with_cursor(mut self, value: Option<String>) -> Self {
-        self.cursor = value;
+    pub fn with_cursor(mut self, value: String) -> Self {
+        self.cursor = Some(value);
         self
     }
 }
@@ -4218,8 +4218,8 @@ impl Default for ExcludedUsersUpdateArg {
 }
 
 impl ExcludedUsersUpdateArg {
-    pub fn with_users(mut self, value: Option<Vec<UserSelectorArg>>) -> Self {
-        self.users = value;
+    pub fn with_users(mut self, value: Vec<UserSelectorArg>) -> Self {
+        self.users = Some(value);
         self
     }
 }
@@ -5826,19 +5826,16 @@ impl GroupCreateArg {
         self
     }
 
-    pub fn with_group_external_id(
-        mut self,
-        value: Option<super::team_common::GroupExternalId>,
-    ) -> Self {
-        self.group_external_id = value;
+    pub fn with_group_external_id(mut self, value: super::team_common::GroupExternalId) -> Self {
+        self.group_external_id = Some(value);
         self
     }
 
     pub fn with_group_management_type(
         mut self,
-        value: Option<super::team_common::GroupManagementType>,
+        value: super::team_common::GroupManagementType,
     ) -> Self {
-        self.group_management_type = value;
+        self.group_management_type = Some(value);
         self
     }
 }
@@ -6188,21 +6185,18 @@ impl GroupFullInfo {
         }
     }
 
-    pub fn with_group_external_id(
-        mut self,
-        value: Option<super::team_common::GroupExternalId>,
-    ) -> Self {
-        self.group_external_id = value;
+    pub fn with_group_external_id(mut self, value: super::team_common::GroupExternalId) -> Self {
+        self.group_external_id = Some(value);
         self
     }
 
-    pub fn with_member_count(mut self, value: Option<u32>) -> Self {
-        self.member_count = value;
+    pub fn with_member_count(mut self, value: u32) -> Self {
+        self.member_count = Some(value);
         self
     }
 
-    pub fn with_members(mut self, value: Option<Vec<GroupMemberInfo>>) -> Self {
-        self.members = value;
+    pub fn with_members(mut self, value: Vec<GroupMemberInfo>) -> Self {
+        self.members = Some(value);
         self
     }
 }
@@ -8023,24 +8017,24 @@ impl GroupUpdateArgs {
         self
     }
 
-    pub fn with_new_group_name(mut self, value: Option<String>) -> Self {
-        self.new_group_name = value;
+    pub fn with_new_group_name(mut self, value: String) -> Self {
+        self.new_group_name = Some(value);
         self
     }
 
     pub fn with_new_group_external_id(
         mut self,
-        value: Option<super::team_common::GroupExternalId>,
+        value: super::team_common::GroupExternalId,
     ) -> Self {
-        self.new_group_external_id = value;
+        self.new_group_external_id = Some(value);
         self
     }
 
     pub fn with_new_group_management_type(
         mut self,
-        value: Option<super::team_common::GroupManagementType>,
+        value: super::team_common::GroupManagementType,
     ) -> Self {
-        self.new_group_management_type = value;
+        self.new_group_management_type = Some(value);
         self
     }
 }
@@ -9869,18 +9863,18 @@ impl LegalHoldPolicy {
         }
     }
 
-    pub fn with_description(mut self, value: Option<LegalHoldPolicyDescription>) -> Self {
-        self.description = value;
+    pub fn with_description(mut self, value: LegalHoldPolicyDescription) -> Self {
+        self.description = Some(value);
         self
     }
 
-    pub fn with_activation_time(mut self, value: Option<super::common::DropboxTimestamp>) -> Self {
-        self.activation_time = value;
+    pub fn with_activation_time(mut self, value: super::common::DropboxTimestamp) -> Self {
+        self.activation_time = Some(value);
         self
     }
 
-    pub fn with_end_date(mut self, value: Option<super::common::DropboxTimestamp>) -> Self {
-        self.end_date = value;
+    pub fn with_end_date(mut self, value: super::common::DropboxTimestamp) -> Self {
+        self.end_date = Some(value);
         self
     }
 }
@@ -10443,8 +10437,8 @@ impl LegalHoldsListHeldRevisionResult {
         }
     }
 
-    pub fn with_cursor(mut self, value: Option<ListHeldRevisionCursor>) -> Self {
-        self.cursor = value;
+    pub fn with_cursor(mut self, value: ListHeldRevisionCursor) -> Self {
+        self.cursor = Some(value);
         self
     }
 }
@@ -10650,8 +10644,8 @@ impl LegalHoldsListHeldRevisionsContinueArg {
         }
     }
 
-    pub fn with_cursor(mut self, value: Option<ListHeldRevisionCursor>) -> Self {
-        self.cursor = value;
+    pub fn with_cursor(mut self, value: ListHeldRevisionCursor) -> Self {
+        self.cursor = Some(value);
         self
     }
 }
@@ -11255,18 +11249,18 @@ impl LegalHoldsPolicyCreateArg {
         }
     }
 
-    pub fn with_description(mut self, value: Option<LegalHoldPolicyDescription>) -> Self {
-        self.description = value;
+    pub fn with_description(mut self, value: LegalHoldPolicyDescription) -> Self {
+        self.description = Some(value);
         self
     }
 
-    pub fn with_start_date(mut self, value: Option<super::common::DropboxTimestamp>) -> Self {
-        self.start_date = value;
+    pub fn with_start_date(mut self, value: super::common::DropboxTimestamp) -> Self {
+        self.start_date = Some(value);
         self
     }
 
-    pub fn with_end_date(mut self, value: Option<super::common::DropboxTimestamp>) -> Self {
-        self.end_date = value;
+    pub fn with_end_date(mut self, value: super::common::DropboxTimestamp) -> Self {
+        self.end_date = Some(value);
         self
     }
 }
@@ -11807,18 +11801,18 @@ impl LegalHoldsPolicyUpdateArg {
         }
     }
 
-    pub fn with_name(mut self, value: Option<LegalHoldPolicyName>) -> Self {
-        self.name = value;
+    pub fn with_name(mut self, value: LegalHoldPolicyName) -> Self {
+        self.name = Some(value);
         self
     }
 
-    pub fn with_description(mut self, value: Option<LegalHoldPolicyDescription>) -> Self {
-        self.description = value;
+    pub fn with_description(mut self, value: LegalHoldPolicyDescription) -> Self {
+        self.description = Some(value);
         self
     }
 
-    pub fn with_members(mut self, value: Option<Vec<super::team_common::TeamMemberId>>) -> Self {
-        self.members = value;
+    pub fn with_members(mut self, value: Vec<super::team_common::TeamMemberId>) -> Self {
+        self.members = Some(value);
         self
     }
 }
@@ -12587,21 +12581,18 @@ impl Default for ListMemberDevicesResult {
 }
 
 impl ListMemberDevicesResult {
-    pub fn with_active_web_sessions(mut self, value: Option<Vec<ActiveWebSession>>) -> Self {
-        self.active_web_sessions = value;
+    pub fn with_active_web_sessions(mut self, value: Vec<ActiveWebSession>) -> Self {
+        self.active_web_sessions = Some(value);
         self
     }
 
-    pub fn with_desktop_client_sessions(
-        mut self,
-        value: Option<Vec<DesktopClientSession>>,
-    ) -> Self {
-        self.desktop_client_sessions = value;
+    pub fn with_desktop_client_sessions(mut self, value: Vec<DesktopClientSession>) -> Self {
+        self.desktop_client_sessions = Some(value);
         self
     }
 
-    pub fn with_mobile_client_sessions(mut self, value: Option<Vec<MobileClientSession>>) -> Self {
-        self.mobile_client_sessions = value;
+    pub fn with_mobile_client_sessions(mut self, value: Vec<MobileClientSession>) -> Self {
+        self.mobile_client_sessions = Some(value);
         self
     }
 }
@@ -12710,8 +12701,8 @@ impl Default for ListMembersAppsArg {
 }
 
 impl ListMembersAppsArg {
-    pub fn with_cursor(mut self, value: Option<String>) -> Self {
-        self.cursor = value;
+    pub fn with_cursor(mut self, value: String) -> Self {
+        self.cursor = Some(value);
         self
     }
 }
@@ -12879,8 +12870,8 @@ impl ListMembersAppsResult {
         }
     }
 
-    pub fn with_cursor(mut self, value: Option<String>) -> Self {
-        self.cursor = value;
+    pub fn with_cursor(mut self, value: String) -> Self {
+        self.cursor = Some(value);
         self
     }
 }
@@ -13007,8 +12998,8 @@ impl Default for ListMembersDevicesArg {
 }
 
 impl ListMembersDevicesArg {
-    pub fn with_cursor(mut self, value: Option<String>) -> Self {
-        self.cursor = value;
+    pub fn with_cursor(mut self, value: String) -> Self {
+        self.cursor = Some(value);
         self
     }
 
@@ -13215,8 +13206,8 @@ impl ListMembersDevicesResult {
         }
     }
 
-    pub fn with_cursor(mut self, value: Option<String>) -> Self {
-        self.cursor = value;
+    pub fn with_cursor(mut self, value: String) -> Self {
+        self.cursor = Some(value);
         self
     }
 }
@@ -13336,8 +13327,8 @@ impl Default for ListTeamAppsArg {
 }
 
 impl ListTeamAppsArg {
-    pub fn with_cursor(mut self, value: Option<String>) -> Self {
-        self.cursor = value;
+    pub fn with_cursor(mut self, value: String) -> Self {
+        self.cursor = Some(value);
         self
     }
 }
@@ -13504,8 +13495,8 @@ impl ListTeamAppsResult {
         }
     }
 
-    pub fn with_cursor(mut self, value: Option<String>) -> Self {
-        self.cursor = value;
+    pub fn with_cursor(mut self, value: String) -> Self {
+        self.cursor = Some(value);
         self
     }
 }
@@ -13632,8 +13623,8 @@ impl Default for ListTeamDevicesArg {
 }
 
 impl ListTeamDevicesArg {
-    pub fn with_cursor(mut self, value: Option<String>) -> Self {
-        self.cursor = value;
+    pub fn with_cursor(mut self, value: String) -> Self {
+        self.cursor = Some(value);
         self
     }
 
@@ -13840,8 +13831,8 @@ impl ListTeamDevicesResult {
         }
     }
 
-    pub fn with_cursor(mut self, value: Option<String>) -> Self {
-        self.cursor = value;
+    pub fn with_cursor(mut self, value: String) -> Self {
+        self.cursor = Some(value);
         self
     }
 }
@@ -14079,29 +14070,23 @@ impl MemberAddArg {
         }
     }
 
-    pub fn with_member_given_name(
-        mut self,
-        value: Option<super::common::OptionalNamePart>,
-    ) -> Self {
-        self.member_given_name = value;
+    pub fn with_member_given_name(mut self, value: super::common::OptionalNamePart) -> Self {
+        self.member_given_name = Some(value);
         self
     }
 
-    pub fn with_member_surname(mut self, value: Option<super::common::OptionalNamePart>) -> Self {
-        self.member_surname = value;
+    pub fn with_member_surname(mut self, value: super::common::OptionalNamePart) -> Self {
+        self.member_surname = Some(value);
         self
     }
 
-    pub fn with_member_external_id(
-        mut self,
-        value: Option<super::team_common::MemberExternalId>,
-    ) -> Self {
-        self.member_external_id = value;
+    pub fn with_member_external_id(mut self, value: super::team_common::MemberExternalId) -> Self {
+        self.member_external_id = Some(value);
         self
     }
 
-    pub fn with_member_persistent_id(mut self, value: Option<String>) -> Self {
-        self.member_persistent_id = value;
+    pub fn with_member_persistent_id(mut self, value: String) -> Self {
+        self.member_persistent_id = Some(value);
         self
     }
 
@@ -14115,8 +14100,8 @@ impl MemberAddArg {
         self
     }
 
-    pub fn with_is_directory_restricted(mut self, value: Option<bool>) -> Self {
-        self.is_directory_restricted = value;
+    pub fn with_is_directory_restricted(mut self, value: bool) -> Self {
+        self.is_directory_restricted = Some(value);
         self
     }
 }
@@ -14515,18 +14500,18 @@ impl MemberDevices {
         }
     }
 
-    pub fn with_web_sessions(mut self, value: Option<Vec<ActiveWebSession>>) -> Self {
-        self.web_sessions = value;
+    pub fn with_web_sessions(mut self, value: Vec<ActiveWebSession>) -> Self {
+        self.web_sessions = Some(value);
         self
     }
 
-    pub fn with_desktop_clients(mut self, value: Option<Vec<DesktopClientSession>>) -> Self {
-        self.desktop_clients = value;
+    pub fn with_desktop_clients(mut self, value: Vec<DesktopClientSession>) -> Self {
+        self.desktop_clients = Some(value);
         self
     }
 
-    pub fn with_mobile_clients(mut self, value: Option<Vec<MobileClientSession>>) -> Self {
-        self.mobile_clients = value;
+    pub fn with_mobile_clients(mut self, value: Vec<MobileClientSession>) -> Self {
+        self.mobile_clients = Some(value);
         self
     }
 }
@@ -14807,51 +14792,51 @@ impl MemberProfile {
         }
     }
 
-    pub fn with_external_id(mut self, value: Option<String>) -> Self {
-        self.external_id = value;
+    pub fn with_external_id(mut self, value: String) -> Self {
+        self.external_id = Some(value);
         self
     }
 
-    pub fn with_account_id(mut self, value: Option<super::users_common::AccountId>) -> Self {
-        self.account_id = value;
+    pub fn with_account_id(mut self, value: super::users_common::AccountId) -> Self {
+        self.account_id = Some(value);
         self
     }
 
     pub fn with_secondary_emails(
         mut self,
-        value: Option<Vec<super::secondary_emails::SecondaryEmail>>,
+        value: Vec<super::secondary_emails::SecondaryEmail>,
     ) -> Self {
-        self.secondary_emails = value;
+        self.secondary_emails = Some(value);
         self
     }
 
-    pub fn with_invited_on(mut self, value: Option<super::common::DropboxTimestamp>) -> Self {
-        self.invited_on = value;
+    pub fn with_invited_on(mut self, value: super::common::DropboxTimestamp) -> Self {
+        self.invited_on = Some(value);
         self
     }
 
-    pub fn with_joined_on(mut self, value: Option<super::common::DropboxTimestamp>) -> Self {
-        self.joined_on = value;
+    pub fn with_joined_on(mut self, value: super::common::DropboxTimestamp) -> Self {
+        self.joined_on = Some(value);
         self
     }
 
-    pub fn with_suspended_on(mut self, value: Option<super::common::DropboxTimestamp>) -> Self {
-        self.suspended_on = value;
+    pub fn with_suspended_on(mut self, value: super::common::DropboxTimestamp) -> Self {
+        self.suspended_on = Some(value);
         self
     }
 
-    pub fn with_persistent_id(mut self, value: Option<String>) -> Self {
-        self.persistent_id = value;
+    pub fn with_persistent_id(mut self, value: String) -> Self {
+        self.persistent_id = Some(value);
         self
     }
 
-    pub fn with_is_directory_restricted(mut self, value: Option<bool>) -> Self {
-        self.is_directory_restricted = value;
+    pub fn with_is_directory_restricted(mut self, value: bool) -> Self {
+        self.is_directory_restricted = Some(value);
         self
     }
 
-    pub fn with_profile_photo_url(mut self, value: Option<String>) -> Self {
-        self.profile_photo_url = value;
+    pub fn with_profile_photo_url(mut self, value: String) -> Self {
+        self.profile_photo_url = Some(value);
         self
     }
 }
@@ -16989,13 +16974,13 @@ impl MembersRemoveArg {
         self
     }
 
-    pub fn with_transfer_dest_id(mut self, value: Option<UserSelectorArg>) -> Self {
-        self.transfer_dest_id = value;
+    pub fn with_transfer_dest_id(mut self, value: UserSelectorArg) -> Self {
+        self.transfer_dest_id = Some(value);
         self
     }
 
-    pub fn with_transfer_admin_id(mut self, value: Option<UserSelectorArg>) -> Self {
-        self.transfer_admin_id = value;
+    pub fn with_transfer_admin_id(mut self, value: UserSelectorArg) -> Self {
+        self.transfer_admin_id = Some(value);
         self
     }
 
@@ -17934,36 +17919,33 @@ impl MembersSetProfileArg {
         }
     }
 
-    pub fn with_new_email(mut self, value: Option<super::common::EmailAddress>) -> Self {
-        self.new_email = value;
+    pub fn with_new_email(mut self, value: super::common::EmailAddress) -> Self {
+        self.new_email = Some(value);
         self
     }
 
-    pub fn with_new_external_id(
-        mut self,
-        value: Option<super::team_common::MemberExternalId>,
-    ) -> Self {
-        self.new_external_id = value;
+    pub fn with_new_external_id(mut self, value: super::team_common::MemberExternalId) -> Self {
+        self.new_external_id = Some(value);
         self
     }
 
-    pub fn with_new_given_name(mut self, value: Option<super::common::OptionalNamePart>) -> Self {
-        self.new_given_name = value;
+    pub fn with_new_given_name(mut self, value: super::common::OptionalNamePart) -> Self {
+        self.new_given_name = Some(value);
         self
     }
 
-    pub fn with_new_surname(mut self, value: Option<super::common::OptionalNamePart>) -> Self {
-        self.new_surname = value;
+    pub fn with_new_surname(mut self, value: super::common::OptionalNamePart) -> Self {
+        self.new_surname = Some(value);
         self
     }
 
-    pub fn with_new_persistent_id(mut self, value: Option<String>) -> Self {
-        self.new_persistent_id = value;
+    pub fn with_new_persistent_id(mut self, value: String) -> Self {
+        self.new_persistent_id = Some(value);
         self
     }
 
-    pub fn with_new_is_directory_restricted(mut self, value: Option<bool>) -> Self {
-        self.new_is_directory_restricted = value;
+    pub fn with_new_is_directory_restricted(mut self, value: bool) -> Self {
+        self.new_is_directory_restricted = Some(value);
         self
     }
 }
@@ -19453,38 +19435,38 @@ impl MobileClientSession {
         }
     }
 
-    pub fn with_ip_address(mut self, value: Option<String>) -> Self {
-        self.ip_address = value;
+    pub fn with_ip_address(mut self, value: String) -> Self {
+        self.ip_address = Some(value);
         self
     }
 
-    pub fn with_country(mut self, value: Option<String>) -> Self {
-        self.country = value;
+    pub fn with_country(mut self, value: String) -> Self {
+        self.country = Some(value);
         self
     }
 
-    pub fn with_created(mut self, value: Option<super::common::DropboxTimestamp>) -> Self {
-        self.created = value;
+    pub fn with_created(mut self, value: super::common::DropboxTimestamp) -> Self {
+        self.created = Some(value);
         self
     }
 
-    pub fn with_updated(mut self, value: Option<super::common::DropboxTimestamp>) -> Self {
-        self.updated = value;
+    pub fn with_updated(mut self, value: super::common::DropboxTimestamp) -> Self {
+        self.updated = Some(value);
         self
     }
 
-    pub fn with_client_version(mut self, value: Option<String>) -> Self {
-        self.client_version = value;
+    pub fn with_client_version(mut self, value: String) -> Self {
+        self.client_version = Some(value);
         self
     }
 
-    pub fn with_os_version(mut self, value: Option<String>) -> Self {
-        self.os_version = value;
+    pub fn with_os_version(mut self, value: String) -> Self {
+        self.os_version = Some(value);
         self
     }
 
-    pub fn with_last_carrier(mut self, value: Option<String>) -> Self {
-        self.last_carrier = value;
+    pub fn with_last_carrier(mut self, value: String) -> Self {
+        self.last_carrier = Some(value);
         self
     }
 }
@@ -19682,8 +19664,8 @@ impl NamespaceMetadata {
         }
     }
 
-    pub fn with_team_member_id(mut self, value: Option<super::team_common::TeamMemberId>) -> Self {
-        self.team_member_id = value;
+    pub fn with_team_member_id(mut self, value: super::team_common::TeamMemberId) -> Self {
+        self.team_member_id = Some(value);
         self
     }
 }
@@ -20869,8 +20851,8 @@ impl RevokeDeviceSessionStatus {
         }
     }
 
-    pub fn with_error_type(mut self, value: Option<RevokeDeviceSessionError>) -> Self {
-        self.error_type = value;
+    pub fn with_error_type(mut self, value: RevokeDeviceSessionError) -> Self {
+        self.error_type = Some(value);
         self
     }
 }
@@ -21425,8 +21407,8 @@ impl RevokeLinkedAppStatus {
         }
     }
 
-    pub fn with_error_type(mut self, value: Option<RevokeLinkedAppError>) -> Self {
-        self.error_type = value;
+    pub fn with_error_type(mut self, value: RevokeLinkedAppError) -> Self {
+        self.error_type = Some(value);
         self
     }
 }
@@ -22356,8 +22338,8 @@ impl TeamFolderCreateArg {
         }
     }
 
-    pub fn with_sync_setting(mut self, value: Option<super::files::SyncSettingArg>) -> Self {
-        self.sync_setting = value;
+    pub fn with_sync_setting(mut self, value: super::files::SyncSettingArg) -> Self {
+        self.sync_setting = Some(value);
         self
     }
 }
@@ -24039,16 +24021,16 @@ impl TeamFolderUpdateSyncSettingsArg {
         }
     }
 
-    pub fn with_sync_setting(mut self, value: Option<super::files::SyncSettingArg>) -> Self {
-        self.sync_setting = value;
+    pub fn with_sync_setting(mut self, value: super::files::SyncSettingArg) -> Self {
+        self.sync_setting = Some(value);
         self
     }
 
     pub fn with_content_sync_settings(
         mut self,
-        value: Option<Vec<super::files::ContentSyncSettingArg>>,
+        value: Vec<super::files::ContentSyncSettingArg>,
     ) -> Self {
-        self.content_sync_settings = value;
+        self.content_sync_settings = Some(value);
         self
     }
 }
@@ -24595,51 +24577,51 @@ impl TeamMemberProfile {
         }
     }
 
-    pub fn with_external_id(mut self, value: Option<String>) -> Self {
-        self.external_id = value;
+    pub fn with_external_id(mut self, value: String) -> Self {
+        self.external_id = Some(value);
         self
     }
 
-    pub fn with_account_id(mut self, value: Option<super::users_common::AccountId>) -> Self {
-        self.account_id = value;
+    pub fn with_account_id(mut self, value: super::users_common::AccountId) -> Self {
+        self.account_id = Some(value);
         self
     }
 
     pub fn with_secondary_emails(
         mut self,
-        value: Option<Vec<super::secondary_emails::SecondaryEmail>>,
+        value: Vec<super::secondary_emails::SecondaryEmail>,
     ) -> Self {
-        self.secondary_emails = value;
+        self.secondary_emails = Some(value);
         self
     }
 
-    pub fn with_invited_on(mut self, value: Option<super::common::DropboxTimestamp>) -> Self {
-        self.invited_on = value;
+    pub fn with_invited_on(mut self, value: super::common::DropboxTimestamp) -> Self {
+        self.invited_on = Some(value);
         self
     }
 
-    pub fn with_joined_on(mut self, value: Option<super::common::DropboxTimestamp>) -> Self {
-        self.joined_on = value;
+    pub fn with_joined_on(mut self, value: super::common::DropboxTimestamp) -> Self {
+        self.joined_on = Some(value);
         self
     }
 
-    pub fn with_suspended_on(mut self, value: Option<super::common::DropboxTimestamp>) -> Self {
-        self.suspended_on = value;
+    pub fn with_suspended_on(mut self, value: super::common::DropboxTimestamp) -> Self {
+        self.suspended_on = Some(value);
         self
     }
 
-    pub fn with_persistent_id(mut self, value: Option<String>) -> Self {
-        self.persistent_id = value;
+    pub fn with_persistent_id(mut self, value: String) -> Self {
+        self.persistent_id = Some(value);
         self
     }
 
-    pub fn with_is_directory_restricted(mut self, value: Option<bool>) -> Self {
-        self.is_directory_restricted = value;
+    pub fn with_is_directory_restricted(mut self, value: bool) -> Self {
+        self.is_directory_restricted = Some(value);
         self
     }
 
-    pub fn with_profile_photo_url(mut self, value: Option<String>) -> Self {
-        self.profile_photo_url = value;
+    pub fn with_profile_photo_url(mut self, value: String) -> Self {
+        self.profile_photo_url = Some(value);
         self
     }
 }
@@ -26044,8 +26026,8 @@ impl UserCustomQuotaResult {
         }
     }
 
-    pub fn with_quota_gb(mut self, value: Option<UserQuota>) -> Self {
-        self.quota_gb = value;
+    pub fn with_quota_gb(mut self, value: UserQuota) -> Self {
+        self.quota_gb = Some(value);
         self
     }
 }

--- a/src/generated/team_common.rs
+++ b/src/generated/team_common.rs
@@ -127,13 +127,13 @@ impl GroupSummary {
         }
     }
 
-    pub fn with_group_external_id(mut self, value: Option<GroupExternalId>) -> Self {
-        self.group_external_id = value;
+    pub fn with_group_external_id(mut self, value: GroupExternalId) -> Self {
+        self.group_external_id = Some(value);
         self
     }
 
-    pub fn with_member_count(mut self, value: Option<u32>) -> Self {
-        self.member_count = value;
+    pub fn with_member_count(mut self, value: u32) -> Self {
+        self.member_count = Some(value);
         self
     }
 }
@@ -432,13 +432,13 @@ impl Default for TimeRange {
 }
 
 impl TimeRange {
-    pub fn with_start_time(mut self, value: Option<super::common::DropboxTimestamp>) -> Self {
-        self.start_time = value;
+    pub fn with_start_time(mut self, value: super::common::DropboxTimestamp) -> Self {
+        self.start_time = Some(value);
         self
     }
 
-    pub fn with_end_time(mut self, value: Option<super::common::DropboxTimestamp>) -> Self {
-        self.end_time = value;
+    pub fn with_end_time(mut self, value: super::common::DropboxTimestamp) -> Self {
+        self.end_time = Some(value);
         self
     }
 }

--- a/src/generated/team_common.rs
+++ b/src/generated/team_common.rs
@@ -136,7 +136,6 @@ impl GroupSummary {
         self.member_count = value;
         self
     }
-
 }
 
 const GROUP_SUMMARY_FIELDS: &[&str] = &["group_name",
@@ -429,6 +428,18 @@ impl Default for TimeRange {
             start_time: None,
             end_time: None,
         }
+    }
+}
+
+impl TimeRange {
+    pub fn with_start_time(mut self, value: Option<super::common::DropboxTimestamp>) -> Self {
+        self.start_time = value;
+        self
+    }
+
+    pub fn with_end_time(mut self, value: Option<super::common::DropboxTimestamp>) -> Self {
+        self.end_time = value;
+        self
     }
 }
 

--- a/src/generated/team_policies.rs
+++ b/src/generated/team_policies.rs
@@ -1755,7 +1755,6 @@ impl TeamMemberPolicies {
             suggest_members_policy,
         }
     }
-
 }
 
 const TEAM_MEMBER_POLICIES_FIELDS: &[&str] = &["sharing",
@@ -1886,7 +1885,6 @@ impl TeamSharingPolicies {
             shared_link_create_policy,
         }
     }
-
 }
 
 const TEAM_SHARING_POLICIES_FIELDS: &[&str] = &["shared_folder_member_policy",

--- a/src/generated/users.rs
+++ b/src/generated/users.rs
@@ -116,8 +116,8 @@ impl Account {
         }
     }
 
-    pub fn with_profile_photo_url(mut self, value: Option<String>) -> Self {
-        self.profile_photo_url = value;
+    pub fn with_profile_photo_url(mut self, value: String) -> Self {
+        self.profile_photo_url = Some(value);
         self
     }
 }
@@ -292,13 +292,13 @@ impl BasicAccount {
         }
     }
 
-    pub fn with_profile_photo_url(mut self, value: Option<String>) -> Self {
-        self.profile_photo_url = value;
+    pub fn with_profile_photo_url(mut self, value: String) -> Self {
+        self.profile_photo_url = Some(value);
         self
     }
 
-    pub fn with_team_member_id(mut self, value: Option<String>) -> Self {
-        self.team_member_id = value;
+    pub fn with_team_member_id(mut self, value: String) -> Self {
+        self.team_member_id = Some(value);
         self
     }
 }
@@ -581,23 +581,23 @@ impl FullAccount {
         }
     }
 
-    pub fn with_profile_photo_url(mut self, value: Option<String>) -> Self {
-        self.profile_photo_url = value;
+    pub fn with_profile_photo_url(mut self, value: String) -> Self {
+        self.profile_photo_url = Some(value);
         self
     }
 
-    pub fn with_country(mut self, value: Option<String>) -> Self {
-        self.country = value;
+    pub fn with_country(mut self, value: String) -> Self {
+        self.country = Some(value);
         self
     }
 
-    pub fn with_team(mut self, value: Option<FullTeam>) -> Self {
-        self.team = value;
+    pub fn with_team(mut self, value: FullTeam) -> Self {
+        self.team = Some(value);
         self
     }
 
-    pub fn with_team_member_id(mut self, value: Option<String>) -> Self {
-        self.team_member_id = value;
+    pub fn with_team_member_id(mut self, value: String) -> Self {
+        self.team_member_id = Some(value);
         self
     }
 }

--- a/src/generated/users.rs
+++ b/src/generated/users.rs
@@ -120,7 +120,6 @@ impl Account {
         self.profile_photo_url = value;
         self
     }
-
 }
 
 const ACCOUNT_FIELDS: &[&str] = &["account_id",
@@ -302,7 +301,6 @@ impl BasicAccount {
         self.team_member_id = value;
         self
     }
-
 }
 
 const BASIC_ACCOUNT_FIELDS: &[&str] = &["account_id",
@@ -602,7 +600,6 @@ impl FullAccount {
         self.team_member_id = value;
         self
     }
-
 }
 
 const FULL_ACCOUNT_FIELDS: &[&str] = &["account_id",
@@ -837,7 +834,6 @@ impl FullTeam {
             office_addin_policy,
         }
     }
-
 }
 
 const FULL_TEAM_FIELDS: &[&str] = &["id",
@@ -957,7 +953,6 @@ impl GetAccountArg {
             account_id,
         }
     }
-
 }
 
 const GET_ACCOUNT_ARG_FIELDS: &[&str] = &["account_id"];
@@ -1047,7 +1042,6 @@ impl GetAccountBatchArg {
             account_ids,
         }
     }
-
 }
 
 const GET_ACCOUNT_BATCH_ARG_FIELDS: &[&str] = &["account_ids"];
@@ -1282,7 +1276,6 @@ impl IndividualSpaceAllocation {
             allocated,
         }
     }
-
 }
 
 const INDIVIDUAL_SPACE_ALLOCATION_FIELDS: &[&str] = &["allocated"];
@@ -1392,7 +1385,6 @@ impl Name {
             abbreviated_name,
         }
     }
-
 }
 
 const NAME_FIELDS: &[&str] = &["given_name",
@@ -1660,7 +1652,6 @@ impl SpaceUsage {
             allocation,
         }
     }
-
 }
 
 const SPACE_USAGE_FIELDS: &[&str] = &["used",
@@ -1764,7 +1755,6 @@ impl Team {
             name,
         }
     }
-
 }
 
 const TEAM_FIELDS: &[&str] = &["id",
@@ -1883,7 +1873,6 @@ impl TeamSpaceAllocation {
             user_within_team_space_used_cached,
         }
     }
-
 }
 
 const TEAM_SPACE_ALLOCATION_FIELDS: &[&str] = &["used",
@@ -2164,7 +2153,6 @@ impl UserFeaturesGetValuesBatchArg {
             features,
         }
     }
-
 }
 
 const USER_FEATURES_GET_VALUES_BATCH_ARG_FIELDS: &[&str] = &["features"];
@@ -2324,7 +2312,6 @@ impl UserFeaturesGetValuesBatchResult {
             values,
         }
     }
-
 }
 
 const USER_FEATURES_GET_VALUES_BATCH_RESULT_FIELDS: &[&str] = &["values"];

--- a/tests/list_folder_recursive.rs
+++ b/tests/list_folder_recursive.rs
@@ -51,7 +51,7 @@ fn list_folder_recursive() {
         client.as_ref(),
         &files::ListFolderArg::new(FOLDER.to_owned())
             .with_recursive(true)
-            .with_limit(Some(10)))
+            .with_limit(10))
     {
         Ok(Ok(files::ListFolderResult { entries, cursor, has_more })) => {
             println!("{} entries", entries.len());


### PR DESCRIPTION
This concerns builder methods on structs, the `fn with_fieldname(mut self, value: ...) -> Self` methods that let you change a field, and can be chained together as an expression.

Two changes:
1. Structs which have no required fields, but only optional fields, were not having any builder methods emitted at all, because the logic to skip emitting a constructor skipped the whole `impl` block. This affects a relatively low number of structs and is completely backwards compatible, as it's only adding methods.
2. Change builder methods for optional fields (i.e. whose type is `Option<T>`) to take the value type `T` as an argument directly. The rationale for this change is that optional fields always have `None` as their default value, so there's practically no reason to call builder methods to explicitly set `None` as a value. Making users wrap the value in `Some(...)` is just line noise and adds no value. This is a backwards-incompatible change, but all callers have to do is remove the `Some(...)` from around the value.

## **Checklist**

**General Contributing**
<!-- Change [ ] to [x] if you have: -->
- [x] Have you read the Code of Conduct and signed the [CLA](https://opensource.dropbox.com/cla/)?

**Validation**
<!-- Describe which tests cover the changes you've made, and any additional manual validation you
     did to ensure the correctness of this change. Does this change warrant addition of new tests?
     Does this change have performance implications? Etc. -->
tests pass, clippy is happy