### PR TITLE
derive Clone and PartialEq for every type

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -6,6 +6,8 @@ xxxx-yy-zz
   variants may exist. This is because Stone explicitly reserves the right to add new fields and
   variants unless the type is a `union_closed`, so adding this attribute means future updates won't
   break existing code.
+* All structs and enums now implement the `PartialEq` and `Clone` traits, in addition to `Debug`
+  which was already implemented.
 * Renamed the `_Unknown` catch-all enum variant to `Other` in all cases. Going along with the above,
   your match statement should always have an `Other | _ => { ... }` case at the end. `Other`
   protects you against server-side changes, whereas `_` protects you against client-side code

--- a/generator/rust.stoneg.py
+++ b/generator/rust.stoneg.py
@@ -5,6 +5,9 @@ from stone import ir
 from stone.backends.helpers import split_words
 
 
+DERIVE_TRAITS = u'Debug, Clone, PartialEq'
+
+
 def fmt_shouting_snake(name):
     return '_'.join([word.upper() for word in split_words(name)])
 
@@ -89,7 +92,7 @@ class RustBackend(RustHelperBackend):
     def _emit_struct(self, struct):
         struct_name = self.struct_name(struct)
         self._emit_doc(struct.doc)
-        self.emit(u'#[derive(Debug)]')
+        self.emit(u'#[derive({})]'.format(DERIVE_TRAITS))
         self.emit(u'#[non_exhaustive] // structs may have more fields added in the future.')
         with self.block(u'pub struct {}'.format(struct_name)):
             for field in struct.all_fields:
@@ -113,7 +116,7 @@ class RustBackend(RustHelperBackend):
     def _emit_polymorphic_struct(self, struct):
         enum_name = self.enum_name(struct)
         self._emit_doc(struct.doc)
-        self.emit(u'#[derive(Debug)]')
+        self.emit(u'#[derive({})]'.format(DERIVE_TRAITS))
         if struct.is_catch_all():
             self.emit(u'#[non_exhaustive] // variants may be added in the future')
         with self.block(u'pub enum {}'.format(enum_name)):
@@ -130,7 +133,7 @@ class RustBackend(RustHelperBackend):
     def _emit_union(self, union):
         enum_name = self.enum_name(union)
         self._emit_doc(union.doc)
-        self.emit(u'#[derive(Debug)]')
+        self.emit(u'#[derive({})]'.format(DERIVE_TRAITS))
         if not union.closed:
             self.emit(u'#[non_exhaustive] // variants may be added in the future')
         with self.block(u'pub enum {}'.format(enum_name)):

--- a/generator/test.stoneg.py
+++ b/generator/test.stoneg.py
@@ -130,6 +130,7 @@ class TestBackend(RustHelperBackend):
                         .format(ns_name,
                                 self.struct_name(typ)))
                 test_value.emit_asserts(self, 'x')
+                self.emit(u'assert_eq!(x, x.clone());')
 
                 if test_value.is_serializable():
                     # now serialize it back to JSON, deserialize it again, and
@@ -143,6 +144,7 @@ class TestBackend(RustHelperBackend):
                     if typ.all_fields:
                         self.emit(u'let x2 = {};'.format(de))
                         test_value.emit_asserts(self, 'x2')
+                        self.emit(u'assert_eq!(x, x2);')
                     else:
                         self.emit(u'{};'.format(de))
                 else:

--- a/src/generated/account.rs
+++ b/src/generated/account.rs
@@ -21,7 +21,7 @@ pub fn set_profile_photo(
         None)
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 #[non_exhaustive] // variants may be added in the future
 pub enum PhotoSourceArg {
     /// Image data in base64-encoded bytes.
@@ -84,7 +84,7 @@ impl ::serde::ser::Serialize for PhotoSourceArg {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 #[non_exhaustive] // structs may have more fields added in the future.
 pub struct SetProfilePhotoArg {
     /// Image to set as the user's new profile photo.
@@ -174,7 +174,7 @@ impl ::serde::ser::Serialize for SetProfilePhotoArg {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 #[non_exhaustive] // variants may be added in the future
 pub enum SetProfilePhotoError {
     /// File cannot be set as profile photo.
@@ -297,7 +297,7 @@ impl ::std::fmt::Display for SetProfilePhotoError {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 #[non_exhaustive] // structs may have more fields added in the future.
 pub struct SetProfilePhotoResult {
     /// URL for the photo representing the user, if one is set.

--- a/src/generated/auth.rs
+++ b/src/generated/auth.rs
@@ -35,7 +35,7 @@ pub fn token_revoke(
 }
 
 /// Error occurred because the account doesn't have permission to access the resource.
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 #[non_exhaustive] // variants may be added in the future
 pub enum AccessError {
     /// Current account type cannot access the resource.
@@ -128,7 +128,7 @@ impl ::std::fmt::Display for AccessError {
 }
 
 /// Errors occurred during authentication.
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 #[non_exhaustive] // variants may be added in the future
 pub enum AuthError {
     /// The access token is invalid.
@@ -275,7 +275,7 @@ impl ::std::fmt::Display for AuthError {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 #[non_exhaustive] // variants may be added in the future
 pub enum InvalidAccountTypeError {
     /// Current account type doesn't have permission to access this route endpoint.
@@ -359,7 +359,7 @@ impl ::std::fmt::Display for InvalidAccountTypeError {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 #[non_exhaustive] // variants may be added in the future
 pub enum PaperAccessError {
     /// Paper is disabled.
@@ -444,7 +444,7 @@ impl ::std::fmt::Display for PaperAccessError {
 }
 
 /// Error occurred because the app is being rate limited.
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 #[non_exhaustive] // structs may have more fields added in the future.
 pub struct RateLimitError {
     /// The reason why the app is being rate limited.
@@ -552,7 +552,7 @@ impl ::serde::ser::Serialize for RateLimitError {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 #[non_exhaustive] // variants may be added in the future
 pub enum RateLimitReason {
     /// You are making too many requests in the past few minutes.
@@ -624,7 +624,7 @@ impl ::serde::ser::Serialize for RateLimitReason {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 #[non_exhaustive] // structs may have more fields added in the future.
 pub struct TokenFromOAuth1Arg {
     /// The supplied OAuth 1.0 access token.
@@ -727,7 +727,7 @@ impl ::serde::ser::Serialize for TokenFromOAuth1Arg {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 #[non_exhaustive] // variants may be added in the future
 pub enum TokenFromOAuth1Error {
     /// Part or all of the OAuth 1.0 access token info is invalid.
@@ -811,7 +811,7 @@ impl ::std::fmt::Display for TokenFromOAuth1Error {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 #[non_exhaustive] // structs may have more fields added in the future.
 pub struct TokenFromOAuth1Result {
     /// The OAuth 2.0 token generated from the supplied OAuth 1.0 token.
@@ -901,7 +901,7 @@ impl ::serde::ser::Serialize for TokenFromOAuth1Result {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 #[non_exhaustive] // structs may have more fields added in the future.
 pub struct TokenScopeError {
     /// The required scope to access the route.

--- a/src/generated/check.rs
+++ b/src/generated/check.rs
@@ -43,7 +43,7 @@ pub fn user(
 }
 
 /// EchoArg contains the arguments to be sent to the Dropbox servers.
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 #[non_exhaustive] // structs may have more fields added in the future.
 pub struct EchoArg {
     /// The string that you'd like to be echoed back to you.
@@ -130,7 +130,7 @@ impl ::serde::ser::Serialize for EchoArg {
 }
 
 /// EchoResult contains the result returned from the Dropbox servers.
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 #[non_exhaustive] // structs may have more fields added in the future.
 pub struct EchoResult {
     /// If everything worked correctly, this would be the same as query.

--- a/src/generated/common.rs
+++ b/src/generated/common.rs
@@ -19,7 +19,7 @@ pub type OptionalNamePart = String;
 pub type SessionId = String;
 pub type SharedFolderId = NamespaceId;
 
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 #[non_exhaustive] // variants may be added in the future
 pub enum PathRoot {
     /// Paths are relative to the authenticating user's home namespace, whether or not that user
@@ -117,7 +117,7 @@ impl ::serde::ser::Serialize for PathRoot {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 #[non_exhaustive] // variants may be added in the future
 pub enum PathRootError {
     /// The root namespace id in Dropbox-API-Path-Root header is not valid. The value of this error
@@ -207,7 +207,7 @@ impl ::std::fmt::Display for PathRootError {
 }
 
 /// Information about current user's root.
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 #[non_exhaustive] // variants may be added in the future
 pub enum RootInfo {
     Team(TeamRootInfo),
@@ -274,7 +274,7 @@ impl ::serde::ser::Serialize for RootInfo {
 }
 
 /// Root info when user is member of a team with a separate root namespace ID.
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 #[non_exhaustive] // structs may have more fields added in the future.
 pub struct TeamRootInfo {
     /// The namespace ID for user's root namespace. It will be the namespace ID of the shared team
@@ -398,7 +398,7 @@ impl ::serde::ser::Serialize for TeamRootInfo {
 
 /// Root info when user is not member of a team or the user is a member of a team and the team does
 /// not have a separate root namespace.
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 #[non_exhaustive] // structs may have more fields added in the future.
 pub struct UserRootInfo {
     /// The namespace ID for user's root namespace. It will be the namespace ID of the shared team

--- a/src/generated/contacts.rs
+++ b/src/generated/contacts.rs
@@ -35,7 +35,7 @@ pub fn delete_manual_contacts_batch(
         None)
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 #[non_exhaustive] // structs may have more fields added in the future.
 pub struct DeleteManualContactsArg {
     /// List of manually added contacts to be deleted.
@@ -125,7 +125,7 @@ impl ::serde::ser::Serialize for DeleteManualContactsArg {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 #[non_exhaustive] // variants may be added in the future
 pub enum DeleteManualContactsError {
     /// Can't delete contacts from this list. Make sure the list only has manually added contacts.

--- a/src/generated/dbx_async.rs
+++ b/src/generated/dbx_async.rs
@@ -11,7 +11,7 @@ pub type AsyncJobId = String;
 
 /// Result returned by methods that may either launch an asynchronous job or complete synchronously.
 /// Upon synchronous completion of the job, no additional information is returned.
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 pub enum LaunchEmptyResult {
     /// This response indicates that the processing is asynchronous. The string is an id that can be
     /// used to obtain the status of the asynchronous job.
@@ -83,7 +83,7 @@ impl ::serde::ser::Serialize for LaunchEmptyResult {
 /// asynchronous job, or complete the request synchronously, can use this union by extending it, and
 /// adding a 'complete' field with the type of the synchronous response. See
 /// [`LaunchEmptyResult`](LaunchEmptyResult) for an example.
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 pub enum LaunchResultBase {
     /// This response indicates that the processing is asynchronous. The string is an id that can be
     /// used to obtain the status of the asynchronous job.
@@ -139,7 +139,7 @@ impl ::serde::ser::Serialize for LaunchResultBase {
 }
 
 /// Arguments for methods that poll the status of an asynchronous job.
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 #[non_exhaustive] // structs may have more fields added in the future.
 pub struct PollArg {
     /// Id of the asynchronous job. This is the value of a response returned from the method that
@@ -232,7 +232,7 @@ impl ::serde::ser::Serialize for PollArg {
 
 /// Result returned by methods that poll for the status of an asynchronous job. Upon completion of
 /// the job, no additional information is returned.
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 pub enum PollEmptyResult {
     /// The asynchronous job is still in progress.
     InProgress,
@@ -296,7 +296,7 @@ impl ::serde::ser::Serialize for PollEmptyResult {
 }
 
 /// Error returned by methods for polling the status of asynchronous job.
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 #[non_exhaustive] // variants may be added in the future
 pub enum PollError {
     /// The job ID is invalid.
@@ -384,7 +384,7 @@ impl ::std::fmt::Display for PollError {
 /// Result returned by methods that poll for the status of an asynchronous job. Unions that extend
 /// this union should add a 'complete' field with a type of the information returned upon job
 /// completion. See [`PollEmptyResult`](PollEmptyResult) for an example.
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 pub enum PollResultBase {
     /// The asynchronous job is still in progress.
     InProgress,

--- a/src/generated/file_properties.rs
+++ b/src/generated/file_properties.rs
@@ -295,7 +295,7 @@ pub fn templates_update_for_user(
         None)
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 #[non_exhaustive] // structs may have more fields added in the future.
 pub struct AddPropertiesArg {
     /// A unique identifier for the file or folder.
@@ -399,7 +399,7 @@ impl ::serde::ser::Serialize for AddPropertiesArg {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 #[non_exhaustive] // variants may be added in the future
 pub enum AddPropertiesError {
     /// Template does not exist for the given identifier.
@@ -568,7 +568,7 @@ impl ::std::fmt::Display for AddPropertiesError {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 #[non_exhaustive] // structs may have more fields added in the future.
 pub struct AddTemplateArg {
     /// Display name for the template. Template names can be up to 256 bytes.
@@ -685,7 +685,7 @@ impl ::serde::ser::Serialize for AddTemplateArg {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 #[non_exhaustive] // structs may have more fields added in the future.
 pub struct AddTemplateResult {
     /// An identifier for template added by  See
@@ -777,7 +777,7 @@ impl ::serde::ser::Serialize for AddTemplateResult {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 #[non_exhaustive] // structs may have more fields added in the future.
 pub struct GetTemplateArg {
     /// An identifier for template added by route  See
@@ -869,7 +869,7 @@ impl ::serde::ser::Serialize for GetTemplateArg {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 #[non_exhaustive] // structs may have more fields added in the future.
 pub struct GetTemplateResult {
     /// Display name for the template. Template names can be up to 256 bytes.
@@ -986,7 +986,7 @@ impl ::serde::ser::Serialize for GetTemplateResult {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 #[non_exhaustive] // variants may be added in the future
 pub enum InvalidPropertyGroupError {
     /// Template does not exist for the given identifier.
@@ -1142,7 +1142,7 @@ impl ::std::fmt::Display for InvalidPropertyGroupError {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 #[non_exhaustive] // structs may have more fields added in the future.
 pub struct ListTemplateResult {
     /// List of identifiers for templates added by  See
@@ -1235,7 +1235,7 @@ impl ::serde::ser::Serialize for ListTemplateResult {
 }
 
 /// Logical operator to join search queries together.
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 #[non_exhaustive] // variants may be added in the future
 pub enum LogicalOperator {
     /// Append a query with an "or" operator.
@@ -1294,7 +1294,7 @@ impl ::serde::ser::Serialize for LogicalOperator {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 #[non_exhaustive] // variants may be added in the future
 pub enum LookUpPropertiesError {
     /// No property group was found.
@@ -1365,7 +1365,7 @@ impl ::std::fmt::Display for LookUpPropertiesError {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 #[non_exhaustive] // variants may be added in the future
 pub enum LookupError {
     MalformedPath(String),
@@ -1492,7 +1492,7 @@ impl ::std::fmt::Display for LookupError {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 #[non_exhaustive] // variants may be added in the future
 pub enum ModifyTemplateError {
     /// Template does not exist for the given identifier.
@@ -1633,7 +1633,7 @@ impl ::std::fmt::Display for ModifyTemplateError {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 #[non_exhaustive] // structs may have more fields added in the future.
 pub struct OverwritePropertyGroupArg {
     /// A unique identifier for the file or folder.
@@ -1737,7 +1737,7 @@ impl ::serde::ser::Serialize for OverwritePropertyGroupArg {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 #[non_exhaustive] // variants may be added in the future
 pub enum PropertiesError {
     /// Template does not exist for the given identifier.
@@ -1854,7 +1854,7 @@ impl ::std::fmt::Display for PropertiesError {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 #[non_exhaustive] // structs may have more fields added in the future.
 pub struct PropertiesSearchArg {
     /// Queries to search.
@@ -1962,7 +1962,7 @@ impl ::serde::ser::Serialize for PropertiesSearchArg {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 #[non_exhaustive] // structs may have more fields added in the future.
 pub struct PropertiesSearchContinueArg {
     /// The cursor returned by your last call to [`properties_search()`](properties_search) or
@@ -2053,7 +2053,7 @@ impl ::serde::ser::Serialize for PropertiesSearchContinueArg {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 #[non_exhaustive] // variants may be added in the future
 pub enum PropertiesSearchContinueError {
     /// Indicates that the cursor has been invalidated. Call
@@ -2125,7 +2125,7 @@ impl ::std::fmt::Display for PropertiesSearchContinueError {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 #[non_exhaustive] // variants may be added in the future
 pub enum PropertiesSearchError {
     PropertyGroupLookup(LookUpPropertiesError),
@@ -2199,7 +2199,7 @@ impl ::std::fmt::Display for PropertiesSearchError {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 #[non_exhaustive] // structs may have more fields added in the future.
 pub struct PropertiesSearchMatch {
     /// The ID for the matched file or folder.
@@ -2333,7 +2333,7 @@ impl ::serde::ser::Serialize for PropertiesSearchMatch {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 #[non_exhaustive] // variants may be added in the future
 pub enum PropertiesSearchMode {
     /// Search for a value associated with this field name.
@@ -2396,7 +2396,7 @@ impl ::serde::ser::Serialize for PropertiesSearchMode {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 #[non_exhaustive] // structs may have more fields added in the future.
 pub struct PropertiesSearchQuery {
     /// The property field value for which to search across templates.
@@ -2517,7 +2517,7 @@ impl ::serde::ser::Serialize for PropertiesSearchQuery {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 #[non_exhaustive] // structs may have more fields added in the future.
 pub struct PropertiesSearchResult {
     /// A list (possibly empty) of matches for the query.
@@ -2628,7 +2628,7 @@ impl ::serde::ser::Serialize for PropertiesSearchResult {
 
 /// Raw key/value data to be associated with a Dropbox file. Property fields are added to Dropbox
 /// files as a [`PropertyGroup`](PropertyGroup).
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 #[non_exhaustive] // structs may have more fields added in the future.
 pub struct PropertyField {
     /// Key of the property field associated with a file and template. Keys can be up to 256 bytes.
@@ -2734,7 +2734,7 @@ impl ::serde::ser::Serialize for PropertyField {
 
 /// Defines how a single property field may be structured. Used exclusively by
 /// [`PropertyGroupTemplate`](PropertyGroupTemplate).
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 #[non_exhaustive] // structs may have more fields added in the future.
 pub struct PropertyFieldTemplate {
     /// Key of the property field being described. Property field keys can be up to 256 bytes.
@@ -2855,7 +2855,7 @@ impl ::serde::ser::Serialize for PropertyFieldTemplate {
 /// [`PropertyGroupTemplate`](PropertyGroupTemplate). Properties are always added to a Dropbox file
 /// as a [`PropertyGroup`](PropertyGroup). The possible key names and value types in this group are
 /// defined by the corresponding [`PropertyGroupTemplate`](PropertyGroupTemplate).
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 #[non_exhaustive] // structs may have more fields added in the future.
 pub struct PropertyGroup {
     /// A unique identifier for the associated template.
@@ -2960,7 +2960,7 @@ impl ::serde::ser::Serialize for PropertyGroup {
 }
 
 /// Defines how a property group may be structured.
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 #[non_exhaustive] // structs may have more fields added in the future.
 pub struct PropertyGroupTemplate {
     /// Display name for the template. Template names can be up to 256 bytes.
@@ -3077,7 +3077,7 @@ impl ::serde::ser::Serialize for PropertyGroupTemplate {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 #[non_exhaustive] // structs may have more fields added in the future.
 pub struct PropertyGroupUpdate {
     /// A unique identifier for a property template.
@@ -3205,7 +3205,7 @@ impl ::serde::ser::Serialize for PropertyGroupUpdate {
 }
 
 /// Data type of the given property field added.
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 #[non_exhaustive] // variants may be added in the future
 pub enum PropertyType {
     /// The associated property field will be of type string. Unicode is supported.
@@ -3264,7 +3264,7 @@ impl ::serde::ser::Serialize for PropertyType {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 #[non_exhaustive] // structs may have more fields added in the future.
 pub struct RemovePropertiesArg {
     /// A unique identifier for the file or folder.
@@ -3369,7 +3369,7 @@ impl ::serde::ser::Serialize for RemovePropertiesArg {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 #[non_exhaustive] // variants may be added in the future
 pub enum RemovePropertiesError {
     /// Template does not exist for the given identifier.
@@ -3502,7 +3502,7 @@ impl ::std::fmt::Display for RemovePropertiesError {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 #[non_exhaustive] // structs may have more fields added in the future.
 pub struct RemoveTemplateArg {
     /// An identifier for a template created by [`templates_add_for_user()`](templates_add_for_user)
@@ -3593,7 +3593,7 @@ impl ::serde::ser::Serialize for RemoveTemplateArg {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 #[non_exhaustive] // variants may be added in the future
 pub enum TemplateError {
     /// Template does not exist for the given identifier.
@@ -3681,7 +3681,7 @@ impl ::std::fmt::Display for TemplateError {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 #[non_exhaustive] // variants may be added in the future
 pub enum TemplateFilter {
     /// Only templates with an ID in the supplied list will be returned (a subset of templates will
@@ -3758,7 +3758,7 @@ impl ::serde::ser::Serialize for TemplateFilter {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 #[non_exhaustive] // variants may be added in the future
 pub enum TemplateFilterBase {
     /// Only templates with an ID in the supplied list will be returned (a subset of templates will
@@ -3822,7 +3822,7 @@ impl ::serde::ser::Serialize for TemplateFilterBase {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 #[non_exhaustive] // variants may be added in the future
 pub enum TemplateOwnerType {
     /// Template will be associated with a user.
@@ -3894,7 +3894,7 @@ impl ::serde::ser::Serialize for TemplateOwnerType {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 #[non_exhaustive] // structs may have more fields added in the future.
 pub struct UpdatePropertiesArg {
     /// A unique identifier for the file or folder.
@@ -3997,7 +3997,7 @@ impl ::serde::ser::Serialize for UpdatePropertiesArg {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 #[non_exhaustive] // variants may be added in the future
 pub enum UpdatePropertiesError {
     /// Template does not exist for the given identifier.
@@ -4169,7 +4169,7 @@ impl ::std::fmt::Display for UpdatePropertiesError {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 #[non_exhaustive] // structs may have more fields added in the future.
 pub struct UpdateTemplateArg {
     /// An identifier for template added by  See
@@ -4316,7 +4316,7 @@ impl ::serde::ser::Serialize for UpdateTemplateArg {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 #[non_exhaustive] // structs may have more fields added in the future.
 pub struct UpdateTemplateResult {
     /// An identifier for template added by route  See

--- a/src/generated/file_requests.rs
+++ b/src/generated/file_requests.rs
@@ -141,7 +141,7 @@ pub fn update(
 }
 
 /// There was an error counting the file requests.
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 #[non_exhaustive] // variants may be added in the future
 pub enum CountFileRequestsError {
     /// This user's Dropbox Business team doesn't allow file requests.
@@ -213,7 +213,7 @@ impl ::std::fmt::Display for CountFileRequestsError {
 }
 
 /// Result for [`count()`](count).
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 #[non_exhaustive] // structs may have more fields added in the future.
 pub struct CountFileRequestsResult {
     /// The number file requests owner by this user.
@@ -304,7 +304,7 @@ impl ::serde::ser::Serialize for CountFileRequestsResult {
 }
 
 /// Arguments for [`create()`](create).
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 #[non_exhaustive] // structs may have more fields added in the future.
 pub struct CreateFileRequestArgs {
     /// The title of the file request. Must not be empty.
@@ -465,7 +465,7 @@ impl ::serde::ser::Serialize for CreateFileRequestArgs {
 }
 
 /// There was an error creating the file request.
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 #[non_exhaustive] // variants may be added in the future
 pub enum CreateFileRequestError {
     /// This user's Dropbox Business team doesn't allow file requests.
@@ -646,7 +646,7 @@ impl ::std::fmt::Display for CreateFileRequestError {
 }
 
 /// There was an error deleting all closed file requests.
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 #[non_exhaustive] // variants may be added in the future
 pub enum DeleteAllClosedFileRequestsError {
     /// This user's Dropbox Business team doesn't allow file requests.
@@ -800,7 +800,7 @@ impl ::std::fmt::Display for DeleteAllClosedFileRequestsError {
 }
 
 /// Result for [`delete_all_closed()`](delete_all_closed).
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 #[non_exhaustive] // structs may have more fields added in the future.
 pub struct DeleteAllClosedFileRequestsResult {
     /// The file requests deleted for this user.
@@ -891,7 +891,7 @@ impl ::serde::ser::Serialize for DeleteAllClosedFileRequestsResult {
 }
 
 /// Arguments for [`delete()`](delete).
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 #[non_exhaustive] // structs may have more fields added in the future.
 pub struct DeleteFileRequestArgs {
     /// List IDs of the file requests to delete.
@@ -982,7 +982,7 @@ impl ::serde::ser::Serialize for DeleteFileRequestArgs {
 }
 
 /// There was an error deleting these file requests.
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 #[non_exhaustive] // variants may be added in the future
 pub enum DeleteFileRequestError {
     /// This user's Dropbox Business team doesn't allow file requests.
@@ -1149,7 +1149,7 @@ impl ::std::fmt::Display for DeleteFileRequestError {
 }
 
 /// Result for [`delete()`](delete).
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 #[non_exhaustive] // structs may have more fields added in the future.
 pub struct DeleteFileRequestsResult {
     /// The file requests deleted by the request.
@@ -1241,7 +1241,7 @@ impl ::serde::ser::Serialize for DeleteFileRequestsResult {
 
 /// A [file request](https://www.dropbox.com/help/9090) for receiving files into the user's Dropbox
 /// account.
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 #[non_exhaustive] // structs may have more fields added in the future.
 pub struct FileRequest {
     /// The ID of the file request.
@@ -1460,7 +1460,7 @@ impl ::serde::ser::Serialize for FileRequest {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 #[non_exhaustive] // structs may have more fields added in the future.
 pub struct FileRequestDeadline {
     /// The deadline for this file request.
@@ -1570,7 +1570,7 @@ impl ::serde::ser::Serialize for FileRequestDeadline {
 }
 
 /// There is an error with the file request.
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 #[non_exhaustive] // variants may be added in the future
 pub enum FileRequestError {
     /// This user's Dropbox Business team doesn't allow file requests.
@@ -1724,7 +1724,7 @@ impl ::std::fmt::Display for FileRequestError {
 }
 
 /// There is an error accessing the file requests functionality.
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 #[non_exhaustive] // variants may be added in the future
 pub enum GeneralFileRequestsError {
     /// This user's Dropbox Business team doesn't allow file requests.
@@ -1796,7 +1796,7 @@ impl ::std::fmt::Display for GeneralFileRequestsError {
 }
 
 /// Arguments for [`get()`](get).
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 #[non_exhaustive] // structs may have more fields added in the future.
 pub struct GetFileRequestArgs {
     /// The ID of the file request to retrieve.
@@ -1887,7 +1887,7 @@ impl ::serde::ser::Serialize for GetFileRequestArgs {
 }
 
 /// There was an error retrieving the specified file request.
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 #[non_exhaustive] // variants may be added in the future
 pub enum GetFileRequestError {
     /// This user's Dropbox Business team doesn't allow file requests.
@@ -2040,7 +2040,7 @@ impl ::std::fmt::Display for GetFileRequestError {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 #[non_exhaustive] // variants may be added in the future
 pub enum GracePeriod {
     OneDay,
@@ -2147,7 +2147,7 @@ impl ::serde::ser::Serialize for GracePeriod {
 }
 
 /// Arguments for [`list_v2()`](list_v2).
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 #[non_exhaustive] // structs may have more fields added in the future.
 pub struct ListFileRequestsArg {
     /// The maximum number of file requests that should be returned per request.
@@ -2233,7 +2233,7 @@ impl ::serde::ser::Serialize for ListFileRequestsArg {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 #[non_exhaustive] // structs may have more fields added in the future.
 pub struct ListFileRequestsContinueArg {
     /// The cursor returned by the previous API call specified in the endpoint description.
@@ -2324,7 +2324,7 @@ impl ::serde::ser::Serialize for ListFileRequestsContinueArg {
 }
 
 /// There was an error retrieving the file requests.
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 #[non_exhaustive] // variants may be added in the future
 pub enum ListFileRequestsContinueError {
     /// This user's Dropbox Business team doesn't allow file requests.
@@ -2409,7 +2409,7 @@ impl ::std::fmt::Display for ListFileRequestsContinueError {
 }
 
 /// There was an error retrieving the file requests.
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 #[non_exhaustive] // variants may be added in the future
 pub enum ListFileRequestsError {
     /// This user's Dropbox Business team doesn't allow file requests.
@@ -2481,7 +2481,7 @@ impl ::std::fmt::Display for ListFileRequestsError {
 }
 
 /// Result for [`list()`](list).
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 #[non_exhaustive] // structs may have more fields added in the future.
 pub struct ListFileRequestsResult {
     /// The file requests owned by this user. Apps with the app folder permission will only see file
@@ -2573,7 +2573,7 @@ impl ::serde::ser::Serialize for ListFileRequestsResult {
 }
 
 /// Result for [`list_v2()`](list_v2) and [`list_continue()`](list_continue).
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 #[non_exhaustive] // structs may have more fields added in the future.
 pub struct ListFileRequestsV2Result {
     /// The file requests owned by this user. Apps with the app folder permission will only see file
@@ -2692,7 +2692,7 @@ impl ::serde::ser::Serialize for ListFileRequestsV2Result {
 }
 
 /// Arguments for [`update()`](update).
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 #[non_exhaustive] // structs may have more fields added in the future.
 pub struct UpdateFileRequestArgs {
     /// The ID of the file request to update.
@@ -2874,7 +2874,7 @@ impl ::serde::ser::Serialize for UpdateFileRequestArgs {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 #[non_exhaustive] // variants may be added in the future
 pub enum UpdateFileRequestDeadline {
     /// Do not change the file request's deadline.
@@ -2948,7 +2948,7 @@ impl ::serde::ser::Serialize for UpdateFileRequestDeadline {
 }
 
 /// There is an error updating the file request.
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 #[non_exhaustive] // variants may be added in the future
 pub enum UpdateFileRequestError {
     /// This user's Dropbox Business team doesn't allow file requests.

--- a/src/generated/files.rs
+++ b/src/generated/files.rs
@@ -1151,7 +1151,7 @@ pub fn upload_session_start(
         Some(body))
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 #[non_exhaustive] // structs may have more fields added in the future.
 pub struct AlphaGetMetadataArg {
     /// The path of a file or folder on Dropbox.
@@ -1341,7 +1341,7 @@ impl ::serde::ser::Serialize for AlphaGetMetadataArg {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 pub enum AlphaGetMetadataError {
     Path(LookupError),
     PropertiesError(super::file_properties::LookUpPropertiesError),
@@ -1422,7 +1422,7 @@ impl ::std::fmt::Display for AlphaGetMetadataError {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 #[non_exhaustive] // structs may have more fields added in the future.
 pub struct CommitInfo {
     /// Path in the user's Dropbox to save the file.
@@ -1633,7 +1633,7 @@ impl ::serde::ser::Serialize for CommitInfo {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 #[non_exhaustive] // structs may have more fields added in the future.
 pub struct CommitInfoWithProperties {
     /// Path in the user's Dropbox to save the file.
@@ -1844,7 +1844,7 @@ impl ::serde::ser::Serialize for CommitInfoWithProperties {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 #[non_exhaustive] // structs may have more fields added in the future.
 pub struct ContentSyncSetting {
     /// Id of the item this setting is applied to.
@@ -1947,7 +1947,7 @@ impl ::serde::ser::Serialize for ContentSyncSetting {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 #[non_exhaustive] // structs may have more fields added in the future.
 pub struct ContentSyncSettingArg {
     /// Id of the item this setting is applied to.
@@ -2050,7 +2050,7 @@ impl ::serde::ser::Serialize for ContentSyncSettingArg {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 #[non_exhaustive] // structs may have more fields added in the future.
 pub struct CreateFolderArg {
     /// Path in the user's Dropbox to create.
@@ -2159,7 +2159,7 @@ impl ::serde::ser::Serialize for CreateFolderArg {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 #[non_exhaustive] // structs may have more fields added in the future.
 pub struct CreateFolderBatchArg {
     /// List of paths to be created in the user's Dropbox. Duplicate path arguments in the batch are
@@ -2287,7 +2287,7 @@ impl ::serde::ser::Serialize for CreateFolderBatchArg {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 #[non_exhaustive] // variants may be added in the future
 pub enum CreateFolderBatchError {
     /// The operation would involve too many files or folders.
@@ -2358,7 +2358,7 @@ impl ::std::fmt::Display for CreateFolderBatchError {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 #[non_exhaustive] // variants may be added in the future
 pub enum CreateFolderBatchJobStatus {
     /// The asynchronous job is still in progress.
@@ -2447,7 +2447,7 @@ impl ::serde::ser::Serialize for CreateFolderBatchJobStatus {
 
 /// Result returned by [`create_folder_batch()`](create_folder_batch) that may either launch an
 /// asynchronous job or complete synchronously.
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 #[non_exhaustive] // variants may be added in the future
 pub enum CreateFolderBatchLaunch {
     /// This response indicates that the processing is asynchronous. The string is an id that can be
@@ -2521,7 +2521,7 @@ impl ::serde::ser::Serialize for CreateFolderBatchLaunch {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 #[non_exhaustive] // structs may have more fields added in the future.
 pub struct CreateFolderBatchResult {
     /// Each entry in [`CreateFolderBatchArg::paths`](CreateFolderBatchArg) will appear at the same
@@ -2612,7 +2612,7 @@ impl ::serde::ser::Serialize for CreateFolderBatchResult {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 pub enum CreateFolderBatchResultEntry {
     Success(CreateFolderEntryResult),
     Failure(CreateFolderEntryError),
@@ -2675,7 +2675,7 @@ impl ::serde::ser::Serialize for CreateFolderBatchResultEntry {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 #[non_exhaustive] // variants may be added in the future
 pub enum CreateFolderEntryError {
     Path(WriteError),
@@ -2749,7 +2749,7 @@ impl ::std::fmt::Display for CreateFolderEntryError {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 #[non_exhaustive] // structs may have more fields added in the future.
 pub struct CreateFolderEntryResult {
     /// Metadata of the created folder.
@@ -2839,7 +2839,7 @@ impl ::serde::ser::Serialize for CreateFolderEntryResult {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 pub enum CreateFolderError {
     Path(WriteError),
 }
@@ -2904,7 +2904,7 @@ impl ::std::fmt::Display for CreateFolderError {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 #[non_exhaustive] // structs may have more fields added in the future.
 pub struct CreateFolderResult {
     /// Metadata of the created folder.
@@ -2994,7 +2994,7 @@ impl ::serde::ser::Serialize for CreateFolderResult {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 #[non_exhaustive] // structs may have more fields added in the future.
 pub struct DeleteArg {
     /// Path in the user's Dropbox to delete.
@@ -3103,7 +3103,7 @@ impl ::serde::ser::Serialize for DeleteArg {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 #[non_exhaustive] // structs may have more fields added in the future.
 pub struct DeleteBatchArg {
     pub entries: Vec<DeleteArg>,
@@ -3192,7 +3192,7 @@ impl ::serde::ser::Serialize for DeleteBatchArg {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 #[non_exhaustive] // variants may be added in the future
 pub enum DeleteBatchError {
     /// Use [`DeleteError::TooManyWriteOperations`](DeleteError::TooManyWriteOperations).
@@ -3265,7 +3265,7 @@ impl ::std::fmt::Display for DeleteBatchError {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 #[non_exhaustive] // variants may be added in the future
 pub enum DeleteBatchJobStatus {
     /// The asynchronous job is still in progress.
@@ -3354,7 +3354,7 @@ impl ::serde::ser::Serialize for DeleteBatchJobStatus {
 
 /// Result returned by [`delete_batch()`](delete_batch) that may either launch an asynchronous job
 /// or complete synchronously.
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 #[non_exhaustive] // variants may be added in the future
 pub enum DeleteBatchLaunch {
     /// This response indicates that the processing is asynchronous. The string is an id that can be
@@ -3428,7 +3428,7 @@ impl ::serde::ser::Serialize for DeleteBatchLaunch {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 #[non_exhaustive] // structs may have more fields added in the future.
 pub struct DeleteBatchResult {
     /// Each entry in [`DeleteBatchArg::entries`](DeleteBatchArg) will appear at the same position
@@ -3519,7 +3519,7 @@ impl ::serde::ser::Serialize for DeleteBatchResult {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 #[non_exhaustive] // structs may have more fields added in the future.
 pub struct DeleteBatchResultData {
     /// Metadata of the deleted object.
@@ -3609,7 +3609,7 @@ impl ::serde::ser::Serialize for DeleteBatchResultData {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 pub enum DeleteBatchResultEntry {
     Success(DeleteBatchResultData),
     Failure(DeleteError),
@@ -3672,7 +3672,7 @@ impl ::serde::ser::Serialize for DeleteBatchResultEntry {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 #[non_exhaustive] // variants may be added in the future
 pub enum DeleteError {
     PathLookup(LookupError),
@@ -3788,7 +3788,7 @@ impl ::std::fmt::Display for DeleteError {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 #[non_exhaustive] // structs may have more fields added in the future.
 pub struct DeleteResult {
     /// Metadata of the deleted object.
@@ -3879,7 +3879,7 @@ impl ::serde::ser::Serialize for DeleteResult {
 }
 
 /// Indicates that there used to be a file or folder at this path, but it no longer exists.
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 #[non_exhaustive] // structs may have more fields added in the future.
 pub struct DeletedMetadata {
     /// The last component of the path (including extension). This never contains a slash.
@@ -4031,7 +4031,7 @@ impl ::serde::ser::Serialize for DeletedMetadata {
 }
 
 /// Dimensions for a photo or video.
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 #[non_exhaustive] // structs may have more fields added in the future.
 pub struct Dimensions {
     /// Height of the photo/video.
@@ -4134,7 +4134,7 @@ impl ::serde::ser::Serialize for Dimensions {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 #[non_exhaustive] // structs may have more fields added in the future.
 pub struct DownloadArg {
     /// The path of the file to download.
@@ -4242,7 +4242,7 @@ impl ::serde::ser::Serialize for DownloadArg {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 #[non_exhaustive] // variants may be added in the future
 pub enum DownloadError {
     Path(LookupError),
@@ -4329,7 +4329,7 @@ impl ::std::fmt::Display for DownloadError {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 #[non_exhaustive] // structs may have more fields added in the future.
 pub struct DownloadZipArg {
     /// The path of the folder to download.
@@ -4419,7 +4419,7 @@ impl ::serde::ser::Serialize for DownloadZipArg {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 #[non_exhaustive] // variants may be added in the future
 pub enum DownloadZipError {
     Path(LookupError),
@@ -4519,7 +4519,7 @@ impl ::std::fmt::Display for DownloadZipError {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 #[non_exhaustive] // structs may have more fields added in the future.
 pub struct DownloadZipResult {
     pub metadata: FolderMetadata,
@@ -4608,7 +4608,7 @@ impl ::serde::ser::Serialize for DownloadZipResult {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 #[non_exhaustive] // structs may have more fields added in the future.
 pub struct ExportArg {
     /// The path of the file to be exported.
@@ -4698,7 +4698,7 @@ impl ::serde::ser::Serialize for ExportArg {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 #[non_exhaustive] // variants may be added in the future
 pub enum ExportError {
     Path(LookupError),
@@ -4799,7 +4799,7 @@ impl ::std::fmt::Display for ExportError {
 }
 
 /// Export information for a file.
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 #[non_exhaustive] // structs may have more fields added in the future.
 pub struct ExportInfo {
     /// Format to which the file can be exported to.
@@ -4885,7 +4885,7 @@ impl ::serde::ser::Serialize for ExportInfo {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 #[non_exhaustive] // structs may have more fields added in the future.
 pub struct ExportMetadata {
     /// The last component of the path (including extension). This never contains a slash.
@@ -5008,7 +5008,7 @@ impl ::serde::ser::Serialize for ExportMetadata {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 #[non_exhaustive] // structs may have more fields added in the future.
 pub struct ExportResult {
     /// Metadata for the exported version of the file.
@@ -5111,7 +5111,7 @@ impl ::serde::ser::Serialize for ExportResult {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 #[non_exhaustive] // variants may be added in the future
 pub enum FileCategory {
     /// jpg, png, gif, and more.
@@ -5287,7 +5287,7 @@ impl ::serde::ser::Serialize for FileCategory {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 #[non_exhaustive] // structs may have more fields added in the future.
 pub struct FileLock {
     /// The lock description.
@@ -5377,7 +5377,7 @@ impl ::serde::ser::Serialize for FileLock {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 #[non_exhaustive] // variants may be added in the future
 pub enum FileLockContent {
     /// Empty type to indicate no lock.
@@ -5447,7 +5447,7 @@ impl ::serde::ser::Serialize for FileLockContent {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 #[non_exhaustive] // structs may have more fields added in the future.
 pub struct FileLockMetadata {
     /// True if caller holds the file lock.
@@ -5587,7 +5587,7 @@ impl ::serde::ser::Serialize for FileLockMetadata {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 #[non_exhaustive] // structs may have more fields added in the future.
 pub struct FileMetadata {
     /// The last component of the path (including extension). This never contains a slash.
@@ -5990,7 +5990,7 @@ impl ::serde::ser::Serialize for FileMetadata {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 #[non_exhaustive] // structs may have more fields added in the future.
 pub struct FileOpsResult {
 }
@@ -6041,7 +6041,7 @@ impl ::serde::ser::Serialize for FileOpsResult {
 }
 
 /// Sharing info for a file which is contained by a shared folder.
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 #[non_exhaustive] // structs may have more fields added in the future.
 pub struct FileSharingInfo {
     /// True if the file or folder is inside a read-only shared folder.
@@ -6163,7 +6163,7 @@ impl ::serde::ser::Serialize for FileSharingInfo {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 #[non_exhaustive] // variants may be added in the future
 pub enum FileStatus {
     Active,
@@ -6233,7 +6233,7 @@ impl ::serde::ser::Serialize for FileStatus {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 #[non_exhaustive] // structs may have more fields added in the future.
 pub struct FolderMetadata {
     /// The last component of the path (including extension). This never contains a slash.
@@ -6458,7 +6458,7 @@ impl ::serde::ser::Serialize for FolderMetadata {
 
 /// Sharing info for a folder which is contained in a shared folder or is a shared folder mount
 /// point.
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 #[non_exhaustive] // structs may have more fields added in the future.
 pub struct FolderSharingInfo {
     /// True if the file or folder is inside a read-only shared folder.
@@ -6623,7 +6623,7 @@ impl ::serde::ser::Serialize for FolderSharingInfo {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 #[non_exhaustive] // structs may have more fields added in the future.
 pub struct GetCopyReferenceArg {
     /// The path to the file or folder you want to get a copy reference to.
@@ -6713,7 +6713,7 @@ impl ::serde::ser::Serialize for GetCopyReferenceArg {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 #[non_exhaustive] // variants may be added in the future
 pub enum GetCopyReferenceError {
     Path(LookupError),
@@ -6787,7 +6787,7 @@ impl ::std::fmt::Display for GetCopyReferenceError {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 #[non_exhaustive] // structs may have more fields added in the future.
 pub struct GetCopyReferenceResult {
     /// Metadata of the file or folder.
@@ -6908,7 +6908,7 @@ impl ::serde::ser::Serialize for GetCopyReferenceResult {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 #[non_exhaustive] // structs may have more fields added in the future.
 pub struct GetMetadataArg {
     /// The path of a file or folder on Dropbox.
@@ -7076,7 +7076,7 @@ impl ::serde::ser::Serialize for GetMetadataArg {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 pub enum GetMetadataError {
     Path(LookupError),
 }
@@ -7141,7 +7141,7 @@ impl ::std::fmt::Display for GetMetadataError {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 #[non_exhaustive] // structs may have more fields added in the future.
 pub struct GetTemporaryLinkArg {
     /// The path to the file you want a temporary link to.
@@ -7231,7 +7231,7 @@ impl ::serde::ser::Serialize for GetTemporaryLinkArg {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 #[non_exhaustive] // variants may be added in the future
 pub enum GetTemporaryLinkError {
     Path(LookupError),
@@ -7333,7 +7333,7 @@ impl ::std::fmt::Display for GetTemporaryLinkError {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 #[non_exhaustive] // structs may have more fields added in the future.
 pub struct GetTemporaryLinkResult {
     /// Metadata of the file.
@@ -7436,7 +7436,7 @@ impl ::serde::ser::Serialize for GetTemporaryLinkResult {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 #[non_exhaustive] // structs may have more fields added in the future.
 pub struct GetTemporaryUploadLinkArg {
     /// Contains the path and other optional modifiers for the future upload commit. Equivalent to
@@ -7546,7 +7546,7 @@ impl ::serde::ser::Serialize for GetTemporaryUploadLinkArg {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 #[non_exhaustive] // structs may have more fields added in the future.
 pub struct GetTemporaryUploadLinkResult {
     /// The temporary link which can be used to stream a file to a Dropbox location.
@@ -7637,7 +7637,7 @@ impl ::serde::ser::Serialize for GetTemporaryUploadLinkResult {
 }
 
 /// Arguments for [`get_thumbnail_batch()`](get_thumbnail_batch).
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 #[non_exhaustive] // structs may have more fields added in the future.
 pub struct GetThumbnailBatchArg {
     /// List of files to get thumbnails.
@@ -7727,7 +7727,7 @@ impl ::serde::ser::Serialize for GetThumbnailBatchArg {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 #[non_exhaustive] // variants may be added in the future
 pub enum GetThumbnailBatchError {
     /// The operation involves more than 25 files.
@@ -7798,7 +7798,7 @@ impl ::std::fmt::Display for GetThumbnailBatchError {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 #[non_exhaustive] // structs may have more fields added in the future.
 pub struct GetThumbnailBatchResult {
     /// List of files and their thumbnails.
@@ -7888,7 +7888,7 @@ impl ::serde::ser::Serialize for GetThumbnailBatchResult {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 #[non_exhaustive] // structs may have more fields added in the future.
 pub struct GetThumbnailBatchResultData {
     pub metadata: FileMetadata,
@@ -7990,7 +7990,7 @@ impl ::serde::ser::Serialize for GetThumbnailBatchResultData {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 #[non_exhaustive] // variants may be added in the future
 pub enum GetThumbnailBatchResultEntry {
     Success(GetThumbnailBatchResultData),
@@ -8064,7 +8064,7 @@ impl ::serde::ser::Serialize for GetThumbnailBatchResultEntry {
 }
 
 /// GPS coordinates for a photo or video.
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 #[non_exhaustive] // structs may have more fields added in the future.
 pub struct GpsCoordinates {
     /// Latitude of the GPS coordinates.
@@ -8167,7 +8167,7 @@ impl ::serde::ser::Serialize for GpsCoordinates {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 #[non_exhaustive] // structs may have more fields added in the future.
 pub struct HighlightSpan {
     /// String to be determined whether it should be highlighted or not.
@@ -8270,7 +8270,7 @@ impl ::serde::ser::Serialize for HighlightSpan {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 #[non_exhaustive] // structs may have more fields added in the future.
 pub struct ListFolderArg {
     /// A unique identifier for the file.
@@ -8534,7 +8534,7 @@ impl ::serde::ser::Serialize for ListFolderArg {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 #[non_exhaustive] // structs may have more fields added in the future.
 pub struct ListFolderContinueArg {
     /// The cursor returned by your last call to [`list_folder()`](list_folder) or
@@ -8625,7 +8625,7 @@ impl ::serde::ser::Serialize for ListFolderContinueArg {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 #[non_exhaustive] // variants may be added in the future
 pub enum ListFolderContinueError {
     Path(LookupError),
@@ -8713,7 +8713,7 @@ impl ::std::fmt::Display for ListFolderContinueError {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 #[non_exhaustive] // variants may be added in the future
 pub enum ListFolderError {
     Path(LookupError),
@@ -8803,7 +8803,7 @@ impl ::std::fmt::Display for ListFolderError {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 #[non_exhaustive] // structs may have more fields added in the future.
 pub struct ListFolderGetLatestCursorResult {
     /// Pass the cursor into [`list_folder_continue()`](list_folder_continue) to see what's changed
@@ -8894,7 +8894,7 @@ impl ::serde::ser::Serialize for ListFolderGetLatestCursorResult {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 #[non_exhaustive] // structs may have more fields added in the future.
 pub struct ListFolderLongpollArg {
     /// A cursor as returned by [`list_folder()`](list_folder) or
@@ -9006,7 +9006,7 @@ impl ::serde::ser::Serialize for ListFolderLongpollArg {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 #[non_exhaustive] // variants may be added in the future
 pub enum ListFolderLongpollError {
     /// Indicates that the cursor has been invalidated. Call [`list_folder()`](list_folder) to
@@ -9078,7 +9078,7 @@ impl ::std::fmt::Display for ListFolderLongpollError {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 #[non_exhaustive] // structs may have more fields added in the future.
 pub struct ListFolderLongpollResult {
     /// Indicates whether new changes are available. If true, call
@@ -9188,7 +9188,7 @@ impl ::serde::ser::Serialize for ListFolderLongpollResult {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 #[non_exhaustive] // structs may have more fields added in the future.
 pub struct ListFolderResult {
     /// The files and (direct) subfolders in the folder.
@@ -9306,7 +9306,7 @@ impl ::serde::ser::Serialize for ListFolderResult {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 #[non_exhaustive] // structs may have more fields added in the future.
 pub struct ListRevisionsArg {
     /// The path to the file you want to see the revisions of.
@@ -9432,7 +9432,7 @@ impl ::serde::ser::Serialize for ListRevisionsArg {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 #[non_exhaustive] // variants may be added in the future
 pub enum ListRevisionsError {
     Path(LookupError),
@@ -9506,7 +9506,7 @@ impl ::std::fmt::Display for ListRevisionsError {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 #[non_exhaustive] // variants may be added in the future
 pub enum ListRevisionsMode {
     /// Returns revisions with the same file path as identified by the latest file entry at the
@@ -9580,7 +9580,7 @@ impl ::serde::ser::Serialize for ListRevisionsMode {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 #[non_exhaustive] // structs may have more fields added in the future.
 pub struct ListRevisionsResult {
     /// If the file identified by the latest revision in the response is either deleted or moved.
@@ -9701,7 +9701,7 @@ impl ::serde::ser::Serialize for ListRevisionsResult {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 #[non_exhaustive] // structs may have more fields added in the future.
 pub struct LockConflictError {
     /// The lock that caused the conflict.
@@ -9791,7 +9791,7 @@ impl ::serde::ser::Serialize for LockConflictError {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 #[non_exhaustive] // structs may have more fields added in the future.
 pub struct LockFileArg {
     /// Path in the user's Dropbox to a file.
@@ -9881,7 +9881,7 @@ impl ::serde::ser::Serialize for LockFileArg {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 #[non_exhaustive] // structs may have more fields added in the future.
 pub struct LockFileBatchArg {
     /// List of 'entries'. Each 'entry' contains a path of the file which will be locked or queried.
@@ -9972,7 +9972,7 @@ impl ::serde::ser::Serialize for LockFileBatchArg {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 #[non_exhaustive] // structs may have more fields added in the future.
 pub struct LockFileBatchResult {
     /// Each Entry in the 'entries' will have '.tag' with the operation status (e.g. success), the
@@ -10063,7 +10063,7 @@ impl ::serde::ser::Serialize for LockFileBatchResult {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 #[non_exhaustive] // variants may be added in the future
 pub enum LockFileError {
     /// Could not find the specified resource.
@@ -10228,7 +10228,7 @@ impl ::std::fmt::Display for LockFileError {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 #[non_exhaustive] // structs may have more fields added in the future.
 pub struct LockFileResult {
     /// Metadata of the file.
@@ -10331,7 +10331,7 @@ impl ::serde::ser::Serialize for LockFileResult {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 pub enum LockFileResultEntry {
     Success(LockFileResult),
     Failure(LockFileError),
@@ -10394,7 +10394,7 @@ impl ::serde::ser::Serialize for LockFileResultEntry {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 #[non_exhaustive] // variants may be added in the future
 pub enum LookupError {
     /// The given path does not satisfy the required path format. Please refer to the [Path formats
@@ -10553,7 +10553,7 @@ impl ::std::fmt::Display for LookupError {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 pub enum MediaInfo {
     /// Indicate the photo/video is still under processing and metadata is not available yet.
     Pending,
@@ -10621,7 +10621,7 @@ impl ::serde::ser::Serialize for MediaInfo {
 }
 
 /// Metadata for a photo or video.
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 pub enum MediaMetadata {
     Photo(PhotoMetadata),
     Video(VideoMetadata),
@@ -10682,7 +10682,7 @@ impl ::serde::ser::Serialize for MediaMetadata {
 }
 
 /// Metadata for a file or folder.
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 pub enum Metadata {
     File(FileMetadata),
     Folder(FolderMetadata),
@@ -10774,7 +10774,7 @@ impl ::serde::ser::Serialize for Metadata {
 }
 
 /// Metadata for a file, folder or other resource types.
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 #[non_exhaustive] // variants may be added in the future
 pub enum MetadataV2 {
     Metadata(Metadata),
@@ -10836,7 +10836,7 @@ impl ::serde::ser::Serialize for MetadataV2 {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 #[non_exhaustive] // structs may have more fields added in the future.
 pub struct MinimalFileLinkMetadata {
     /// URL of the shared link.
@@ -10977,7 +10977,7 @@ impl ::serde::ser::Serialize for MinimalFileLinkMetadata {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 #[non_exhaustive] // structs may have more fields added in the future.
 pub struct MoveBatchArg {
     /// List of entries to be moved or copied. Each entry is [`RelocationPath`](RelocationPath).
@@ -11105,7 +11105,7 @@ impl ::serde::ser::Serialize for MoveBatchArg {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 #[non_exhaustive] // variants may be added in the future
 pub enum MoveIntoVaultError {
     /// Moving shared folder into Vault is not allowed.
@@ -11176,7 +11176,7 @@ impl ::std::fmt::Display for MoveIntoVaultError {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 #[non_exhaustive] // variants may be added in the future
 pub enum PathOrLink {
     Path(ReadPath),
@@ -11249,7 +11249,7 @@ impl ::serde::ser::Serialize for PathOrLink {
 }
 
 /// Metadata for a photo.
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 #[non_exhaustive] // structs may have more fields added in the future.
 pub struct PhotoMetadata {
     /// Dimension of the photo/video.
@@ -11371,7 +11371,7 @@ impl ::serde::ser::Serialize for PhotoMetadata {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 #[non_exhaustive] // structs may have more fields added in the future.
 pub struct PreviewArg {
     /// The path of the file to preview.
@@ -11479,7 +11479,7 @@ impl ::serde::ser::Serialize for PreviewArg {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 pub enum PreviewError {
     /// An error occurs when downloading metadata for the file.
     Path(LookupError),
@@ -11584,7 +11584,7 @@ impl ::std::fmt::Display for PreviewError {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 #[non_exhaustive] // structs may have more fields added in the future.
 pub struct PreviewResult {
     /// Metadata corresponding to the file received as an argument. Will be populated if the
@@ -11690,7 +11690,7 @@ impl ::serde::ser::Serialize for PreviewResult {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 #[non_exhaustive] // structs may have more fields added in the future.
 pub struct RelocationArg {
     /// Path in the user's Dropbox to be copied or moved.
@@ -11849,7 +11849,7 @@ impl ::serde::ser::Serialize for RelocationArg {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 #[non_exhaustive] // structs may have more fields added in the future.
 pub struct RelocationBatchArg {
     /// List of entries to be moved or copied. Each entry is [`RelocationPath`](RelocationPath).
@@ -11995,7 +11995,7 @@ impl ::serde::ser::Serialize for RelocationBatchArg {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 #[non_exhaustive] // structs may have more fields added in the future.
 pub struct RelocationBatchArgBase {
     /// List of entries to be moved or copied. Each entry is [`RelocationPath`](RelocationPath).
@@ -12104,7 +12104,7 @@ impl ::serde::ser::Serialize for RelocationBatchArgBase {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 #[non_exhaustive] // variants may be added in the future
 pub enum RelocationBatchError {
     FromLookup(LookupError),
@@ -12360,7 +12360,7 @@ impl ::std::fmt::Display for RelocationBatchError {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 #[non_exhaustive] // variants may be added in the future
 pub enum RelocationBatchErrorEntry {
     /// User errors that retry won't help.
@@ -12450,7 +12450,7 @@ impl ::serde::ser::Serialize for RelocationBatchErrorEntry {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 pub enum RelocationBatchJobStatus {
     /// The asynchronous job is still in progress.
     InProgress,
@@ -12530,7 +12530,7 @@ impl ::serde::ser::Serialize for RelocationBatchJobStatus {
 
 /// Result returned by [`copy_batch()`](copy_batch) or [`move_batch()`](move_batch) that may either
 /// launch an asynchronous job or complete synchronously.
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 #[non_exhaustive] // variants may be added in the future
 pub enum RelocationBatchLaunch {
     /// This response indicates that the processing is asynchronous. The string is an id that can be
@@ -12604,7 +12604,7 @@ impl ::serde::ser::Serialize for RelocationBatchLaunch {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 #[non_exhaustive] // structs may have more fields added in the future.
 pub struct RelocationBatchResult {
     pub entries: Vec<RelocationBatchResultData>,
@@ -12693,7 +12693,7 @@ impl ::serde::ser::Serialize for RelocationBatchResult {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 #[non_exhaustive] // structs may have more fields added in the future.
 pub struct RelocationBatchResultData {
     /// Metadata of the relocated object.
@@ -12783,7 +12783,7 @@ impl ::serde::ser::Serialize for RelocationBatchResultData {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 #[non_exhaustive] // variants may be added in the future
 pub enum RelocationBatchResultEntry {
     Success(Metadata),
@@ -12864,7 +12864,7 @@ impl ::serde::ser::Serialize for RelocationBatchResultEntry {
 /// Result returned by [`copy_batch_check_v2()`](copy_batch_check_v2) or
 /// [`move_batch_check_v2()`](move_batch_check_v2) that may either be in progress or completed with
 /// result for each entry.
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 pub enum RelocationBatchV2JobStatus {
     /// The asynchronous job is still in progress.
     InProgress,
@@ -12927,7 +12927,7 @@ impl ::serde::ser::Serialize for RelocationBatchV2JobStatus {
 
 /// Result returned by [`copy_batch_v2()`](copy_batch_v2) or [`move_batch_v2()`](move_batch_v2) that
 /// may either launch an asynchronous job or complete synchronously.
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 pub enum RelocationBatchV2Launch {
     /// This response indicates that the processing is asynchronous. The string is an id that can be
     /// used to obtain the status of the asynchronous job.
@@ -12992,7 +12992,7 @@ impl ::serde::ser::Serialize for RelocationBatchV2Launch {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 #[non_exhaustive] // structs may have more fields added in the future.
 pub struct RelocationBatchV2Result {
     /// Each entry in CopyBatchArg.entries or [`MoveBatchArg::entries`](MoveBatchArg) will appear at
@@ -13083,7 +13083,7 @@ impl ::serde::ser::Serialize for RelocationBatchV2Result {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 #[non_exhaustive] // variants may be added in the future
 pub enum RelocationError {
     FromLookup(LookupError),
@@ -13326,7 +13326,7 @@ impl ::std::fmt::Display for RelocationError {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 #[non_exhaustive] // structs may have more fields added in the future.
 pub struct RelocationPath {
     /// Path in the user's Dropbox to be copied or moved.
@@ -13429,7 +13429,7 @@ impl ::serde::ser::Serialize for RelocationPath {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 #[non_exhaustive] // structs may have more fields added in the future.
 pub struct RelocationResult {
     /// Metadata of the relocated object.
@@ -13519,7 +13519,7 @@ impl ::serde::ser::Serialize for RelocationResult {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 #[non_exhaustive] // structs may have more fields added in the future.
 pub struct RestoreArg {
     /// The path to save the restored file.
@@ -13622,7 +13622,7 @@ impl ::serde::ser::Serialize for RestoreArg {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 #[non_exhaustive] // variants may be added in the future
 pub enum RestoreError {
     /// An error occurs when downloading metadata for the file.
@@ -13740,7 +13740,7 @@ impl ::std::fmt::Display for RestoreError {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 #[non_exhaustive] // structs may have more fields added in the future.
 pub struct SaveCopyReferenceArg {
     /// A copy reference returned by [`copy_reference_get()`](copy_reference_get).
@@ -13843,7 +13843,7 @@ impl ::serde::ser::Serialize for SaveCopyReferenceArg {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 #[non_exhaustive] // variants may be added in the future
 pub enum SaveCopyReferenceError {
     Path(WriteError),
@@ -13970,7 +13970,7 @@ impl ::std::fmt::Display for SaveCopyReferenceError {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 #[non_exhaustive] // structs may have more fields added in the future.
 pub struct SaveCopyReferenceResult {
     /// The metadata of the saved file or folder in the user's Dropbox.
@@ -14060,7 +14060,7 @@ impl ::serde::ser::Serialize for SaveCopyReferenceResult {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 #[non_exhaustive] // structs may have more fields added in the future.
 pub struct SaveUrlArg {
     /// The path in Dropbox where the URL will be saved to.
@@ -14163,7 +14163,7 @@ impl ::serde::ser::Serialize for SaveUrlArg {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 #[non_exhaustive] // variants may be added in the future
 pub enum SaveUrlError {
     Path(WriteError),
@@ -14277,7 +14277,7 @@ impl ::std::fmt::Display for SaveUrlError {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 pub enum SaveUrlJobStatus {
     /// The asynchronous job is still in progress.
     InProgress,
@@ -14354,7 +14354,7 @@ impl ::serde::ser::Serialize for SaveUrlJobStatus {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 pub enum SaveUrlResult {
     /// This response indicates that the processing is asynchronous. The string is an id that can be
     /// used to obtain the status of the asynchronous job.
@@ -14420,7 +14420,7 @@ impl ::serde::ser::Serialize for SaveUrlResult {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 #[non_exhaustive] // structs may have more fields added in the future.
 pub struct SearchArg {
     /// The path in the user's Dropbox to search. Should probably be a folder.
@@ -14580,7 +14580,7 @@ impl ::serde::ser::Serialize for SearchArg {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 #[non_exhaustive] // variants may be added in the future
 pub enum SearchError {
     Path(LookupError),
@@ -14686,7 +14686,7 @@ impl ::std::fmt::Display for SearchError {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 #[non_exhaustive] // structs may have more fields added in the future.
 pub struct SearchMatch {
     /// The type of the match.
@@ -14789,7 +14789,7 @@ impl ::serde::ser::Serialize for SearchMatch {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 #[non_exhaustive] // structs may have more fields added in the future.
 pub struct SearchMatchFieldOptions {
     /// Whether to include highlight span from file title.
@@ -14876,7 +14876,7 @@ impl ::serde::ser::Serialize for SearchMatchFieldOptions {
 }
 
 /// Indicates what type of match was found for a given item.
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 pub enum SearchMatchType {
     /// This item was matched on its file or folder name.
     Filename,
@@ -14953,7 +14953,7 @@ impl ::serde::ser::Serialize for SearchMatchType {
 }
 
 /// Indicates what type of match was found for a given item.
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 #[non_exhaustive] // variants may be added in the future
 pub enum SearchMatchTypeV2 {
     /// This item was matched on its file or folder name.
@@ -15051,7 +15051,7 @@ impl ::serde::ser::Serialize for SearchMatchTypeV2 {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 #[non_exhaustive] // structs may have more fields added in the future.
 pub struct SearchMatchV2 {
     /// The metadata for the matched file or folder.
@@ -15177,7 +15177,7 @@ impl ::serde::ser::Serialize for SearchMatchV2 {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 pub enum SearchMode {
     /// Search file and folder names.
     Filename,
@@ -15253,7 +15253,7 @@ impl ::serde::ser::Serialize for SearchMode {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 #[non_exhaustive] // structs may have more fields added in the future.
 pub struct SearchOptions {
     /// Scopes the search to a path in the user's Dropbox. Searches the entire Dropbox if not
@@ -15450,7 +15450,7 @@ impl ::serde::ser::Serialize for SearchOptions {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 #[non_exhaustive] // variants may be added in the future
 pub enum SearchOrderBy {
     Relevance,
@@ -15520,7 +15520,7 @@ impl ::serde::ser::Serialize for SearchOrderBy {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 #[non_exhaustive] // structs may have more fields added in the future.
 pub struct SearchResult {
     /// A list (possibly empty) of matches for the query.
@@ -15638,7 +15638,7 @@ impl ::serde::ser::Serialize for SearchResult {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 #[non_exhaustive] // structs may have more fields added in the future.
 pub struct SearchV2Arg {
     /// The string to search for. May match across multiple fields based on the request arguments.
@@ -15783,7 +15783,7 @@ impl ::serde::ser::Serialize for SearchV2Arg {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 #[non_exhaustive] // structs may have more fields added in the future.
 pub struct SearchV2ContinueArg {
     /// The cursor returned by your last call to [`search_v2()`](search_v2). Used to fetch the next
@@ -15874,7 +15874,7 @@ impl ::serde::ser::Serialize for SearchV2ContinueArg {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 #[non_exhaustive] // structs may have more fields added in the future.
 pub struct SearchV2Result {
     /// A list (possibly empty) of matches for the query.
@@ -15997,7 +15997,7 @@ impl ::serde::ser::Serialize for SearchV2Result {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 #[non_exhaustive] // structs may have more fields added in the future.
 pub struct SharedLink {
     /// Shared link url.
@@ -16105,7 +16105,7 @@ impl ::serde::ser::Serialize for SharedLink {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 #[non_exhaustive] // structs may have more fields added in the future.
 pub struct SharedLinkFileInfo {
     /// The shared link corresponding to either a file or shared link to a folder. If it is for a
@@ -16236,7 +16236,7 @@ impl ::serde::ser::Serialize for SharedLinkFileInfo {
 }
 
 /// Sharing info for a file or folder.
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 #[non_exhaustive] // structs may have more fields added in the future.
 pub struct SharingInfo {
     /// True if the file or folder is inside a read-only shared folder.
@@ -16326,7 +16326,7 @@ impl ::serde::ser::Serialize for SharingInfo {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 #[non_exhaustive] // structs may have more fields added in the future.
 pub struct SingleUserLock {
     /// The time the lock was created.
@@ -16450,7 +16450,7 @@ impl ::serde::ser::Serialize for SingleUserLock {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 #[non_exhaustive] // structs may have more fields added in the future.
 pub struct SymlinkInfo {
     /// The target this symlink points to.
@@ -16540,7 +16540,7 @@ impl ::serde::ser::Serialize for SymlinkInfo {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 #[non_exhaustive] // variants may be added in the future
 pub enum SyncSetting {
     /// On first sync to members' computers, the specified folder will follow its parent folder's
@@ -16628,7 +16628,7 @@ impl ::serde::ser::Serialize for SyncSetting {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 #[non_exhaustive] // variants may be added in the future
 pub enum SyncSettingArg {
     /// On first sync to members' computers, the specified folder will follow its parent folder's
@@ -16702,7 +16702,7 @@ impl ::serde::ser::Serialize for SyncSettingArg {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 #[non_exhaustive] // variants may be added in the future
 pub enum SyncSettingsError {
     Path(LookupError),
@@ -16802,7 +16802,7 @@ impl ::std::fmt::Display for SyncSettingsError {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 #[non_exhaustive] // structs may have more fields added in the future.
 pub struct ThumbnailArg {
     /// The path to the image file you want to thumbnail.
@@ -16947,7 +16947,7 @@ impl ::serde::ser::Serialize for ThumbnailArg {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 pub enum ThumbnailError {
     /// An error occurs when downloading metadata for the image.
     Path(LookupError),
@@ -17052,7 +17052,7 @@ impl ::std::fmt::Display for ThumbnailError {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 pub enum ThumbnailFormat {
     Jpeg,
     Png,
@@ -17113,7 +17113,7 @@ impl ::serde::ser::Serialize for ThumbnailFormat {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 pub enum ThumbnailMode {
     /// Scale down the image to fit within the given size.
     Strict,
@@ -17189,7 +17189,7 @@ impl ::serde::ser::Serialize for ThumbnailMode {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 pub enum ThumbnailSize {
     /// 32 by 32 px.
     W32h32,
@@ -17343,7 +17343,7 @@ impl ::serde::ser::Serialize for ThumbnailSize {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 #[non_exhaustive] // structs may have more fields added in the future.
 pub struct ThumbnailV2Arg {
     /// Information specifying which file to preview. This could be a path to a file, a shared link
@@ -17489,7 +17489,7 @@ impl ::serde::ser::Serialize for ThumbnailV2Arg {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 #[non_exhaustive] // variants may be added in the future
 pub enum ThumbnailV2Error {
     /// An error occurred when downloading metadata for the image.
@@ -17629,7 +17629,7 @@ impl ::std::fmt::Display for ThumbnailV2Error {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 #[non_exhaustive] // structs may have more fields added in the future.
 pub struct UnlockFileArg {
     /// Path in the user's Dropbox to a file.
@@ -17719,7 +17719,7 @@ impl ::serde::ser::Serialize for UnlockFileArg {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 #[non_exhaustive] // structs may have more fields added in the future.
 pub struct UnlockFileBatchArg {
     /// List of 'entries'. Each 'entry' contains a path of the file which will be unlocked.
@@ -17810,7 +17810,7 @@ impl ::serde::ser::Serialize for UnlockFileBatchArg {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 #[non_exhaustive] // variants may be added in the future
 pub enum UploadError {
     /// Unable to save the uploaded contents to a file.
@@ -17896,7 +17896,7 @@ impl ::std::fmt::Display for UploadError {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 #[non_exhaustive] // variants may be added in the future
 pub enum UploadErrorWithProperties {
     /// Unable to save the uploaded contents to a file.
@@ -17970,7 +17970,7 @@ impl ::serde::ser::Serialize for UploadErrorWithProperties {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 #[non_exhaustive] // structs may have more fields added in the future.
 pub struct UploadSessionAppendArg {
     /// Contains the upload session ID and the offset.
@@ -18079,7 +18079,7 @@ impl ::serde::ser::Serialize for UploadSessionAppendArg {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 #[non_exhaustive] // structs may have more fields added in the future.
 pub struct UploadSessionCursor {
     /// The upload session ID (returned by [`upload_session_start()`](upload_session_start)).
@@ -18183,7 +18183,7 @@ impl ::serde::ser::Serialize for UploadSessionCursor {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 #[non_exhaustive] // structs may have more fields added in the future.
 pub struct UploadSessionFinishArg {
     /// Contains the upload session ID and the offset.
@@ -18286,7 +18286,7 @@ impl ::serde::ser::Serialize for UploadSessionFinishArg {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 #[non_exhaustive] // structs may have more fields added in the future.
 pub struct UploadSessionFinishBatchArg {
     /// Commit information for each file in the batch.
@@ -18376,7 +18376,7 @@ impl ::serde::ser::Serialize for UploadSessionFinishBatchArg {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 pub enum UploadSessionFinishBatchJobStatus {
     /// The asynchronous job is still in progress.
     InProgress,
@@ -18439,7 +18439,7 @@ impl ::serde::ser::Serialize for UploadSessionFinishBatchJobStatus {
 
 /// Result returned by [`upload_session_finish_batch()`](upload_session_finish_batch) that may
 /// either launch an asynchronous job or complete synchronously.
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 #[non_exhaustive] // variants may be added in the future
 pub enum UploadSessionFinishBatchLaunch {
     /// This response indicates that the processing is asynchronous. The string is an id that can be
@@ -18513,7 +18513,7 @@ impl ::serde::ser::Serialize for UploadSessionFinishBatchLaunch {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 #[non_exhaustive] // structs may have more fields added in the future.
 pub struct UploadSessionFinishBatchResult {
     /// Each entry in [`UploadSessionFinishBatchArg::entries`](UploadSessionFinishBatchArg) will
@@ -18605,7 +18605,7 @@ impl ::serde::ser::Serialize for UploadSessionFinishBatchResult {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 pub enum UploadSessionFinishBatchResultEntry {
     Success(FileMetadata),
     Failure(UploadSessionFinishError),
@@ -18668,7 +18668,7 @@ impl ::serde::ser::Serialize for UploadSessionFinishBatchResultEntry {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 #[non_exhaustive] // variants may be added in the future
 pub enum UploadSessionFinishError {
     /// The session arguments are incorrect; the value explains the reason.
@@ -18845,7 +18845,7 @@ impl ::std::fmt::Display for UploadSessionFinishError {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 #[non_exhaustive] // variants may be added in the future
 pub enum UploadSessionLookupError {
     /// The upload session ID was not found or has expired. Upload sessions are valid for 48 hours.
@@ -18997,7 +18997,7 @@ impl ::std::fmt::Display for UploadSessionLookupError {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 #[non_exhaustive] // structs may have more fields added in the future.
 pub struct UploadSessionOffsetError {
     /// The offset up to which data has been collected.
@@ -19087,7 +19087,7 @@ impl ::serde::ser::Serialize for UploadSessionOffsetError {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 #[non_exhaustive] // structs may have more fields added in the future.
 pub struct UploadSessionStartArg {
     /// If true, the current session will be closed, at which point you won't be able to call
@@ -19193,7 +19193,7 @@ impl ::serde::ser::Serialize for UploadSessionStartArg {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 #[non_exhaustive] // variants may be added in the future
 pub enum UploadSessionStartError {
     /// Uploading data not allowed when starting concurrent upload session.
@@ -19277,7 +19277,7 @@ impl ::std::fmt::Display for UploadSessionStartError {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 #[non_exhaustive] // structs may have more fields added in the future.
 pub struct UploadSessionStartResult {
     /// A unique identifier for the upload session. Pass this to
@@ -19369,7 +19369,7 @@ impl ::serde::ser::Serialize for UploadSessionStartResult {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 #[non_exhaustive] // variants may be added in the future
 pub enum UploadSessionType {
     /// Pieces of content are uploaded sequentially one after another. This is the default behavior.
@@ -19441,7 +19441,7 @@ impl ::serde::ser::Serialize for UploadSessionType {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 #[non_exhaustive] // structs may have more fields added in the future.
 pub struct UploadWriteFailed {
     /// The reason why the file couldn't be saved.
@@ -19547,7 +19547,7 @@ impl ::serde::ser::Serialize for UploadWriteFailed {
 }
 
 /// Metadata for a video.
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 #[non_exhaustive] // structs may have more fields added in the future.
 pub struct VideoMetadata {
     /// Dimension of the photo/video.
@@ -19687,7 +19687,7 @@ impl ::serde::ser::Serialize for VideoMetadata {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 #[non_exhaustive] // variants may be added in the future
 pub enum WriteConflictError {
     /// There's a file in the way.
@@ -19784,7 +19784,7 @@ impl ::std::fmt::Display for WriteConflictError {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 #[non_exhaustive] // variants may be added in the future
 pub enum WriteError {
     /// The given path does not satisfy the required path format. Please refer to the [Path formats
@@ -19966,7 +19966,7 @@ impl ::std::fmt::Display for WriteError {
 /// path refers to a file with identical contents, nothing gets written; no conflict. The conflict
 /// checking differs in the case where there's a file at the target path with contents different
 /// from the contents you're trying to write.
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 pub enum WriteMode {
     /// Do not overwrite an existing file if there is a conflict. The autorename strategy is to
     /// append a number to the file name. For example, "document.txt" might become "document

--- a/src/generated/paper.rs
+++ b/src/generated/paper.rs
@@ -369,7 +369,7 @@ pub fn folders_create(
         None)
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 #[non_exhaustive] // structs may have more fields added in the future.
 pub struct AddMember {
     /// User which should be added to the Paper doc. Specify only email address or Dropbox account
@@ -478,7 +478,7 @@ impl ::serde::ser::Serialize for AddMember {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 #[non_exhaustive] // structs may have more fields added in the future.
 pub struct AddPaperDocUser {
     /// The Paper doc ID.
@@ -619,7 +619,7 @@ impl ::serde::ser::Serialize for AddPaperDocUser {
 }
 
 /// Per-member result for [`docs_users_add()`](docs_users_add).
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 #[non_exhaustive] // structs may have more fields added in the future.
 pub struct AddPaperDocUserMemberResult {
     /// One of specified input members.
@@ -722,7 +722,7 @@ impl ::serde::ser::Serialize for AddPaperDocUserMemberResult {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 #[non_exhaustive] // variants may be added in the future
 pub enum AddPaperDocUserResult {
     /// User was successfully added to the Paper doc.
@@ -859,7 +859,7 @@ impl ::serde::ser::Serialize for AddPaperDocUserResult {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 #[non_exhaustive] // structs may have more fields added in the future.
 pub struct Cursor {
     /// The actual cursor value.
@@ -976,7 +976,7 @@ impl ::serde::ser::Serialize for Cursor {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 #[non_exhaustive] // variants may be added in the future
 pub enum DocLookupError {
     /// Your account does not have permissions to perform this action. This may be due to it only
@@ -1064,7 +1064,7 @@ impl ::std::fmt::Display for DocLookupError {
 }
 
 /// The subscription level of a Paper doc.
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 pub enum DocSubscriptionLevel {
     /// No change email messages unless you're the creator.
     Default,
@@ -1154,7 +1154,7 @@ impl ::serde::ser::Serialize for DocSubscriptionLevel {
 }
 
 /// The desired export format of the Paper doc.
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 #[non_exhaustive] // variants may be added in the future
 pub enum ExportFormat {
     /// The HTML export format.
@@ -1227,7 +1227,7 @@ impl ::serde::ser::Serialize for ExportFormat {
 }
 
 /// Data structure representing a Paper folder.
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 #[non_exhaustive] // structs may have more fields added in the future.
 pub struct Folder {
     /// Paper folder ID. This ID uniquely identifies the folder.
@@ -1332,7 +1332,7 @@ impl ::serde::ser::Serialize for Folder {
 
 /// The sharing policy of a Paper folder. The sharing policy of subfolders is inherited from the
 /// root folder.
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 pub enum FolderSharingPolicyType {
     /// Everyone in your team and anyone directly invited can access this folder.
     Team,
@@ -1396,7 +1396,7 @@ impl ::serde::ser::Serialize for FolderSharingPolicyType {
 }
 
 /// The subscription level of a Paper folder.
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 pub enum FolderSubscriptionLevel {
     /// Not shown in activity, no email messages.
     None,
@@ -1486,7 +1486,7 @@ impl ::serde::ser::Serialize for FolderSubscriptionLevel {
 }
 
 /// Metadata about Paper folders containing the specififed Paper doc.
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 #[non_exhaustive] // structs may have more fields added in the future.
 pub struct FoldersContainingPaperDoc {
     /// The sharing policy of the folder containing the Paper doc.
@@ -1591,7 +1591,7 @@ impl ::serde::ser::Serialize for FoldersContainingPaperDoc {
 }
 
 /// The import format of the incoming data.
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 #[non_exhaustive] // variants may be added in the future
 pub enum ImportFormat {
     /// The provided data is interpreted as standard HTML.
@@ -1678,7 +1678,7 @@ impl ::serde::ser::Serialize for ImportFormat {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 #[non_exhaustive] // structs may have more fields added in the future.
 pub struct InviteeInfoWithPermissionLevel {
     /// Email address invited to the Paper doc.
@@ -1784,7 +1784,7 @@ impl ::serde::ser::Serialize for InviteeInfoWithPermissionLevel {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 #[non_exhaustive] // variants may be added in the future
 pub enum ListDocsCursorError {
     CursorError(PaperApiCursorError),
@@ -1858,7 +1858,7 @@ impl ::std::fmt::Display for ListDocsCursorError {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 #[non_exhaustive] // structs may have more fields added in the future.
 pub struct ListPaperDocsArgs {
     /// Allows user to specify how the Paper docs should be filtered.
@@ -1999,7 +1999,7 @@ impl ::serde::ser::Serialize for ListPaperDocsArgs {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 #[non_exhaustive] // structs may have more fields added in the future.
 pub struct ListPaperDocsContinueArgs {
     /// The cursor obtained from [`docs_list()`](docs_list) or
@@ -2090,7 +2090,7 @@ impl ::serde::ser::Serialize for ListPaperDocsContinueArgs {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 #[non_exhaustive] // variants may be added in the future
 pub enum ListPaperDocsFilterBy {
     /// Fetches all Paper doc IDs that the user has ever accessed.
@@ -2162,7 +2162,7 @@ impl ::serde::ser::Serialize for ListPaperDocsFilterBy {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 #[non_exhaustive] // structs may have more fields added in the future.
 pub struct ListPaperDocsResponse {
     /// The list of Paper doc IDs that can be used to access the given Paper docs or supplied to
@@ -2285,7 +2285,7 @@ impl ::serde::ser::Serialize for ListPaperDocsResponse {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 #[non_exhaustive] // variants may be added in the future
 pub enum ListPaperDocsSortBy {
     /// Sorts the Paper docs by the time they were last accessed.
@@ -2370,7 +2370,7 @@ impl ::serde::ser::Serialize for ListPaperDocsSortBy {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 #[non_exhaustive] // variants may be added in the future
 pub enum ListPaperDocsSortOrder {
     /// Sorts the search result in ascending order.
@@ -2442,7 +2442,7 @@ impl ::serde::ser::Serialize for ListPaperDocsSortOrder {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 #[non_exhaustive] // variants may be added in the future
 pub enum ListUsersCursorError {
     /// Your account does not have permissions to perform this action. This may be due to it only
@@ -2545,7 +2545,7 @@ impl ::std::fmt::Display for ListUsersCursorError {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 #[non_exhaustive] // structs may have more fields added in the future.
 pub struct ListUsersOnFolderArgs {
     /// The Paper doc ID.
@@ -2654,7 +2654,7 @@ impl ::serde::ser::Serialize for ListUsersOnFolderArgs {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 #[non_exhaustive] // structs may have more fields added in the future.
 pub struct ListUsersOnFolderContinueArgs {
     /// The Paper doc ID.
@@ -2759,7 +2759,7 @@ impl ::serde::ser::Serialize for ListUsersOnFolderContinueArgs {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 #[non_exhaustive] // structs may have more fields added in the future.
 pub struct ListUsersOnFolderResponse {
     /// List of email addresses that are invited on the Paper folder.
@@ -2898,7 +2898,7 @@ impl ::serde::ser::Serialize for ListUsersOnFolderResponse {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 #[non_exhaustive] // structs may have more fields added in the future.
 pub struct ListUsersOnPaperDocArgs {
     /// The Paper doc ID.
@@ -3025,7 +3025,7 @@ impl ::serde::ser::Serialize for ListUsersOnPaperDocArgs {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 #[non_exhaustive] // structs may have more fields added in the future.
 pub struct ListUsersOnPaperDocContinueArgs {
     /// The Paper doc ID.
@@ -3129,7 +3129,7 @@ impl ::serde::ser::Serialize for ListUsersOnPaperDocContinueArgs {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 #[non_exhaustive] // structs may have more fields added in the future.
 pub struct ListUsersOnPaperDocResponse {
     /// List of email addresses with their respective permission levels that are invited on the
@@ -3283,7 +3283,7 @@ impl ::serde::ser::Serialize for ListUsersOnPaperDocResponse {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 #[non_exhaustive] // variants may be added in the future
 pub enum PaperApiBaseError {
     /// Your account does not have permissions to perform this action. This may be due to it only
@@ -3357,7 +3357,7 @@ impl ::std::fmt::Display for PaperApiBaseError {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 #[non_exhaustive] // variants may be added in the future
 pub enum PaperApiCursorError {
     /// The provided cursor is expired.
@@ -3468,7 +3468,7 @@ impl ::std::fmt::Display for PaperApiCursorError {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 #[non_exhaustive] // structs may have more fields added in the future.
 pub struct PaperDocCreateArgs {
     /// The format of provided data.
@@ -3577,7 +3577,7 @@ impl ::serde::ser::Serialize for PaperDocCreateArgs {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 #[non_exhaustive] // variants may be added in the future
 pub enum PaperDocCreateError {
     /// Your account does not have permissions to perform this action. This may be due to it only
@@ -3704,7 +3704,7 @@ impl ::std::fmt::Display for PaperDocCreateError {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 #[non_exhaustive] // structs may have more fields added in the future.
 pub struct PaperDocCreateUpdateResult {
     /// Doc ID of the newly created doc.
@@ -3820,7 +3820,7 @@ impl ::serde::ser::Serialize for PaperDocCreateUpdateResult {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 #[non_exhaustive] // structs may have more fields added in the future.
 pub struct PaperDocExport {
     /// The Paper doc ID.
@@ -3922,7 +3922,7 @@ impl ::serde::ser::Serialize for PaperDocExport {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 #[non_exhaustive] // structs may have more fields added in the future.
 pub struct PaperDocExportResult {
     /// The Paper doc owner's email address.
@@ -4052,7 +4052,7 @@ impl ::serde::ser::Serialize for PaperDocExportResult {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 #[non_exhaustive] // variants may be added in the future
 pub enum PaperDocPermissionLevel {
     /// User will be granted edit permissions.
@@ -4124,7 +4124,7 @@ impl ::serde::ser::Serialize for PaperDocPermissionLevel {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 #[non_exhaustive] // structs may have more fields added in the future.
 pub struct PaperDocSharingPolicy {
     /// The Paper doc ID.
@@ -4227,7 +4227,7 @@ impl ::serde::ser::Serialize for PaperDocSharingPolicy {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 #[non_exhaustive] // structs may have more fields added in the future.
 pub struct PaperDocUpdateArgs {
     /// The Paper doc ID.
@@ -4362,7 +4362,7 @@ impl ::serde::ser::Serialize for PaperDocUpdateArgs {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 #[non_exhaustive] // variants may be added in the future
 pub enum PaperDocUpdateError {
     /// Your account does not have permissions to perform this action. This may be due to it only
@@ -4528,7 +4528,7 @@ impl ::std::fmt::Display for PaperDocUpdateError {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 #[non_exhaustive] // variants may be added in the future
 pub enum PaperDocUpdatePolicy {
     /// The content will be appended to the doc.
@@ -4613,7 +4613,7 @@ impl ::serde::ser::Serialize for PaperDocUpdatePolicy {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 #[non_exhaustive] // structs may have more fields added in the future.
 pub struct PaperFolderCreateArg {
     /// The name of the new Paper folder.
@@ -4744,7 +4744,7 @@ impl ::serde::ser::Serialize for PaperFolderCreateArg {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 #[non_exhaustive] // variants may be added in the future
 pub enum PaperFolderCreateError {
     /// Your account does not have permissions to perform this action. This may be due to it only
@@ -4844,7 +4844,7 @@ impl ::std::fmt::Display for PaperFolderCreateError {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 #[non_exhaustive] // structs may have more fields added in the future.
 pub struct PaperFolderCreateResult {
     /// Folder ID of the newly created folder.
@@ -4934,7 +4934,7 @@ impl ::serde::ser::Serialize for PaperFolderCreateResult {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 #[non_exhaustive] // structs may have more fields added in the future.
 pub struct RefPaperDoc {
     /// The Paper doc ID.
@@ -5024,7 +5024,7 @@ impl ::serde::ser::Serialize for RefPaperDoc {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 #[non_exhaustive] // structs may have more fields added in the future.
 pub struct RemovePaperDocUser {
     /// The Paper doc ID.
@@ -5129,7 +5129,7 @@ impl ::serde::ser::Serialize for RemovePaperDocUser {
 }
 
 /// Sharing policy of Paper doc.
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 #[non_exhaustive] // structs may have more fields added in the future.
 pub struct SharingPolicy {
     /// This value applies to the non-team members.
@@ -5233,7 +5233,7 @@ impl ::serde::ser::Serialize for SharingPolicy {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 pub enum SharingPublicPolicyType {
     /// Users who have a link to this doc can edit it.
     PeopleWithLinkCanEdit,
@@ -5323,7 +5323,7 @@ impl ::serde::ser::Serialize for SharingPublicPolicyType {
 }
 
 /// The sharing policy type of the Paper doc.
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 pub enum SharingTeamPolicyType {
     /// Users who have a link to this doc can edit it.
     PeopleWithLinkCanEdit,
@@ -5399,7 +5399,7 @@ impl ::serde::ser::Serialize for SharingTeamPolicyType {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 #[non_exhaustive] // structs may have more fields added in the future.
 pub struct UserInfoWithPermissionLevel {
     /// User shared on the Paper doc.
@@ -5502,7 +5502,7 @@ impl ::serde::ser::Serialize for UserInfoWithPermissionLevel {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 #[non_exhaustive] // variants may be added in the future
 pub enum UserOnPaperDocFilter {
     /// all users who have visited the Paper doc.

--- a/src/generated/secondary_emails.rs
+++ b/src/generated/secondary_emails.rs
@@ -7,7 +7,7 @@
     clippy::doc_markdown,
 )]
 
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 #[non_exhaustive] // structs may have more fields added in the future.
 pub struct SecondaryEmail {
     /// Secondary email address.

--- a/src/generated/seen_state.rs
+++ b/src/generated/seen_state.rs
@@ -8,7 +8,7 @@
 )]
 
 /// Possible platforms on which a user may view content.
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 #[non_exhaustive] // variants may be added in the future
 pub enum PlatformType {
     /// The content was viewed on the web.

--- a/src/generated/sharing.rs
+++ b/src/generated/sharing.rs
@@ -688,7 +688,7 @@ pub fn update_folder_policy(
 }
 
 /// Information about the inheritance policy of a shared folder.
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 #[non_exhaustive] // variants may be added in the future
 pub enum AccessInheritance {
     /// The shared folder inherits its members from the parent folder.
@@ -761,7 +761,7 @@ impl ::serde::ser::Serialize for AccessInheritance {
 }
 
 /// Defines the access levels for collaborators.
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 #[non_exhaustive] // variants may be added in the future
 pub enum AccessLevel {
     /// The collaborator is the owner of the shared folder. Owners can view and edit the shared
@@ -863,7 +863,7 @@ impl ::serde::ser::Serialize for AccessLevel {
 
 /// Who can change a shared folder's access control list (ACL). In other words, who can add, remove,
 /// or change the privileges of members.
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 #[non_exhaustive] // variants may be added in the future
 pub enum AclUpdatePolicy {
     /// Only the owner can update the ACL.
@@ -936,7 +936,7 @@ impl ::serde::ser::Serialize for AclUpdatePolicy {
 }
 
 /// Arguments for [`add_file_member()`](add_file_member).
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 #[non_exhaustive] // structs may have more fields added in the future.
 pub struct AddFileMemberArgs {
     /// File to which to add members.
@@ -1113,7 +1113,7 @@ impl ::serde::ser::Serialize for AddFileMemberArgs {
 }
 
 /// Errors for [`add_file_member()`](add_file_member).
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 #[non_exhaustive] // variants may be added in the future
 pub enum AddFileMemberError {
     UserError(SharingUserError),
@@ -1229,7 +1229,7 @@ impl ::std::fmt::Display for AddFileMemberError {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 #[non_exhaustive] // structs may have more fields added in the future.
 pub struct AddFolderMemberArg {
     /// The ID for the shared folder.
@@ -1369,7 +1369,7 @@ impl ::serde::ser::Serialize for AddFolderMemberArg {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 #[non_exhaustive] // variants may be added in the future
 pub enum AddFolderMemberError {
     /// Unable to access shared folder.
@@ -1617,7 +1617,7 @@ impl ::std::fmt::Display for AddFolderMemberError {
 }
 
 /// The member and type of access the member should have when added to a shared folder.
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 #[non_exhaustive] // structs may have more fields added in the future.
 pub struct AddMember {
     /// The member to add to the shared folder.
@@ -1726,7 +1726,7 @@ impl ::serde::ser::Serialize for AddMember {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 #[non_exhaustive] // variants may be added in the future
 pub enum AddMemberSelectorError {
     /// Automatically created groups can only be added to team folders.
@@ -1877,7 +1877,7 @@ impl ::std::fmt::Display for AddMemberSelectorError {
 }
 
 /// Information about the content that has a link audience different than that of this folder.
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 #[non_exhaustive] // structs may have more fields added in the future.
 pub struct AudienceExceptionContentInfo {
     /// The name of the content, which is either a file or a folder.
@@ -1969,7 +1969,7 @@ impl ::serde::ser::Serialize for AudienceExceptionContentInfo {
 
 /// The total count and truncated list of information of content inside this folder that has a
 /// different audience than the link on this folder. This is only returned for folders.
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 #[non_exhaustive] // structs may have more fields added in the future.
 pub struct AudienceExceptions {
     pub count: u32,
@@ -2075,7 +2075,7 @@ impl ::serde::ser::Serialize for AudienceExceptions {
 
 /// Information about the shared folder that prevents the link audience for this link from being
 /// more restrictive.
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 #[non_exhaustive] // structs may have more fields added in the future.
 pub struct AudienceRestrictingSharedFolder {
     /// The ID of the shared folder.
@@ -2196,7 +2196,7 @@ impl ::serde::ser::Serialize for AudienceRestrictingSharedFolder {
 }
 
 /// Arguments for [`change_file_member_access()`](change_file_member_access).
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 #[non_exhaustive] // structs may have more fields added in the future.
 pub struct ChangeFileMemberAccessArgs {
     /// File for which we are changing a member's access.
@@ -2313,7 +2313,7 @@ impl ::serde::ser::Serialize for ChangeFileMemberAccessArgs {
 }
 
 /// Metadata for a collection-based shared link.
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 #[non_exhaustive] // structs may have more fields added in the future.
 pub struct CollectionLinkMetadata {
     /// URL of the shared link.
@@ -2434,7 +2434,7 @@ impl ::serde::ser::Serialize for CollectionLinkMetadata {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 #[non_exhaustive] // structs may have more fields added in the future.
 pub struct CreateSharedLinkArg {
     /// The path to share.
@@ -2563,7 +2563,7 @@ impl ::serde::ser::Serialize for CreateSharedLinkArg {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 #[non_exhaustive] // variants may be added in the future
 pub enum CreateSharedLinkError {
     Path(super::files::LookupError),
@@ -2637,7 +2637,7 @@ impl ::std::fmt::Display for CreateSharedLinkError {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 #[non_exhaustive] // structs may have more fields added in the future.
 pub struct CreateSharedLinkWithSettingsArg {
     /// The path to be shared by the shared link.
@@ -2745,7 +2745,7 @@ impl ::serde::ser::Serialize for CreateSharedLinkWithSettingsArg {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 pub enum CreateSharedLinkWithSettingsError {
     Path(super::files::LookupError),
     /// This user's email address is not verified. This functionality is only available on accounts
@@ -2875,7 +2875,7 @@ impl ::std::fmt::Display for CreateSharedLinkWithSettingsError {
 
 /// The expected metadata of a shared link for a file or folder when a link is first created for the
 /// content. Absent if the link already exists.
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 #[non_exhaustive] // structs may have more fields added in the future.
 pub struct ExpectedSharedContentLinkMetadata {
     /// The audience options that are available for the content. Some audience options may be
@@ -3071,7 +3071,7 @@ impl ::serde::ser::Serialize for ExpectedSharedContentLinkMetadata {
 }
 
 /// Sharing actions that may be taken on files.
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 #[non_exhaustive] // variants may be added in the future
 pub enum FileAction {
     /// Disable viewer information on the file.
@@ -3273,7 +3273,7 @@ impl ::serde::ser::Serialize for FileAction {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 #[non_exhaustive] // variants may be added in the future
 pub enum FileErrorResult {
     /// File specified by id was not found.
@@ -3371,7 +3371,7 @@ impl ::serde::ser::Serialize for FileErrorResult {
 }
 
 /// The metadata of a file shared link.
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 #[non_exhaustive] // structs may have more fields added in the future.
 pub struct FileLinkMetadata {
     /// URL of the shared link.
@@ -3645,7 +3645,7 @@ impl ::serde::ser::Serialize for FileLinkMetadata {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 #[non_exhaustive] // variants may be added in the future
 pub enum FileMemberActionError {
     /// Specified member was not found.
@@ -3759,7 +3759,7 @@ impl ::std::fmt::Display for FileMemberActionError {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 pub enum FileMemberActionIndividualResult {
     /// Member was successfully removed from this file. If AccessLevel is given, the member still
     /// has access via a parent shared folder.
@@ -3833,7 +3833,7 @@ impl ::serde::ser::Serialize for FileMemberActionIndividualResult {
 
 /// Per-member result for [`add_file_member()`](add_file_member) or
 /// [`change_file_member_access()`](change_file_member_access).
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 #[non_exhaustive] // structs may have more fields added in the future.
 pub struct FileMemberActionResult {
     /// One of specified input members.
@@ -3936,7 +3936,7 @@ impl ::serde::ser::Serialize for FileMemberActionResult {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 #[non_exhaustive] // variants may be added in the future
 pub enum FileMemberRemoveActionResult {
     /// Member was successfully removed from this file.
@@ -4011,7 +4011,7 @@ impl ::serde::ser::Serialize for FileMemberRemoveActionResult {
 }
 
 /// Whether the user is allowed to take the sharing action on the file.
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 #[non_exhaustive] // structs may have more fields added in the future.
 pub struct FilePermission {
     /// The action that the user may wish to take on the file.
@@ -4133,7 +4133,7 @@ impl ::serde::ser::Serialize for FilePermission {
 }
 
 /// Actions that may be taken on shared folders.
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 #[non_exhaustive] // variants may be added in the future
 pub enum FolderAction {
     /// Change folder options, such as who can be invited to join the folder.
@@ -4362,7 +4362,7 @@ impl ::serde::ser::Serialize for FolderAction {
 }
 
 /// The metadata of a folder shared link.
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 #[non_exhaustive] // structs may have more fields added in the future.
 pub struct FolderLinkMetadata {
     /// URL of the shared link.
@@ -4573,7 +4573,7 @@ impl ::serde::ser::Serialize for FolderLinkMetadata {
 }
 
 /// Whether the user is allowed to take the action on the shared folder.
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 #[non_exhaustive] // structs may have more fields added in the future.
 pub struct FolderPermission {
     /// The action that the user may wish to take on the folder.
@@ -4696,7 +4696,7 @@ impl ::serde::ser::Serialize for FolderPermission {
 }
 
 /// A set of policies governing membership and privileges for a shared folder.
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 #[non_exhaustive] // structs may have more fields added in the future.
 pub struct FolderPolicy {
     /// Who can add and remove members from this shared folder.
@@ -4858,7 +4858,7 @@ impl ::serde::ser::Serialize for FolderPolicy {
 }
 
 /// Arguments of [`get_file_metadata()`](get_file_metadata).
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 #[non_exhaustive] // structs may have more fields added in the future.
 pub struct GetFileMetadataArg {
     /// The file to query.
@@ -4969,7 +4969,7 @@ impl ::serde::ser::Serialize for GetFileMetadataArg {
 }
 
 /// Arguments of [`get_file_metadata_batch()`](get_file_metadata_batch).
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 #[non_exhaustive] // structs may have more fields added in the future.
 pub struct GetFileMetadataBatchArg {
     /// The files to query.
@@ -5080,7 +5080,7 @@ impl ::serde::ser::Serialize for GetFileMetadataBatchArg {
 }
 
 /// Per file results of [`get_file_metadata_batch()`](get_file_metadata_batch).
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 #[non_exhaustive] // structs may have more fields added in the future.
 pub struct GetFileMetadataBatchResult {
     /// This is the input file identifier corresponding to one of
@@ -5185,7 +5185,7 @@ impl ::serde::ser::Serialize for GetFileMetadataBatchResult {
 }
 
 /// Error result for [`get_file_metadata()`](get_file_metadata).
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 #[non_exhaustive] // variants may be added in the future
 pub enum GetFileMetadataError {
     UserError(SharingUserError),
@@ -5275,7 +5275,7 @@ impl ::std::fmt::Display for GetFileMetadataError {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 #[non_exhaustive] // variants may be added in the future
 pub enum GetFileMetadataIndividualResult {
     /// The result for this file if it was successful.
@@ -5349,7 +5349,7 @@ impl ::serde::ser::Serialize for GetFileMetadataIndividualResult {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 #[non_exhaustive] // structs may have more fields added in the future.
 pub struct GetMetadataArgs {
     /// The ID for the shared folder.
@@ -5459,7 +5459,7 @@ impl ::serde::ser::Serialize for GetMetadataArgs {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 #[non_exhaustive] // variants may be added in the future
 pub enum GetSharedLinkFileError {
     /// The shared link wasn't found.
@@ -5569,7 +5569,7 @@ impl ::std::fmt::Display for GetSharedLinkFileError {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 #[non_exhaustive] // structs may have more fields added in the future.
 pub struct GetSharedLinkMetadataArg {
     /// URL of the shared link.
@@ -5696,7 +5696,7 @@ impl ::serde::ser::Serialize for GetSharedLinkMetadataArg {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 #[non_exhaustive] // structs may have more fields added in the future.
 pub struct GetSharedLinksArg {
     /// See [`get_shared_links()`](get_shared_links) description.
@@ -5782,7 +5782,7 @@ impl ::serde::ser::Serialize for GetSharedLinksArg {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 #[non_exhaustive] // variants may be added in the future
 pub enum GetSharedLinksError {
     Path(super::files::MalformedPathError),
@@ -5859,7 +5859,7 @@ impl ::std::fmt::Display for GetSharedLinksError {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 #[non_exhaustive] // structs may have more fields added in the future.
 pub struct GetSharedLinksResult {
     /// Shared links applicable to the path argument.
@@ -5951,7 +5951,7 @@ impl ::serde::ser::Serialize for GetSharedLinksResult {
 
 /// The information about a group. Groups is a way to manage a list of users  who need same access
 /// permission to the shared folder.
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 #[non_exhaustive] // structs may have more fields added in the future.
 pub struct GroupInfo {
     pub group_name: String,
@@ -6162,7 +6162,7 @@ impl ::serde::ser::Serialize for GroupInfo {
 }
 
 /// The information about a group member of the shared content.
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 #[non_exhaustive] // structs may have more fields added in the future.
 pub struct GroupMembershipInfo {
     /// The access type for this member. It contains inherited access type from parent folder, and
@@ -6321,7 +6321,7 @@ impl ::serde::ser::Serialize for GroupMembershipInfo {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 #[non_exhaustive] // structs may have more fields added in the future.
 pub struct InsufficientPlan {
     /// A message to tell the user to upgrade in order to support expected action.
@@ -6430,7 +6430,7 @@ impl ::serde::ser::Serialize for InsufficientPlan {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 #[non_exhaustive] // structs may have more fields added in the future.
 pub struct InsufficientQuotaAmounts {
     /// The amount of space needed to add the item (the size of the item).
@@ -6547,7 +6547,7 @@ impl ::serde::ser::Serialize for InsufficientQuotaAmounts {
 }
 
 /// Information about the recipient of a shared content invitation.
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 #[non_exhaustive] // variants may be added in the future
 pub enum InviteeInfo {
     /// Email address of invited user.
@@ -6611,7 +6611,7 @@ impl ::serde::ser::Serialize for InviteeInfo {
 }
 
 /// Information about an invited member of a shared content.
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 #[non_exhaustive] // structs may have more fields added in the future.
 pub struct InviteeMembershipInfo {
     /// The access type for this member. It contains inherited access type from parent folder, and
@@ -6790,7 +6790,7 @@ impl ::serde::ser::Serialize for InviteeMembershipInfo {
 
 /// Error occurred while performing an asynchronous job from [`unshare_folder()`](unshare_folder) or
 /// [`remove_folder_member()`](remove_folder_member).
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 #[non_exhaustive] // variants may be added in the future
 pub enum JobError {
     /// Error occurred while performing [`unshare_folder()`](unshare_folder) action.
@@ -6900,7 +6900,7 @@ impl ::std::fmt::Display for JobError {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 pub enum JobStatus {
     /// The asynchronous job is still in progress.
     InProgress,
@@ -6980,7 +6980,7 @@ impl ::serde::ser::Serialize for JobStatus {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 #[non_exhaustive] // variants may be added in the future
 pub enum LinkAccessLevel {
     /// Users who use the link can view and comment on the content.
@@ -7053,7 +7053,7 @@ impl ::serde::ser::Serialize for LinkAccessLevel {
 }
 
 /// Actions that can be performed on a link.
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 #[non_exhaustive] // variants may be added in the future
 pub enum LinkAction {
     /// Change the access level of the link.
@@ -7177,7 +7177,7 @@ impl ::serde::ser::Serialize for LinkAction {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 #[non_exhaustive] // variants may be added in the future
 pub enum LinkAudience {
     /// Link is accessible by anyone.
@@ -7290,7 +7290,7 @@ impl ::serde::ser::Serialize for LinkAudience {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 #[non_exhaustive] // variants may be added in the future
 pub enum LinkExpiry {
     /// Remove the currently set expiry for the link.
@@ -7368,7 +7368,7 @@ impl ::serde::ser::Serialize for LinkExpiry {
 
 /// Metadata for a shared link. This can be either a [`PathLinkMetadata`](PathLinkMetadata) or
 /// [`CollectionLinkMetadata`](CollectionLinkMetadata).
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 #[non_exhaustive] // variants may be added in the future
 pub enum LinkMetadata {
     Path(PathLinkMetadata),
@@ -7436,7 +7436,7 @@ impl ::serde::ser::Serialize for LinkMetadata {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 #[non_exhaustive] // variants may be added in the future
 pub enum LinkPassword {
     /// Remove the currently set password for the link.
@@ -7513,7 +7513,7 @@ impl ::serde::ser::Serialize for LinkPassword {
 }
 
 /// Permissions for actions that can be performed on a link.
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 #[non_exhaustive] // structs may have more fields added in the future.
 pub struct LinkPermission {
     pub action: LinkAction,
@@ -7631,7 +7631,7 @@ impl ::serde::ser::Serialize for LinkPermission {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 #[non_exhaustive] // structs may have more fields added in the future.
 pub struct LinkPermissions {
     /// Whether the caller can revoke the shared link.
@@ -7826,7 +7826,7 @@ impl ::serde::ser::Serialize for LinkPermissions {
 }
 
 /// Settings that apply to a link.
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 #[non_exhaustive] // structs may have more fields added in the future.
 pub struct LinkSettings {
     /// The access level on the link for this file. Currently, it only accepts 'viewer' and
@@ -7968,7 +7968,7 @@ impl ::serde::ser::Serialize for LinkSettings {
 }
 
 /// Arguments for [`list_file_members()`](list_file_members).
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 #[non_exhaustive] // structs may have more fields added in the future.
 pub struct ListFileMembersArg {
     /// The file for which you want to see members.
@@ -8113,7 +8113,7 @@ impl ::serde::ser::Serialize for ListFileMembersArg {
 }
 
 /// Arguments for [`list_file_members_batch()`](list_file_members_batch).
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 #[non_exhaustive] // structs may have more fields added in the future.
 pub struct ListFileMembersBatchArg {
     /// Files for which to return members.
@@ -8222,7 +8222,7 @@ impl ::serde::ser::Serialize for ListFileMembersBatchArg {
 }
 
 /// Per-file result for [`list_file_members_batch()`](list_file_members_batch).
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 #[non_exhaustive] // structs may have more fields added in the future.
 pub struct ListFileMembersBatchResult {
     /// This is the input file identifier, whether an ID or a path.
@@ -8326,7 +8326,7 @@ impl ::serde::ser::Serialize for ListFileMembersBatchResult {
 }
 
 /// Arguments for [`list_file_members_continue()`](list_file_members_continue).
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 #[non_exhaustive] // structs may have more fields added in the future.
 pub struct ListFileMembersContinueArg {
     /// The cursor returned by your last call to [`list_file_members()`](list_file_members),
@@ -8419,7 +8419,7 @@ impl ::serde::ser::Serialize for ListFileMembersContinueArg {
 }
 
 /// Error for [`list_file_members_continue()`](list_file_members_continue).
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 #[non_exhaustive] // variants may be added in the future
 pub enum ListFileMembersContinueError {
     UserError(SharingUserError),
@@ -8522,7 +8522,7 @@ impl ::std::fmt::Display for ListFileMembersContinueError {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 #[non_exhaustive] // structs may have more fields added in the future.
 pub struct ListFileMembersCountResult {
     /// A list of members on this file.
@@ -8626,7 +8626,7 @@ impl ::serde::ser::Serialize for ListFileMembersCountResult {
 }
 
 /// Error for [`list_file_members()`](list_file_members).
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 #[non_exhaustive] // variants may be added in the future
 pub enum ListFileMembersError {
     UserError(SharingUserError),
@@ -8716,7 +8716,7 @@ impl ::std::fmt::Display for ListFileMembersError {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 #[non_exhaustive] // variants may be added in the future
 pub enum ListFileMembersIndividualResult {
     /// The results of the query for this file if it was successful.
@@ -8791,7 +8791,7 @@ impl ::serde::ser::Serialize for ListFileMembersIndividualResult {
 }
 
 /// Arguments for [`list_received_files()`](list_received_files).
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 #[non_exhaustive] // structs may have more fields added in the future.
 pub struct ListFilesArg {
     /// Number of files to return max per query. Defaults to 100 if no limit is specified.
@@ -8898,7 +8898,7 @@ impl ::serde::ser::Serialize for ListFilesArg {
 }
 
 /// Arguments for [`list_received_files_continue()`](list_received_files_continue).
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 #[non_exhaustive] // structs may have more fields added in the future.
 pub struct ListFilesContinueArg {
     /// Cursor in [`ListFilesResult::cursor`](ListFilesResult).
@@ -8989,7 +8989,7 @@ impl ::serde::ser::Serialize for ListFilesContinueArg {
 }
 
 /// Error results for [`list_received_files_continue()`](list_received_files_continue).
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 #[non_exhaustive] // variants may be added in the future
 pub enum ListFilesContinueError {
     /// User account had a problem.
@@ -9078,7 +9078,7 @@ impl ::std::fmt::Display for ListFilesContinueError {
 }
 
 /// Success results for [`list_received_files()`](list_received_files).
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 #[non_exhaustive] // structs may have more fields added in the future.
 pub struct ListFilesResult {
     /// Information about the files shared with current user.
@@ -9186,7 +9186,7 @@ impl ::serde::ser::Serialize for ListFilesResult {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 #[non_exhaustive] // structs may have more fields added in the future.
 pub struct ListFolderMembersArgs {
     /// The ID for the shared folder.
@@ -9315,7 +9315,7 @@ impl ::serde::ser::Serialize for ListFolderMembersArgs {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 #[non_exhaustive] // structs may have more fields added in the future.
 pub struct ListFolderMembersContinueArg {
     /// The cursor returned by your last call to [`list_folder_members()`](list_folder_members) or
@@ -9406,7 +9406,7 @@ impl ::serde::ser::Serialize for ListFolderMembersContinueArg {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 #[non_exhaustive] // variants may be added in the future
 pub enum ListFolderMembersContinueError {
     AccessError(SharedFolderAccessError),
@@ -9493,7 +9493,7 @@ impl ::std::fmt::Display for ListFolderMembersContinueError {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 #[non_exhaustive] // structs may have more fields added in the future.
 pub struct ListFolderMembersCursorArg {
     /// This is a list indicating whether each returned member will include a boolean value
@@ -9600,7 +9600,7 @@ impl ::serde::ser::Serialize for ListFolderMembersCursorArg {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 #[non_exhaustive] // structs may have more fields added in the future.
 pub struct ListFoldersArgs {
     /// The maximum number of results to return per request.
@@ -9706,7 +9706,7 @@ impl ::serde::ser::Serialize for ListFoldersArgs {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 #[non_exhaustive] // structs may have more fields added in the future.
 pub struct ListFoldersContinueArg {
     /// The cursor returned by the previous API call specified in the endpoint description.
@@ -9796,7 +9796,7 @@ impl ::serde::ser::Serialize for ListFoldersContinueArg {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 #[non_exhaustive] // variants may be added in the future
 pub enum ListFoldersContinueError {
     /// [`ListFoldersContinueArg::cursor`](ListFoldersContinueArg) is invalid.
@@ -9871,7 +9871,7 @@ impl ::std::fmt::Display for ListFoldersContinueError {
 /// [`list_mountable_folders()`](list_mountable_folders), depending on which endpoint was requested.
 /// Unmounted shared folders can be identified by the absence of
 /// [`SharedFolderMetadata::path_lower`](SharedFolderMetadata).
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 #[non_exhaustive] // structs may have more fields added in the future.
 pub struct ListFoldersResult {
     /// List of all shared folders the authenticated user has access to.
@@ -9983,7 +9983,7 @@ impl ::serde::ser::Serialize for ListFoldersResult {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 #[non_exhaustive] // structs may have more fields added in the future.
 pub struct ListSharedLinksArg {
     /// See [`list_shared_links()`](list_shared_links) description.
@@ -10105,7 +10105,7 @@ impl ::serde::ser::Serialize for ListSharedLinksArg {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 #[non_exhaustive] // variants may be added in the future
 pub enum ListSharedLinksError {
     Path(super::files::LookupError),
@@ -10193,7 +10193,7 @@ impl ::std::fmt::Display for ListSharedLinksError {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 #[non_exhaustive] // structs may have more fields added in the future.
 pub struct ListSharedLinksResult {
     /// Shared links applicable to the path argument.
@@ -10317,7 +10317,7 @@ impl ::serde::ser::Serialize for ListSharedLinksResult {
 }
 
 /// Contains information about a member's access level to content after an operation.
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 #[non_exhaustive] // structs may have more fields added in the future.
 pub struct MemberAccessLevelResult {
     /// The member still has this level of access to the content through a parent folder.
@@ -10442,7 +10442,7 @@ impl ::serde::ser::Serialize for MemberAccessLevelResult {
 }
 
 /// Actions that may be taken on members of a shared folder.
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 #[non_exhaustive] // variants may be added in the future
 pub enum MemberAction {
     /// Allow the member to keep a copy of the folder when removing.
@@ -10567,7 +10567,7 @@ impl ::serde::ser::Serialize for MemberAction {
 }
 
 /// Whether the user is allowed to take the action on the associated member.
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 #[non_exhaustive] // structs may have more fields added in the future.
 pub struct MemberPermission {
     /// The action that the user may wish to take on the member.
@@ -10690,7 +10690,7 @@ impl ::serde::ser::Serialize for MemberPermission {
 
 /// Policy governing who can be a member of a shared folder. Only applicable to folders owned by a
 /// user on a team.
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 #[non_exhaustive] // variants may be added in the future
 pub enum MemberPolicy {
     /// Only a teammate can become a member.
@@ -10763,7 +10763,7 @@ impl ::serde::ser::Serialize for MemberPolicy {
 }
 
 /// Includes different ways to identify a member of a shared folder.
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 #[non_exhaustive] // variants may be added in the future
 pub enum MemberSelector {
     /// Dropbox account, team member, or group ID of member.
@@ -10844,7 +10844,7 @@ impl ::serde::ser::Serialize for MemberSelector {
 }
 
 /// The information about a member of the shared content.
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 #[non_exhaustive] // structs may have more fields added in the future.
 pub struct MembershipInfo {
     /// The access type for this member. It contains inherited access type from parent folder, and
@@ -10990,7 +10990,7 @@ impl ::serde::ser::Serialize for MembershipInfo {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 #[non_exhaustive] // structs may have more fields added in the future.
 pub struct ModifySharedLinkSettingsArgs {
     /// URL of the shared link to change its settings.
@@ -11111,7 +11111,7 @@ impl ::serde::ser::Serialize for ModifySharedLinkSettingsArgs {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 #[non_exhaustive] // variants may be added in the future
 pub enum ModifySharedLinkSettingsError {
     /// The shared link wasn't found.
@@ -11240,7 +11240,7 @@ impl ::std::fmt::Display for ModifySharedLinkSettingsError {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 #[non_exhaustive] // structs may have more fields added in the future.
 pub struct MountFolderArg {
     /// The ID of the shared folder to mount.
@@ -11330,7 +11330,7 @@ impl ::serde::ser::Serialize for MountFolderArg {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 #[non_exhaustive] // variants may be added in the future
 pub enum MountFolderError {
     AccessError(SharedFolderAccessError),
@@ -11469,7 +11469,7 @@ impl ::std::fmt::Display for MountFolderError {
 }
 
 /// Contains information about a parent folder that a member has access to.
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 #[non_exhaustive] // structs may have more fields added in the future.
 pub struct ParentFolderAccessInfo {
     /// Display name for the folder.
@@ -11604,7 +11604,7 @@ impl ::serde::ser::Serialize for ParentFolderAccessInfo {
 }
 
 /// Metadata for a path-based shared link.
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 #[non_exhaustive] // structs may have more fields added in the future.
 pub struct PathLinkMetadata {
     /// URL of the shared link.
@@ -11739,7 +11739,7 @@ impl ::serde::ser::Serialize for PathLinkMetadata {
 }
 
 /// Flag to indicate pending upload default (for linking to not-yet-existing paths).
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 pub enum PendingUploadMode {
     /// Assume pending uploads are files.
     File,
@@ -11803,7 +11803,7 @@ impl ::serde::ser::Serialize for PendingUploadMode {
 }
 
 /// Possible reasons the user is denied a permission.
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 #[non_exhaustive] // variants may be added in the future
 pub enum PermissionDeniedReason {
     /// User is not on the same team as the folder owner.
@@ -12041,7 +12041,7 @@ impl ::serde::ser::Serialize for PermissionDeniedReason {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 #[non_exhaustive] // structs may have more fields added in the future.
 pub struct RelinquishFileMembershipArg {
     /// The path or id for the file.
@@ -12131,7 +12131,7 @@ impl ::serde::ser::Serialize for RelinquishFileMembershipArg {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 #[non_exhaustive] // variants may be added in the future
 pub enum RelinquishFileMembershipError {
     AccessError(SharingFileAccessError),
@@ -12232,7 +12232,7 @@ impl ::std::fmt::Display for RelinquishFileMembershipError {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 #[non_exhaustive] // structs may have more fields added in the future.
 pub struct RelinquishFolderMembershipArg {
     /// The ID for the shared folder.
@@ -12340,7 +12340,7 @@ impl ::serde::ser::Serialize for RelinquishFolderMembershipArg {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 #[non_exhaustive] // variants may be added in the future
 pub enum RelinquishFolderMembershipError {
     AccessError(SharedFolderAccessError),
@@ -12497,7 +12497,7 @@ impl ::std::fmt::Display for RelinquishFolderMembershipError {
 }
 
 /// Arguments for [`remove_file_member_2()`](remove_file_member_2).
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 #[non_exhaustive] // structs may have more fields added in the future.
 pub struct RemoveFileMemberArg {
     /// File from which to remove members.
@@ -12603,7 +12603,7 @@ impl ::serde::ser::Serialize for RemoveFileMemberArg {
 }
 
 /// Errors for [`remove_file_member_2()`](remove_file_member_2).
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 #[non_exhaustive] // variants may be added in the future
 pub enum RemoveFileMemberError {
     UserError(SharingUserError),
@@ -12705,7 +12705,7 @@ impl ::std::fmt::Display for RemoveFileMemberError {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 #[non_exhaustive] // structs may have more fields added in the future.
 pub struct RemoveFolderMemberArg {
     /// The ID for the shared folder.
@@ -12827,7 +12827,7 @@ impl ::serde::ser::Serialize for RemoveFolderMemberArg {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 #[non_exhaustive] // variants may be added in the future
 pub enum RemoveFolderMemberError {
     AccessError(SharedFolderAccessError),
@@ -12984,7 +12984,7 @@ impl ::std::fmt::Display for RemoveFolderMemberError {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 pub enum RemoveMemberJobStatus {
     /// The asynchronous job is still in progress.
     InProgress,
@@ -13062,7 +13062,7 @@ impl ::serde::ser::Serialize for RemoveMemberJobStatus {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 #[non_exhaustive] // variants may be added in the future
 pub enum RequestedLinkAccessLevel {
     /// Users who use the link can view and comment on the content.
@@ -13152,7 +13152,7 @@ impl ::serde::ser::Serialize for RequestedLinkAccessLevel {
 /// final resolved visibility of the shared link takes into account other aspects, such as team and
 /// shared folder settings. Check the [`ResolvedVisibility`](ResolvedVisibility) for more info on
 /// the possible resolved visibility values of shared links.
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 pub enum RequestedVisibility {
     /// Anyone who has received the link can access it. No login required.
     Public,
@@ -13231,7 +13231,7 @@ impl ::serde::ser::Serialize for RequestedVisibility {
 /// The actual access permissions values of shared links after taking into account user preferences
 /// and the team and shared folder settings. Check the [`RequestedVisibility`](RequestedVisibility)
 /// for more info on the possible visibility values that can be set by the shared link's owner.
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 #[non_exhaustive] // variants may be added in the future
 pub enum ResolvedVisibility {
     /// Anyone who has received the link can access it. No login required.
@@ -13344,7 +13344,7 @@ impl ::serde::ser::Serialize for ResolvedVisibility {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 #[non_exhaustive] // structs may have more fields added in the future.
 pub struct RevokeSharedLinkArg {
     /// URL of the shared link.
@@ -13434,7 +13434,7 @@ impl ::serde::ser::Serialize for RevokeSharedLinkArg {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 #[non_exhaustive] // variants may be added in the future
 pub enum RevokeSharedLinkError {
     /// The shared link wasn't found.
@@ -13544,7 +13544,7 @@ impl ::std::fmt::Display for RevokeSharedLinkError {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 #[non_exhaustive] // structs may have more fields added in the future.
 pub struct SetAccessInheritanceArg {
     /// The ID for the shared folder.
@@ -13652,7 +13652,7 @@ impl ::serde::ser::Serialize for SetAccessInheritanceArg {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 #[non_exhaustive] // variants may be added in the future
 pub enum SetAccessInheritanceError {
     /// Unable to access shared folder.
@@ -13740,7 +13740,7 @@ impl ::std::fmt::Display for SetAccessInheritanceError {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 #[non_exhaustive] // structs may have more fields added in the future.
 pub struct ShareFolderArg {
     /// The path to the folder to share. If it does not exist, then a new one is created.
@@ -13978,7 +13978,7 @@ impl ::serde::ser::Serialize for ShareFolderArg {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 #[non_exhaustive] // structs may have more fields added in the future.
 pub struct ShareFolderArgBase {
     /// The path to the folder to share. If it does not exist, then a new one is created.
@@ -14178,7 +14178,7 @@ impl ::serde::ser::Serialize for ShareFolderArgBase {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 #[non_exhaustive] // variants may be added in the future
 pub enum ShareFolderError {
     /// This user's email address is not verified. This functionality is only available on accounts
@@ -14308,7 +14308,7 @@ impl ::std::fmt::Display for ShareFolderError {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 #[non_exhaustive] // variants may be added in the future
 pub enum ShareFolderErrorBase {
     /// This user's email address is not verified. This functionality is only available on accounts
@@ -14413,7 +14413,7 @@ impl ::serde::ser::Serialize for ShareFolderErrorBase {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 pub enum ShareFolderJobStatus {
     /// The asynchronous job is still in progress.
     InProgress,
@@ -14490,7 +14490,7 @@ impl ::serde::ser::Serialize for ShareFolderJobStatus {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 pub enum ShareFolderLaunch {
     /// This response indicates that the processing is asynchronous. The string is an id that can be
     /// used to obtain the status of the asynchronous job.
@@ -14555,7 +14555,7 @@ impl ::serde::ser::Serialize for ShareFolderLaunch {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 #[non_exhaustive] // variants may be added in the future
 pub enum SharePathError {
     /// A file is at the specified path.
@@ -14807,7 +14807,7 @@ impl ::std::fmt::Display for SharePathError {
 }
 
 /// Metadata of a shared link for a file or folder.
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 #[non_exhaustive] // structs may have more fields added in the future.
 pub struct SharedContentLinkMetadata {
     /// The audience options that are available for the content. Some audience options may be
@@ -15036,7 +15036,7 @@ impl ::serde::ser::Serialize for SharedContentLinkMetadata {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 #[non_exhaustive] // structs may have more fields added in the future.
 pub struct SharedContentLinkMetadataBase {
     /// The audience options that are available for the content. Some audience options may be
@@ -15235,7 +15235,7 @@ impl ::serde::ser::Serialize for SharedContentLinkMetadataBase {
 /// [`list_file_members()`](list_file_members) and
 /// [`list_file_members_continue()`](list_file_members_continue), and used as part of the results
 /// for [`list_file_members_batch()`](list_file_members_batch).
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 #[non_exhaustive] // structs may have more fields added in the future.
 pub struct SharedFileMembers {
     /// The list of user members of the shared file.
@@ -15376,7 +15376,7 @@ impl ::serde::ser::Serialize for SharedFileMembers {
 }
 
 /// Properties of the shared file.
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 #[non_exhaustive] // structs may have more fields added in the future.
 pub struct SharedFileMetadata {
     /// The ID of the file.
@@ -15705,7 +15705,7 @@ impl ::serde::ser::Serialize for SharedFileMetadata {
 }
 
 /// There is an error accessing the shared folder.
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 #[non_exhaustive] // variants may be added in the future
 pub enum SharedFolderAccessError {
     /// This shared folder ID is invalid.
@@ -15815,7 +15815,7 @@ impl ::std::fmt::Display for SharedFolderAccessError {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 #[non_exhaustive] // variants may be added in the future
 pub enum SharedFolderMemberError {
     /// The target dropbox_id is invalid.
@@ -15911,7 +15911,7 @@ impl ::std::fmt::Display for SharedFolderMemberError {
 }
 
 /// Shared folder user and group membership.
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 #[non_exhaustive] // structs may have more fields added in the future.
 pub struct SharedFolderMembers {
     /// The list of user members of the shared folder.
@@ -16052,7 +16052,7 @@ impl ::serde::ser::Serialize for SharedFolderMembers {
 }
 
 /// The metadata which includes basic information about the shared folder.
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 #[non_exhaustive] // structs may have more fields added in the future.
 pub struct SharedFolderMetadata {
     /// The current user's access level for this shared folder.
@@ -16393,7 +16393,7 @@ impl ::serde::ser::Serialize for SharedFolderMetadata {
 }
 
 /// Properties of the shared folder.
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 #[non_exhaustive] // structs may have more fields added in the future.
 pub struct SharedFolderMetadataBase {
     /// The current user's access level for this shared folder.
@@ -16607,7 +16607,7 @@ impl ::serde::ser::Serialize for SharedFolderMetadataBase {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 #[non_exhaustive] // variants may be added in the future
 pub enum SharedLinkAccessFailureReason {
     /// User is not logged in.
@@ -16720,7 +16720,7 @@ impl ::serde::ser::Serialize for SharedLinkAccessFailureReason {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 #[non_exhaustive] // variants may be added in the future
 pub enum SharedLinkAlreadyExistsMetadata {
     /// Metadata of the shared link that already exists.
@@ -16783,7 +16783,7 @@ impl ::serde::ser::Serialize for SharedLinkAlreadyExistsMetadata {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 #[non_exhaustive] // variants may be added in the future
 pub enum SharedLinkError {
     /// The shared link wasn't found.
@@ -16881,7 +16881,7 @@ impl ::std::fmt::Display for SharedLinkError {
 }
 
 /// The metadata of a shared link.
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 #[non_exhaustive] // variants may be added in the future
 pub enum SharedLinkMetadata {
     File(FileLinkMetadata),
@@ -16963,7 +16963,7 @@ impl ::serde::ser::Serialize for SharedLinkMetadata {
 }
 
 /// Who can view shared links in this folder.
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 #[non_exhaustive] // variants may be added in the future
 pub enum SharedLinkPolicy {
     /// Links can be shared with anyone.
@@ -17048,7 +17048,7 @@ impl ::serde::ser::Serialize for SharedLinkPolicy {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 #[non_exhaustive] // structs may have more fields added in the future.
 pub struct SharedLinkSettings {
     /// The requested access for this shared link.
@@ -17212,7 +17212,7 @@ impl ::serde::ser::Serialize for SharedLinkSettings {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 pub enum SharedLinkSettingsError {
     /// The given settings are invalid (for example, all attributes of the
     /// [`SharedLinkSettings`](SharedLinkSettings) are empty, the requested visibility is
@@ -17295,7 +17295,7 @@ impl ::std::fmt::Display for SharedLinkSettingsError {
 }
 
 /// User could not access this file.
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 #[non_exhaustive] // variants may be added in the future
 pub enum SharingFileAccessError {
     /// Current user does not have sufficient privileges to perform the desired action.
@@ -17419,7 +17419,7 @@ impl ::std::fmt::Display for SharingFileAccessError {
 }
 
 /// User account had a problem preventing this action.
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 #[non_exhaustive] // variants may be added in the future
 pub enum SharingUserError {
     /// This user's email address is not verified. This functionality is only available on accounts
@@ -17493,7 +17493,7 @@ impl ::std::fmt::Display for SharingUserError {
 }
 
 /// Information about a team member.
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 #[non_exhaustive] // structs may have more fields added in the future.
 pub struct TeamMemberInfo {
     /// Information about the member's team.
@@ -17615,7 +17615,7 @@ impl ::serde::ser::Serialize for TeamMemberInfo {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 #[non_exhaustive] // structs may have more fields added in the future.
 pub struct TransferFolderArg {
     /// The ID for the shared folder.
@@ -17718,7 +17718,7 @@ impl ::serde::ser::Serialize for TransferFolderArg {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 #[non_exhaustive] // variants may be added in the future
 pub enum TransferFolderError {
     AccessError(SharedFolderAccessError),
@@ -17872,7 +17872,7 @@ impl ::std::fmt::Display for TransferFolderError {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 #[non_exhaustive] // structs may have more fields added in the future.
 pub struct UnmountFolderArg {
     /// The ID for the shared folder.
@@ -17962,7 +17962,7 @@ impl ::serde::ser::Serialize for UnmountFolderArg {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 #[non_exhaustive] // variants may be added in the future
 pub enum UnmountFolderError {
     AccessError(SharedFolderAccessError),
@@ -18064,7 +18064,7 @@ impl ::std::fmt::Display for UnmountFolderError {
 }
 
 /// Arguments for [`unshare_file()`](unshare_file).
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 #[non_exhaustive] // structs may have more fields added in the future.
 pub struct UnshareFileArg {
     /// The file to unshare.
@@ -18155,7 +18155,7 @@ impl ::serde::ser::Serialize for UnshareFileArg {
 }
 
 /// Error result for [`unshare_file()`](unshare_file).
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 #[non_exhaustive] // variants may be added in the future
 pub enum UnshareFileError {
     UserError(SharingUserError),
@@ -18245,7 +18245,7 @@ impl ::std::fmt::Display for UnshareFileError {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 #[non_exhaustive] // structs may have more fields added in the future.
 pub struct UnshareFolderArg {
     /// The ID for the shared folder.
@@ -18355,7 +18355,7 @@ impl ::serde::ser::Serialize for UnshareFolderArg {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 #[non_exhaustive] // variants may be added in the future
 pub enum UnshareFolderError {
     AccessError(SharedFolderAccessError),
@@ -18469,7 +18469,7 @@ impl ::std::fmt::Display for UnshareFolderError {
 }
 
 /// Arguments for [`update_file_member()`](update_file_member).
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 #[non_exhaustive] // structs may have more fields added in the future.
 pub struct UpdateFileMemberArgs {
     /// File for which we are changing a member's access.
@@ -18585,7 +18585,7 @@ impl ::serde::ser::Serialize for UpdateFileMemberArgs {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 #[non_exhaustive] // structs may have more fields added in the future.
 pub struct UpdateFolderMemberArg {
     /// The ID for the shared folder.
@@ -18706,7 +18706,7 @@ impl ::serde::ser::Serialize for UpdateFolderMemberArg {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 #[non_exhaustive] // variants may be added in the future
 pub enum UpdateFolderMemberError {
     AccessError(SharedFolderAccessError),
@@ -18843,7 +18843,7 @@ impl ::std::fmt::Display for UpdateFolderMemberError {
 }
 
 /// If any of the policies are unset, then they retain their current setting.
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 #[non_exhaustive] // structs may have more fields added in the future.
 pub struct UpdateFolderPolicyArg {
     /// The ID for the shared folder.
@@ -19045,7 +19045,7 @@ impl ::serde::ser::Serialize for UpdateFolderPolicyArg {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 #[non_exhaustive] // variants may be added in the future
 pub enum UpdateFolderPolicyError {
     AccessError(SharedFolderAccessError),
@@ -19187,7 +19187,7 @@ impl ::std::fmt::Display for UpdateFolderPolicyError {
 }
 
 /// The information about a user member of the shared content with an appended last seen timestamp.
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 #[non_exhaustive] // structs may have more fields added in the future.
 pub struct UserFileMembershipInfo {
     /// The access type for this member. It contains inherited access type from parent folder, and
@@ -19385,7 +19385,7 @@ impl ::serde::ser::Serialize for UserFileMembershipInfo {
 /// Basic information about a user. Use [`users::get_account()`](super::users::get_account) and
 /// [`users::get_account_batch()`](super::users::get_account_batch) to obtain more detailed
 /// information.
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 #[non_exhaustive] // structs may have more fields added in the future.
 pub struct UserInfo {
     /// The account ID of the user.
@@ -19538,7 +19538,7 @@ impl ::serde::ser::Serialize for UserInfo {
 }
 
 /// The information about a user member of the shared content.
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 #[non_exhaustive] // structs may have more fields added in the future.
 pub struct UserMembershipInfo {
     /// The access type for this member. It contains inherited access type from parent folder, and
@@ -19697,7 +19697,7 @@ impl ::serde::ser::Serialize for UserMembershipInfo {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 #[non_exhaustive] // variants may be added in the future
 pub enum ViewerInfoPolicy {
     /// Viewer information is available on this file.
@@ -19771,7 +19771,7 @@ impl ::serde::ser::Serialize for ViewerInfoPolicy {
 
 /// Who can access a shared link. The most open visibility is [`Public`](Visibility::Public). The
 /// default depends on many aspects, such as team and user preferences and shared folder settings.
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 #[non_exhaustive] // variants may be added in the future
 pub enum Visibility {
     /// Anyone who has received the link can access it. No login required.

--- a/src/generated/team.rs
+++ b/src/generated/team.rs
@@ -1199,7 +1199,7 @@ pub fn token_get_authenticated_admin(
 }
 
 /// Information on active web sessions.
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 #[non_exhaustive] // structs may have more fields added in the future.
 pub struct ActiveWebSession {
     /// The session id.
@@ -1421,7 +1421,7 @@ impl ::serde::ser::Serialize for ActiveWebSession {
 /// Result of trying to add a secondary email to a user. 'success' is the only value indicating that
 /// a secondary email was successfully added to a user. The other values explain the type of error
 /// that occurred, and include the email for which the error occured.
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 #[non_exhaustive] // variants may be added in the future
 pub enum AddSecondaryEmailResult {
     /// Describes a secondary email that was successfully added to a user.
@@ -1614,7 +1614,7 @@ impl ::serde::ser::Serialize for AddSecondaryEmailResult {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 #[non_exhaustive] // structs may have more fields added in the future.
 pub struct AddSecondaryEmailsArg {
     /// List of users and secondary emails to add.
@@ -1705,7 +1705,7 @@ impl ::serde::ser::Serialize for AddSecondaryEmailsArg {
 }
 
 /// Error returned when adding secondary emails fails.
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 #[non_exhaustive] // variants may be added in the future
 pub enum AddSecondaryEmailsError {
     /// Secondary emails are disabled for the team.
@@ -1789,7 +1789,7 @@ impl ::std::fmt::Display for AddSecondaryEmailsError {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 #[non_exhaustive] // structs may have more fields added in the future.
 pub struct AddSecondaryEmailsResult {
     /// List of users and secondary email results.
@@ -1880,7 +1880,7 @@ impl ::serde::ser::Serialize for AddSecondaryEmailsResult {
 }
 
 /// Describes which team-related admin permissions a user has.
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 pub enum AdminTier {
     /// User is an administrator of the team - has all permissions.
     TeamAdmin,
@@ -1970,7 +1970,7 @@ impl ::serde::ser::Serialize for AdminTier {
 }
 
 /// Information on linked third party applications.
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 #[non_exhaustive] // structs may have more fields added in the future.
 pub struct ApiApp {
     /// The application unique id.
@@ -2141,7 +2141,7 @@ impl ::serde::ser::Serialize for ApiApp {
 }
 
 /// Base report structure.
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 #[non_exhaustive] // structs may have more fields added in the future.
 pub struct BaseDfbReport {
     /// First date present in the results as 'YYYY-MM-DD' or None.
@@ -2232,7 +2232,7 @@ impl ::serde::ser::Serialize for BaseDfbReport {
 }
 
 /// Base error that all errors for existing team folders should extend.
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 #[non_exhaustive] // variants may be added in the future
 pub enum BaseTeamFolderError {
     AccessError(TeamFolderAccessError),
@@ -2339,7 +2339,7 @@ impl ::std::fmt::Display for BaseTeamFolderError {
 }
 
 /// Error returned when getting member custom quota.
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 #[non_exhaustive] // variants may be added in the future
 pub enum CustomQuotaError {
     /// A maximum of 1000 users can be set for a single call.
@@ -2411,7 +2411,7 @@ impl ::std::fmt::Display for CustomQuotaError {
 }
 
 /// User custom quota.
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 #[non_exhaustive] // variants may be added in the future
 pub enum CustomQuotaResult {
     /// User's custom quota.
@@ -2485,7 +2485,7 @@ impl ::serde::ser::Serialize for CustomQuotaResult {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 #[non_exhaustive] // structs may have more fields added in the future.
 pub struct CustomQuotaUsersArg {
     /// List of users.
@@ -2576,7 +2576,7 @@ impl ::serde::ser::Serialize for CustomQuotaUsersArg {
 }
 
 /// Input arguments that can be provided for most reports.
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 #[non_exhaustive] // structs may have more fields added in the future.
 pub struct DateRange {
     /// Optional starting date (inclusive). If start_date is None or too long ago, this field will
@@ -2682,7 +2682,7 @@ impl ::serde::ser::Serialize for DateRange {
 }
 
 /// Errors that can originate from problems in input arguments to reports.
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 #[non_exhaustive] // variants may be added in the future
 pub enum DateRangeError {
     /// Catch-all used for unrecognized values returned from the server. Encountering this value
@@ -2739,7 +2739,7 @@ impl ::std::fmt::Display for DateRangeError {
 /// Result of trying to delete a secondary email address. 'success' is the only value indicating
 /// that a secondary email was successfully deleted. The other values explain the type of error that
 /// occurred, and include the email for which the error occured.
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 #[non_exhaustive] // variants may be added in the future
 pub enum DeleteSecondaryEmailResult {
     /// The secondary email was successfully deleted.
@@ -2836,7 +2836,7 @@ impl ::serde::ser::Serialize for DeleteSecondaryEmailResult {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 #[non_exhaustive] // structs may have more fields added in the future.
 pub struct DeleteSecondaryEmailsArg {
     /// List of users and their secondary emails to delete.
@@ -2926,7 +2926,7 @@ impl ::serde::ser::Serialize for DeleteSecondaryEmailsArg {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 #[non_exhaustive] // structs may have more fields added in the future.
 pub struct DeleteSecondaryEmailsResult {
     pub results: Vec<UserDeleteResult>,
@@ -3016,7 +3016,7 @@ impl ::serde::ser::Serialize for DeleteSecondaryEmailsResult {
 }
 
 /// Information about linked Dropbox desktop client sessions.
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 #[non_exhaustive] // structs may have more fields added in the future.
 pub struct DesktopClientSession {
     /// The session id.
@@ -3250,7 +3250,7 @@ impl ::serde::ser::Serialize for DesktopClientSession {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 #[non_exhaustive] // variants may be added in the future
 pub enum DesktopPlatform {
     /// Official Windows Dropbox desktop client.
@@ -3335,7 +3335,7 @@ impl ::serde::ser::Serialize for DesktopPlatform {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 #[non_exhaustive] // structs may have more fields added in the future.
 pub struct DeviceSession {
     /// The session id.
@@ -3497,7 +3497,7 @@ impl ::serde::ser::Serialize for DeviceSession {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 #[non_exhaustive] // structs may have more fields added in the future.
 pub struct DeviceSessionArg {
     /// The session id.
@@ -3603,7 +3603,7 @@ impl ::serde::ser::Serialize for DeviceSessionArg {
 /// Each of the items is an array of values, one value per day. The value is the number of devices
 /// active within a time window, ending with that day. If there is no data for a day, then the value
 /// will be None.
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 #[non_exhaustive] // structs may have more fields added in the future.
 pub struct DevicesActive {
     /// Array of number of linked windows (desktop) clients with activity.
@@ -3780,7 +3780,7 @@ impl ::serde::ser::Serialize for DevicesActive {
 }
 
 /// Excluded users list argument.
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 #[non_exhaustive] // structs may have more fields added in the future.
 pub struct ExcludedUsersListArg {
     /// Number of results to return per call.
@@ -3867,7 +3867,7 @@ impl ::serde::ser::Serialize for ExcludedUsersListArg {
 }
 
 /// Excluded users list continue argument.
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 #[non_exhaustive] // structs may have more fields added in the future.
 pub struct ExcludedUsersListContinueArg {
     /// Indicates from what point to get the next set of users.
@@ -3958,7 +3958,7 @@ impl ::serde::ser::Serialize for ExcludedUsersListContinueArg {
 }
 
 /// Excluded users list continue error.
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 #[non_exhaustive] // variants may be added in the future
 pub enum ExcludedUsersListContinueError {
     /// The cursor is invalid.
@@ -4030,7 +4030,7 @@ impl ::std::fmt::Display for ExcludedUsersListContinueError {
 }
 
 /// Excluded users list error.
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 #[non_exhaustive] // variants may be added in the future
 pub enum ExcludedUsersListError {
     /// An error occurred.
@@ -4102,7 +4102,7 @@ impl ::std::fmt::Display for ExcludedUsersListError {
 }
 
 /// Excluded users list result.
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 #[non_exhaustive] // structs may have more fields added in the future.
 pub struct ExcludedUsersListResult {
     pub users: Vec<MemberProfile>,
@@ -4229,7 +4229,7 @@ impl ::serde::ser::Serialize for ExcludedUsersListResult {
 
 /// Argument of excluded users update operation. Should include a list of users to add/remove
 /// (according to endpoint), Maximum size of the list is 1000 users.
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 #[non_exhaustive] // structs may have more fields added in the future.
 pub struct ExcludedUsersUpdateArg {
     /// List of users to be added/removed.
@@ -4316,7 +4316,7 @@ impl ::serde::ser::Serialize for ExcludedUsersUpdateArg {
 }
 
 /// Excluded users update error.
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 #[non_exhaustive] // variants may be added in the future
 pub enum ExcludedUsersUpdateError {
     /// At least one of the users is not part of your team.
@@ -4401,7 +4401,7 @@ impl ::std::fmt::Display for ExcludedUsersUpdateError {
 }
 
 /// Excluded users update result.
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 #[non_exhaustive] // structs may have more fields added in the future.
 pub struct ExcludedUsersUpdateResult {
     /// Update status.
@@ -4492,7 +4492,7 @@ impl ::serde::ser::Serialize for ExcludedUsersUpdateResult {
 }
 
 /// Excluded users update operation status.
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 #[non_exhaustive] // variants may be added in the future
 pub enum ExcludedUsersUpdateStatus {
     /// Update successful.
@@ -4552,7 +4552,7 @@ impl ::serde::ser::Serialize for ExcludedUsersUpdateStatus {
 }
 
 /// A set of features that a Dropbox Business account may support.
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 #[non_exhaustive] // variants may be added in the future
 pub enum Feature {
     /// The number of upload API calls allowed per month.
@@ -4652,7 +4652,7 @@ impl ::serde::ser::Serialize for Feature {
 
 /// The values correspond to entries in [`Feature`](Feature). You may get different value according
 /// to your Dropbox Business plan.
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 #[non_exhaustive] // variants may be added in the future
 pub enum FeatureValue {
     UploadApiRateLimit(UploadApiRateLimitValue),
@@ -4762,7 +4762,7 @@ impl ::serde::ser::Serialize for FeatureValue {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 #[non_exhaustive] // structs may have more fields added in the future.
 pub struct FeaturesGetValuesBatchArg {
     /// A list of features in [`Feature`](Feature). If the list is empty, this route will return
@@ -4853,7 +4853,7 @@ impl ::serde::ser::Serialize for FeaturesGetValuesBatchArg {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 #[non_exhaustive] // variants may be added in the future
 pub enum FeaturesGetValuesBatchError {
     /// At least one [`Feature`](Feature) must be included in the
@@ -4925,7 +4925,7 @@ impl ::std::fmt::Display for FeaturesGetValuesBatchError {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 #[non_exhaustive] // structs may have more fields added in the future.
 pub struct FeaturesGetValuesBatchResult {
     pub values: Vec<FeatureValue>,
@@ -5016,7 +5016,7 @@ impl ::serde::ser::Serialize for FeaturesGetValuesBatchResult {
 
 /// Activity Report Result. Each of the items in the storage report is an array of values, one value
 /// per day. If there is no data for a day, then the value will be None.
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 #[non_exhaustive] // structs may have more fields added in the future.
 pub struct GetActivityReport {
     /// First date present in the results as 'YYYY-MM-DD' or None.
@@ -5309,7 +5309,7 @@ impl ::serde::ser::Serialize for GetActivityReport {
 /// Devices Report Result. Contains subsections for different time ranges of activity. Each of the
 /// items in each subsection of the storage report is an array of values, one value per day. If
 /// there is no data for a day, then the value will be None.
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 #[non_exhaustive] // structs may have more fields added in the future.
 pub struct GetDevicesReport {
     /// First date present in the results as 'YYYY-MM-DD' or None.
@@ -5445,7 +5445,7 @@ impl ::serde::ser::Serialize for GetDevicesReport {
 
 /// Membership Report Result. Each of the items in the storage report is an array of values, one
 /// value per day. If there is no data for a day, then the value will be None.
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 #[non_exhaustive] // structs may have more fields added in the future.
 pub struct GetMembershipReport {
     /// First date present in the results as 'YYYY-MM-DD' or None.
@@ -5609,7 +5609,7 @@ impl ::serde::ser::Serialize for GetMembershipReport {
 
 /// Storage Report Result. Each of the items in the storage report is an array of values, one value
 /// per day. If there is no data for a day, then the value will be None.
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 #[non_exhaustive] // structs may have more fields added in the future.
 pub struct GetStorageReport {
     /// First date present in the results as 'YYYY-MM-DD' or None.
@@ -5775,7 +5775,7 @@ impl ::serde::ser::Serialize for GetStorageReport {
 }
 
 /// Role of a user in group.
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 pub enum GroupAccessType {
     /// User is a member of the group, but has no special permissions.
     Member,
@@ -5838,7 +5838,7 @@ impl ::serde::ser::Serialize for GroupAccessType {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 #[non_exhaustive] // structs may have more fields added in the future.
 pub struct GroupCreateArg {
     /// Group name.
@@ -5985,7 +5985,7 @@ impl ::serde::ser::Serialize for GroupCreateArg {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 #[non_exhaustive] // variants may be added in the future
 pub enum GroupCreateError {
     /// The requested group name is already being used by another group.
@@ -6095,7 +6095,7 @@ impl ::std::fmt::Display for GroupCreateError {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 #[non_exhaustive] // variants may be added in the future
 pub enum GroupDeleteError {
     /// No matching group found. No groups match the specified group ID.
@@ -6193,7 +6193,7 @@ impl ::std::fmt::Display for GroupDeleteError {
 }
 
 /// Full description of a group.
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 #[non_exhaustive] // structs may have more fields added in the future.
 pub struct GroupFullInfo {
     pub group_name: String,
@@ -6380,7 +6380,7 @@ impl ::serde::ser::Serialize for GroupFullInfo {
 }
 
 /// Profile of group member, and role in group.
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 #[non_exhaustive] // structs may have more fields added in the future.
 pub struct GroupMemberInfo {
     /// Profile of group member.
@@ -6484,7 +6484,7 @@ impl ::serde::ser::Serialize for GroupMemberInfo {
 }
 
 /// Argument for selecting a group and a single user.
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 #[non_exhaustive] // structs may have more fields added in the future.
 pub struct GroupMemberSelector {
     /// Specify a group.
@@ -6589,7 +6589,7 @@ impl ::serde::ser::Serialize for GroupMemberSelector {
 
 /// Error that can be raised when [`GroupMemberSelector`](GroupMemberSelector) is used, and the user
 /// is required to be a member of the specified group.
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 #[non_exhaustive] // variants may be added in the future
 pub enum GroupMemberSelectorError {
     /// No matching group found. No groups match the specified group ID.
@@ -6686,7 +6686,7 @@ impl ::std::fmt::Display for GroupMemberSelectorError {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 #[non_exhaustive] // variants may be added in the future
 pub enum GroupMemberSetAccessTypeError {
     /// No matching group found. No groups match the specified group ID.
@@ -6796,7 +6796,7 @@ impl ::std::fmt::Display for GroupMemberSetAccessTypeError {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 #[non_exhaustive] // structs may have more fields added in the future.
 pub struct GroupMembersAddArg {
     /// Group to which users will be added.
@@ -6919,7 +6919,7 @@ impl ::serde::ser::Serialize for GroupMembersAddArg {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 #[non_exhaustive] // variants may be added in the future
 pub enum GroupMembersAddError {
     /// No matching group found. No groups match the specified group ID.
@@ -7099,7 +7099,7 @@ impl ::std::fmt::Display for GroupMembersAddError {
 
 /// Result returned by [`groups_members_add()`](groups_members_add) and
 /// [`groups_members_remove()`](groups_members_remove).
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 #[non_exhaustive] // structs may have more fields added in the future.
 pub struct GroupMembersChangeResult {
     /// The group info after member change operation has been performed.
@@ -7204,7 +7204,7 @@ impl ::serde::ser::Serialize for GroupMembersChangeResult {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 #[non_exhaustive] // structs may have more fields added in the future.
 pub struct GroupMembersRemoveArg {
     /// Group from which users will be removed.
@@ -7327,7 +7327,7 @@ impl ::serde::ser::Serialize for GroupMembersRemoveArg {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 #[non_exhaustive] // variants may be added in the future
 pub enum GroupMembersRemoveError {
     /// No matching group found. No groups match the specified group ID.
@@ -7473,7 +7473,7 @@ impl ::std::fmt::Display for GroupMembersRemoveError {
 }
 
 /// Argument for selecting a group and a list of users.
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 #[non_exhaustive] // structs may have more fields added in the future.
 pub struct GroupMembersSelector {
     /// Specify a group.
@@ -7578,7 +7578,7 @@ impl ::serde::ser::Serialize for GroupMembersSelector {
 
 /// Error that can be raised when [`GroupMembersSelector`](GroupMembersSelector) is used, and the
 /// users are required to be members of the specified group.
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 #[non_exhaustive] // variants may be added in the future
 pub enum GroupMembersSelectorError {
     /// No matching group found. No groups match the specified group ID.
@@ -7675,7 +7675,7 @@ impl ::std::fmt::Display for GroupMembersSelectorError {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 #[non_exhaustive] // structs may have more fields added in the future.
 pub struct GroupMembersSetAccessTypeArg {
     /// Specify a group.
@@ -7812,7 +7812,7 @@ impl ::serde::ser::Serialize for GroupMembersSetAccessTypeArg {
 }
 
 /// Argument for selecting a single group, either by group_id or by external group ID.
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 pub enum GroupSelector {
     /// Group ID.
     GroupId(super::team_common::GroupId),
@@ -7884,7 +7884,7 @@ impl ::serde::ser::Serialize for GroupSelector {
 }
 
 /// Error that can be raised when [`GroupSelector`](GroupSelector) is used.
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 #[non_exhaustive] // variants may be added in the future
 pub enum GroupSelectorError {
     /// No matching group found. No groups match the specified group ID.
@@ -7957,7 +7957,7 @@ impl ::std::fmt::Display for GroupSelectorError {
 
 /// Error that can be raised when [`GroupSelector`](GroupSelector) is used and team groups are
 /// disallowed from being used.
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 #[non_exhaustive] // variants may be added in the future
 pub enum GroupSelectorWithTeamGroupError {
     /// No matching group found. No groups match the specified group ID.
@@ -8041,7 +8041,7 @@ impl ::std::fmt::Display for GroupSelectorWithTeamGroupError {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 #[non_exhaustive] // structs may have more fields added in the future.
 pub struct GroupUpdateArgs {
     /// Specify a group.
@@ -8212,7 +8212,7 @@ impl ::serde::ser::Serialize for GroupUpdateArgs {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 #[non_exhaustive] // variants may be added in the future
 pub enum GroupUpdateError {
     /// No matching group found. No groups match the specified group ID.
@@ -8335,7 +8335,7 @@ impl ::std::fmt::Display for GroupUpdateError {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 #[non_exhaustive] // variants may be added in the future
 pub enum GroupsGetInfoError {
     /// The group is not on your team.
@@ -8406,7 +8406,7 @@ impl ::std::fmt::Display for GroupsGetInfoError {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 pub enum GroupsGetInfoItem {
     /// An ID that was provided as a parameter to [`groups_get_info()`](groups_get_info), and did
     /// not match a corresponding group. The ID can be a group ID, or an external ID, depending on
@@ -8473,7 +8473,7 @@ impl ::serde::ser::Serialize for GroupsGetInfoItem {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 #[non_exhaustive] // structs may have more fields added in the future.
 pub struct GroupsListArg {
     /// Number of results to return per call.
@@ -8559,7 +8559,7 @@ impl ::serde::ser::Serialize for GroupsListArg {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 #[non_exhaustive] // structs may have more fields added in the future.
 pub struct GroupsListContinueArg {
     /// Indicates from what point to get the next set of groups.
@@ -8649,7 +8649,7 @@ impl ::serde::ser::Serialize for GroupsListContinueArg {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 #[non_exhaustive] // variants may be added in the future
 pub enum GroupsListContinueError {
     /// The cursor is invalid.
@@ -8720,7 +8720,7 @@ impl ::std::fmt::Display for GroupsListContinueError {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 #[non_exhaustive] // structs may have more fields added in the future.
 pub struct GroupsListResult {
     pub groups: Vec<super::team_common::GroupSummary>,
@@ -8841,7 +8841,7 @@ impl ::serde::ser::Serialize for GroupsListResult {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 #[non_exhaustive] // structs may have more fields added in the future.
 pub struct GroupsMembersListArg {
     /// The group whose members are to be listed.
@@ -8949,7 +8949,7 @@ impl ::serde::ser::Serialize for GroupsMembersListArg {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 #[non_exhaustive] // structs may have more fields added in the future.
 pub struct GroupsMembersListContinueArg {
     /// Indicates from what point to get the next set of groups.
@@ -9039,7 +9039,7 @@ impl ::serde::ser::Serialize for GroupsMembersListContinueArg {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 #[non_exhaustive] // variants may be added in the future
 pub enum GroupsMembersListContinueError {
     /// The cursor is invalid.
@@ -9110,7 +9110,7 @@ impl ::std::fmt::Display for GroupsMembersListContinueError {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 #[non_exhaustive] // structs may have more fields added in the future.
 pub struct GroupsMembersListResult {
     pub members: Vec<GroupMemberInfo>,
@@ -9227,7 +9227,7 @@ impl ::serde::ser::Serialize for GroupsMembersListResult {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 #[non_exhaustive] // variants may be added in the future
 pub enum GroupsPollError {
     /// The job ID is invalid.
@@ -9326,7 +9326,7 @@ impl ::std::fmt::Display for GroupsPollError {
 }
 
 /// Argument for selecting a list of groups, either by group_ids, or external group IDs.
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 pub enum GroupsSelector {
     /// List of group IDs.
     GroupIds(Vec<super::team_common::GroupId>),
@@ -9398,7 +9398,7 @@ impl ::serde::ser::Serialize for GroupsSelector {
 }
 
 /// The value for [`Feature::HasTeamFileEvents`](Feature::HasTeamFileEvents).
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 #[non_exhaustive] // variants may be added in the future
 pub enum HasTeamFileEventsValue {
     /// Does this team have file events.
@@ -9462,7 +9462,7 @@ impl ::serde::ser::Serialize for HasTeamFileEventsValue {
 }
 
 /// The value for [`Feature::HasTeamSelectiveSync`](Feature::HasTeamSelectiveSync).
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 #[non_exhaustive] // variants may be added in the future
 pub enum HasTeamSelectiveSyncValue {
     /// Does this team have team selective sync enabled.
@@ -9526,7 +9526,7 @@ impl ::serde::ser::Serialize for HasTeamSelectiveSyncValue {
 }
 
 /// The value for [`Feature::HasTeamSharedDropbox`](Feature::HasTeamSharedDropbox).
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 #[non_exhaustive] // variants may be added in the future
 pub enum HasTeamSharedDropboxValue {
     /// Does this team have a shared team root.
@@ -9589,7 +9589,7 @@ impl ::serde::ser::Serialize for HasTeamSharedDropboxValue {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 #[non_exhaustive] // structs may have more fields added in the future.
 pub struct IncludeMembersArg {
     /// Whether to return the list of members in the group.  Note that the default value will cause
@@ -9677,7 +9677,7 @@ impl ::serde::ser::Serialize for IncludeMembersArg {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 #[non_exhaustive] // structs may have more fields added in the future.
 pub struct LegalHoldHeldRevisionMetadata {
     /// The held revision filename.
@@ -9897,7 +9897,7 @@ impl ::serde::ser::Serialize for LegalHoldHeldRevisionMetadata {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 #[non_exhaustive] // structs may have more fields added in the future.
 pub struct LegalHoldPolicy {
     /// The legal hold id.
@@ -10099,7 +10099,7 @@ impl ::serde::ser::Serialize for LegalHoldPolicy {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 #[non_exhaustive] // variants may be added in the future
 pub enum LegalHoldStatus {
     /// The legal hold policy is active.
@@ -10223,7 +10223,7 @@ impl ::serde::ser::Serialize for LegalHoldStatus {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 #[non_exhaustive] // variants may be added in the future
 pub enum LegalHoldsError {
     /// There has been an unknown legal hold error.
@@ -10307,7 +10307,7 @@ impl ::std::fmt::Display for LegalHoldsError {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 #[non_exhaustive] // structs may have more fields added in the future.
 pub struct LegalHoldsGetPolicyArg {
     /// The legal hold Id.
@@ -10397,7 +10397,7 @@ impl ::serde::ser::Serialize for LegalHoldsGetPolicyArg {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 #[non_exhaustive] // variants may be added in the future
 pub enum LegalHoldsGetPolicyError {
     /// There has been an unknown legal hold error.
@@ -10494,7 +10494,7 @@ impl ::std::fmt::Display for LegalHoldsGetPolicyError {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 #[non_exhaustive] // structs may have more fields added in the future.
 pub struct LegalHoldsListHeldRevisionResult {
     /// List of file entries that under the hold.
@@ -10618,7 +10618,7 @@ impl ::serde::ser::Serialize for LegalHoldsListHeldRevisionResult {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 #[non_exhaustive] // structs may have more fields added in the future.
 pub struct LegalHoldsListHeldRevisionsArg {
     /// The legal hold Id.
@@ -10708,7 +10708,7 @@ impl ::serde::ser::Serialize for LegalHoldsListHeldRevisionsArg {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 #[non_exhaustive] // structs may have more fields added in the future.
 pub struct LegalHoldsListHeldRevisionsContinueArg {
     /// The legal hold Id.
@@ -10817,7 +10817,7 @@ impl ::serde::ser::Serialize for LegalHoldsListHeldRevisionsContinueArg {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 #[non_exhaustive] // variants may be added in the future
 pub enum LegalHoldsListHeldRevisionsContinueError {
     /// There has been an unknown legal hold error.
@@ -10916,7 +10916,7 @@ impl ::std::fmt::Display for LegalHoldsListHeldRevisionsContinueError {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 #[non_exhaustive] // variants may be added in the future
 pub enum LegalHoldsListHeldRevisionsError {
     /// There has been an unknown legal hold error.
@@ -11039,7 +11039,7 @@ impl ::std::fmt::Display for LegalHoldsListHeldRevisionsError {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 #[non_exhaustive] // structs may have more fields added in the future.
 pub struct LegalHoldsListPoliciesArg {
     /// Whether to return holds that were released.
@@ -11125,7 +11125,7 @@ impl ::serde::ser::Serialize for LegalHoldsListPoliciesArg {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 #[non_exhaustive] // variants may be added in the future
 pub enum LegalHoldsListPoliciesError {
     /// There has been an unknown legal hold error.
@@ -11222,7 +11222,7 @@ impl ::std::fmt::Display for LegalHoldsListPoliciesError {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 #[non_exhaustive] // structs may have more fields added in the future.
 pub struct LegalHoldsListPoliciesResult {
     pub policies: Vec<LegalHoldPolicy>,
@@ -11311,7 +11311,7 @@ impl ::serde::ser::Serialize for LegalHoldsListPoliciesResult {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 #[non_exhaustive] // structs may have more fields added in the future.
 pub struct LegalHoldsPolicyCreateArg {
     /// Policy name.
@@ -11468,7 +11468,7 @@ impl ::serde::ser::Serialize for LegalHoldsPolicyCreateArg {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 #[non_exhaustive] // variants may be added in the future
 pub enum LegalHoldsPolicyCreateError {
     /// There has been an unknown legal hold error.
@@ -11656,7 +11656,7 @@ impl ::std::fmt::Display for LegalHoldsPolicyCreateError {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 #[non_exhaustive] // structs may have more fields added in the future.
 pub struct LegalHoldsPolicyReleaseArg {
     /// The legal hold Id.
@@ -11746,7 +11746,7 @@ impl ::serde::ser::Serialize for LegalHoldsPolicyReleaseArg {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 #[non_exhaustive] // variants may be added in the future
 pub enum LegalHoldsPolicyReleaseError {
     /// There has been an unknown legal hold error.
@@ -11870,7 +11870,7 @@ impl ::std::fmt::Display for LegalHoldsPolicyReleaseError {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 #[non_exhaustive] // structs may have more fields added in the future.
 pub struct LegalHoldsPolicyUpdateArg {
     /// The legal hold Id.
@@ -12014,7 +12014,7 @@ impl ::serde::ser::Serialize for LegalHoldsPolicyUpdateArg {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 #[non_exhaustive] // variants may be added in the future
 pub enum LegalHoldsPolicyUpdateError {
     /// There has been an unknown legal hold error.
@@ -12190,7 +12190,7 @@ impl ::std::fmt::Display for LegalHoldsPolicyUpdateError {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 #[non_exhaustive] // structs may have more fields added in the future.
 pub struct ListMemberAppsArg {
     /// The team member id.
@@ -12282,7 +12282,7 @@ impl ::serde::ser::Serialize for ListMemberAppsArg {
 
 /// Error returned by
 /// [`linked_apps_list_member_linked_apps()`](linked_apps_list_member_linked_apps).
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 #[non_exhaustive] // variants may be added in the future
 pub enum ListMemberAppsError {
     /// Member not found.
@@ -12353,7 +12353,7 @@ impl ::std::fmt::Display for ListMemberAppsError {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 #[non_exhaustive] // structs may have more fields added in the future.
 pub struct ListMemberAppsResult {
     /// List of third party applications linked by this team member.
@@ -12443,7 +12443,7 @@ impl ::serde::ser::Serialize for ListMemberAppsResult {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 #[non_exhaustive] // structs may have more fields added in the future.
 pub struct ListMemberDevicesArg {
     /// The team's member id.
@@ -12587,7 +12587,7 @@ impl ::serde::ser::Serialize for ListMemberDevicesArg {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 #[non_exhaustive] // variants may be added in the future
 pub enum ListMemberDevicesError {
     /// Member not found.
@@ -12658,7 +12658,7 @@ impl ::std::fmt::Display for ListMemberDevicesError {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 #[non_exhaustive] // structs may have more fields added in the future.
 pub struct ListMemberDevicesResult {
     /// List of web sessions made by this team member.
@@ -12781,7 +12781,7 @@ impl ::serde::ser::Serialize for ListMemberDevicesResult {
 }
 
 /// Arguments for [`linked_apps_list_members_linked_apps()`](linked_apps_list_members_linked_apps).
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 #[non_exhaustive] // structs may have more fields added in the future.
 pub struct ListMembersAppsArg {
     /// At the first call to the
@@ -12873,7 +12873,7 @@ impl ::serde::ser::Serialize for ListMembersAppsArg {
 
 /// Error returned by
 /// [`linked_apps_list_members_linked_apps()`](linked_apps_list_members_linked_apps).
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 #[non_exhaustive] // variants may be added in the future
 pub enum ListMembersAppsError {
     /// Indicates that the cursor has been invalidated. Call
@@ -12948,7 +12948,7 @@ impl ::std::fmt::Display for ListMembersAppsError {
 
 /// Information returned by
 /// [`linked_apps_list_members_linked_apps()`](linked_apps_list_members_linked_apps).
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 #[non_exhaustive] // structs may have more fields added in the future.
 pub struct ListMembersAppsResult {
     /// The linked applications of each member of the team.
@@ -13073,7 +13073,7 @@ impl ::serde::ser::Serialize for ListMembersAppsResult {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 #[non_exhaustive] // structs may have more fields added in the future.
 pub struct ListMembersDevicesArg {
     /// At the first call to the [`devices_list_members_devices()`](devices_list_members_devices)
@@ -13216,7 +13216,7 @@ impl ::serde::ser::Serialize for ListMembersDevicesArg {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 #[non_exhaustive] // variants may be added in the future
 pub enum ListMembersDevicesError {
     /// Indicates that the cursor has been invalidated. Call
@@ -13289,7 +13289,7 @@ impl ::std::fmt::Display for ListMembersDevicesError {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 #[non_exhaustive] // structs may have more fields added in the future.
 pub struct ListMembersDevicesResult {
     /// The devices of each member of the team.
@@ -13413,7 +13413,7 @@ impl ::serde::ser::Serialize for ListMembersDevicesResult {
 }
 
 /// Arguments for [`linked_apps_list_team_linked_apps()`](linked_apps_list_team_linked_apps).
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 #[non_exhaustive] // structs may have more fields added in the future.
 pub struct ListTeamAppsArg {
     /// At the first call to the
@@ -13504,7 +13504,7 @@ impl ::serde::ser::Serialize for ListTeamAppsArg {
 }
 
 /// Error returned by [`linked_apps_list_team_linked_apps()`](linked_apps_list_team_linked_apps).
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 #[non_exhaustive] // variants may be added in the future
 pub enum ListTeamAppsError {
     /// Indicates that the cursor has been invalidated. Call
@@ -13579,7 +13579,7 @@ impl ::std::fmt::Display for ListTeamAppsError {
 
 /// Information returned by
 /// [`linked_apps_list_team_linked_apps()`](linked_apps_list_team_linked_apps).
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 #[non_exhaustive] // structs may have more fields added in the future.
 pub struct ListTeamAppsResult {
     /// The linked applications of each member of the team.
@@ -13704,7 +13704,7 @@ impl ::serde::ser::Serialize for ListTeamAppsResult {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 #[non_exhaustive] // structs may have more fields added in the future.
 pub struct ListTeamDevicesArg {
     /// At the first call to the [`devices_list_team_devices()`](devices_list_team_devices) the
@@ -13847,7 +13847,7 @@ impl ::serde::ser::Serialize for ListTeamDevicesArg {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 #[non_exhaustive] // variants may be added in the future
 pub enum ListTeamDevicesError {
     /// Indicates that the cursor has been invalidated. Call
@@ -13920,7 +13920,7 @@ impl ::std::fmt::Display for ListTeamDevicesError {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 #[non_exhaustive] // structs may have more fields added in the future.
 pub struct ListTeamDevicesResult {
     /// The devices of each member of the team.
@@ -14044,7 +14044,7 @@ impl ::serde::ser::Serialize for ListTeamDevicesResult {
 }
 
 /// Specify access type a member should have when joined to a group.
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 #[non_exhaustive] // structs may have more fields added in the future.
 pub struct MemberAccess {
     /// Identity of a user.
@@ -14147,7 +14147,7 @@ impl ::serde::ser::Serialize for MemberAccess {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 #[non_exhaustive] // structs may have more fields added in the future.
 pub struct MemberAddArg {
     pub member_email: super::common::EmailAddress,
@@ -14367,7 +14367,7 @@ impl ::serde::ser::Serialize for MemberAddArg {
 /// Describes the result of attempting to add a single user to the team. 'success' is the only value
 /// indicating that a user was indeed added to the team - the other values explain the type of
 /// failure that occurred, and include the email of the user for which the operation has failed.
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 pub enum MemberAddResult {
     /// Describes a user that was successfully added to the team.
     Success(TeamMemberInfo),
@@ -14591,7 +14591,7 @@ impl ::serde::ser::Serialize for MemberAddResult {
 }
 
 /// Information on devices of a team's member.
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 #[non_exhaustive] // structs may have more fields added in the future.
 pub struct MemberDevices {
     /// The member unique Id.
@@ -14736,7 +14736,7 @@ impl ::serde::ser::Serialize for MemberDevices {
 }
 
 /// Information on linked applications of a team member.
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 #[non_exhaustive] // structs may have more fields added in the future.
 pub struct MemberLinkedApps {
     /// The member unique Id.
@@ -14840,7 +14840,7 @@ impl ::serde::ser::Serialize for MemberLinkedApps {
 }
 
 /// Basic member profile.
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 #[non_exhaustive] // structs may have more fields added in the future.
 pub struct MemberProfile {
     /// ID of user as a member of a team.
@@ -15172,7 +15172,7 @@ impl ::serde::ser::Serialize for MemberProfile {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 pub enum MemberSelectorError {
     /// No matching user found. The provided team_member_id, email, or external_id does not exist on
     /// this team.
@@ -15248,7 +15248,7 @@ impl ::std::fmt::Display for MemberSelectorError {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 #[non_exhaustive] // structs may have more fields added in the future.
 pub struct MembersAddArg {
     /// Details of new members to be added to the team.
@@ -15356,7 +15356,7 @@ impl ::serde::ser::Serialize for MembersAddArg {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 pub enum MembersAddJobStatus {
     /// The asynchronous job is still in progress.
     InProgress,
@@ -15442,7 +15442,7 @@ impl ::serde::ser::Serialize for MembersAddJobStatus {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 pub enum MembersAddLaunch {
     /// This response indicates that the processing is asynchronous. The string is an id that can be
     /// used to obtain the status of the asynchronous job.
@@ -15513,7 +15513,7 @@ impl ::serde::ser::Serialize for MembersAddLaunch {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 #[non_exhaustive] // structs may have more fields added in the future.
 pub struct MembersDataTransferArg {
     /// Identity of user to remove/suspend/have their files moved.
@@ -15633,7 +15633,7 @@ impl ::serde::ser::Serialize for MembersDataTransferArg {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 #[non_exhaustive] // structs may have more fields added in the future.
 pub struct MembersDeactivateArg {
     /// Identity of user to remove/suspend/have their files moved.
@@ -15743,7 +15743,7 @@ impl ::serde::ser::Serialize for MembersDeactivateArg {
 
 /// Exactly one of team_member_id, email, or external_id must be provided to identify the user
 /// account.
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 #[non_exhaustive] // structs may have more fields added in the future.
 pub struct MembersDeactivateBaseArg {
     /// Identity of user to remove/suspend/have their files moved.
@@ -15833,7 +15833,7 @@ impl ::serde::ser::Serialize for MembersDeactivateBaseArg {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 #[non_exhaustive] // variants may be added in the future
 pub enum MembersDeactivateError {
     /// No matching user found. The provided team_member_id, email, or external_id does not exist on
@@ -15918,7 +15918,7 @@ impl ::std::fmt::Display for MembersDeactivateError {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 #[non_exhaustive] // structs may have more fields added in the future.
 pub struct MembersDeleteProfilePhotoArg {
     /// Identity of the user whose profile photo will be deleted.
@@ -16008,7 +16008,7 @@ impl ::serde::ser::Serialize for MembersDeleteProfilePhotoArg {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 #[non_exhaustive] // variants may be added in the future
 pub enum MembersDeleteProfilePhotoError {
     /// No matching user found. The provided team_member_id, email, or external_id does not exist on
@@ -16106,7 +16106,7 @@ impl ::std::fmt::Display for MembersDeleteProfilePhotoError {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 #[non_exhaustive] // structs may have more fields added in the future.
 pub struct MembersGetInfoArgs {
     /// List of team members.
@@ -16197,7 +16197,7 @@ impl ::serde::ser::Serialize for MembersGetInfoArgs {
 }
 
 
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 #[non_exhaustive] // variants may be added in the future
 pub enum MembersGetInfoError {
     /// Catch-all used for unrecognized values returned from the server. Encountering this value
@@ -16253,7 +16253,7 @@ impl ::std::fmt::Display for MembersGetInfoError {
 
 /// Describes a result obtained for a single user whose id was specified in the parameter of
 /// [`members_get_info()`](members_get_info).
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 pub enum MembersGetInfoItem {
     /// An ID that was provided as a parameter to [`members_get_info()`](members_get_info), and did
     /// not match a corresponding user. This might be a team_member_id, an email, or an external ID,
@@ -16320,7 +16320,7 @@ impl ::serde::ser::Serialize for MembersGetInfoItem {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 #[non_exhaustive] // structs may have more fields added in the future.
 pub struct MembersInfo {
     /// Team member IDs of the users under this hold.
@@ -16426,7 +16426,7 @@ impl ::serde::ser::Serialize for MembersInfo {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 #[non_exhaustive] // structs may have more fields added in the future.
 pub struct MembersListArg {
     /// Number of results to return per call.
@@ -16530,7 +16530,7 @@ impl ::serde::ser::Serialize for MembersListArg {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 #[non_exhaustive] // structs may have more fields added in the future.
 pub struct MembersListContinueArg {
     /// Indicates from what point to get the next set of members.
@@ -16620,7 +16620,7 @@ impl ::serde::ser::Serialize for MembersListContinueArg {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 #[non_exhaustive] // variants may be added in the future
 pub enum MembersListContinueError {
     /// The cursor is invalid.
@@ -16692,7 +16692,7 @@ impl ::std::fmt::Display for MembersListContinueError {
 }
 
 
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 #[non_exhaustive] // variants may be added in the future
 pub enum MembersListError {
     /// Catch-all used for unrecognized values returned from the server. Encountering this value
@@ -16746,7 +16746,7 @@ impl ::std::fmt::Display for MembersListError {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 #[non_exhaustive] // structs may have more fields added in the future.
 pub struct MembersListResult {
     /// List of team members.
@@ -16866,7 +16866,7 @@ impl ::serde::ser::Serialize for MembersListResult {
 
 /// Exactly one of team_member_id, email, or external_id must be provided to identify the user
 /// account.
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 #[non_exhaustive] // structs may have more fields added in the future.
 pub struct MembersRecoverArg {
     /// Identity of user to recover.
@@ -16956,7 +16956,7 @@ impl ::serde::ser::Serialize for MembersRecoverArg {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 #[non_exhaustive] // variants may be added in the future
 pub enum MembersRecoverError {
     /// No matching user found. The provided team_member_id, email, or external_id does not exist on
@@ -17067,7 +17067,7 @@ impl ::std::fmt::Display for MembersRecoverError {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 #[non_exhaustive] // structs may have more fields added in the future.
 pub struct MembersRemoveArg {
     /// Identity of user to remove/suspend/have their files moved.
@@ -17254,7 +17254,7 @@ impl ::serde::ser::Serialize for MembersRemoveArg {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 #[non_exhaustive] // variants may be added in the future
 pub enum MembersRemoveError {
     /// No matching user found. The provided team_member_id, email, or external_id does not exist on
@@ -17606,7 +17606,7 @@ impl ::std::fmt::Display for MembersRemoveError {
 }
 
 
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 #[non_exhaustive] // variants may be added in the future
 pub enum MembersSendWelcomeError {
     /// No matching user found. The provided team_member_id, email, or external_id does not exist on
@@ -17693,7 +17693,7 @@ impl ::std::fmt::Display for MembersSendWelcomeError {
 
 /// Exactly one of team_member_id, email, or external_id must be provided to identify the user
 /// account.
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 #[non_exhaustive] // structs may have more fields added in the future.
 pub struct MembersSetPermissionsArg {
     /// Identity of user whose role will be set.
@@ -17796,7 +17796,7 @@ impl ::serde::ser::Serialize for MembersSetPermissionsArg {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 #[non_exhaustive] // variants may be added in the future
 pub enum MembersSetPermissionsError {
     /// No matching user found. The provided team_member_id, email, or external_id does not exist on
@@ -17920,7 +17920,7 @@ impl ::std::fmt::Display for MembersSetPermissionsError {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 #[non_exhaustive] // structs may have more fields added in the future.
 pub struct MembersSetPermissionsResult {
     /// The member ID of the user to which the change was applied.
@@ -18026,7 +18026,7 @@ impl ::serde::ser::Serialize for MembersSetPermissionsResult {
 /// Exactly one of team_member_id, email, or external_id must be provided to identify the user
 /// account. At least one of new_email, new_external_id, new_given_name, and/or new_surname must be
 /// provided.
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 #[non_exhaustive] // structs may have more fields added in the future.
 pub struct MembersSetProfileArg {
     /// Identity of user whose profile will be set.
@@ -18225,7 +18225,7 @@ impl ::serde::ser::Serialize for MembersSetProfileArg {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 #[non_exhaustive] // variants may be added in the future
 pub enum MembersSetProfileError {
     /// No matching user found. The provided team_member_id, email, or external_id does not exist on
@@ -18428,7 +18428,7 @@ impl ::std::fmt::Display for MembersSetProfileError {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 #[non_exhaustive] // structs may have more fields added in the future.
 pub struct MembersSetProfilePhotoArg {
     /// Identity of the user whose profile photo will be set.
@@ -18531,7 +18531,7 @@ impl ::serde::ser::Serialize for MembersSetProfilePhotoArg {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 #[non_exhaustive] // variants may be added in the future
 pub enum MembersSetProfilePhotoError {
     /// No matching user found. The provided team_member_id, email, or external_id does not exist on
@@ -18645,7 +18645,7 @@ impl ::std::fmt::Display for MembersSetProfilePhotoError {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 #[non_exhaustive] // variants may be added in the future
 pub enum MembersSuspendError {
     /// No matching user found. The provided team_member_id, email, or external_id does not exist on
@@ -18769,7 +18769,7 @@ impl ::std::fmt::Display for MembersSuspendError {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 #[non_exhaustive] // variants may be added in the future
 pub enum MembersTransferFilesError {
     /// No matching user found. The provided team_member_id, email, or external_id does not exist on
@@ -18971,7 +18971,7 @@ impl ::std::fmt::Display for MembersTransferFilesError {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 #[non_exhaustive] // variants may be added in the future
 pub enum MembersTransferFormerMembersFilesError {
     /// No matching user found. The provided team_member_id, email, or external_id does not exist on
@@ -19227,7 +19227,7 @@ impl ::std::fmt::Display for MembersTransferFormerMembersFilesError {
 
 /// Exactly one of team_member_id, email, or external_id must be provided to identify the user
 /// account.
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 #[non_exhaustive] // structs may have more fields added in the future.
 pub struct MembersUnsuspendArg {
     /// Identity of user to unsuspend.
@@ -19317,7 +19317,7 @@ impl ::serde::ser::Serialize for MembersUnsuspendArg {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 #[non_exhaustive] // variants may be added in the future
 pub enum MembersUnsuspendError {
     /// No matching user found. The provided team_member_id, email, or external_id does not exist on
@@ -19428,7 +19428,7 @@ impl ::std::fmt::Display for MembersUnsuspendError {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 #[non_exhaustive] // variants may be added in the future
 pub enum MobileClientPlatform {
     /// Official Dropbox iPhone client.
@@ -19540,7 +19540,7 @@ impl ::serde::ser::Serialize for MobileClientPlatform {
 }
 
 /// Information about linked Dropbox mobile client sessions.
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 #[non_exhaustive] // structs may have more fields added in the future.
 pub struct MobileClientSession {
     /// The session id.
@@ -19787,7 +19787,7 @@ impl ::serde::ser::Serialize for MobileClientSession {
 }
 
 /// Properties of a namespace.
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 #[non_exhaustive] // structs may have more fields added in the future.
 pub struct NamespaceMetadata {
     /// The name of this namespace.
@@ -19926,7 +19926,7 @@ impl ::serde::ser::Serialize for NamespaceMetadata {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 #[non_exhaustive] // variants may be added in the future
 pub enum NamespaceType {
     /// App sandbox folder.
@@ -20025,7 +20025,7 @@ impl ::serde::ser::Serialize for NamespaceType {
 }
 
 /// User result for setting member custom quota.
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 #[non_exhaustive] // variants may be added in the future
 pub enum RemoveCustomQuotaResult {
     /// Successfully removed user.
@@ -20105,7 +20105,7 @@ impl ::serde::ser::Serialize for RemoveCustomQuotaResult {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 #[non_exhaustive] // structs may have more fields added in the future.
 pub struct RemovedStatus {
     /// True if the removed team member is recoverable.
@@ -20211,7 +20211,7 @@ impl ::serde::ser::Serialize for RemovedStatus {
 /// Result of trying to resend verification email to a secondary email address. 'success' is the
 /// only value indicating that a verification email was successfully sent. The other values explain
 /// the type of error that occurred, and include the email for which the error occured.
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 #[non_exhaustive] // variants may be added in the future
 pub enum ResendSecondaryEmailResult {
     /// A verification email was successfully sent to the secondary email address.
@@ -20308,7 +20308,7 @@ impl ::serde::ser::Serialize for ResendSecondaryEmailResult {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 #[non_exhaustive] // structs may have more fields added in the future.
 pub struct ResendVerificationEmailArg {
     /// List of users and secondary emails to resend verification emails to.
@@ -20399,7 +20399,7 @@ impl ::serde::ser::Serialize for ResendVerificationEmailArg {
 }
 
 /// List of users and resend results.
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 #[non_exhaustive] // structs may have more fields added in the future.
 pub struct ResendVerificationEmailResult {
     pub results: Vec<UserResendResult>,
@@ -20488,7 +20488,7 @@ impl ::serde::ser::Serialize for ResendVerificationEmailResult {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 #[non_exhaustive] // structs may have more fields added in the future.
 pub struct RevokeDesktopClientArg {
     /// The session id.
@@ -20610,7 +20610,7 @@ impl ::serde::ser::Serialize for RevokeDesktopClientArg {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 pub enum RevokeDeviceSessionArg {
     /// End an active session.
     WebSession(DeviceSessionArg),
@@ -20680,7 +20680,7 @@ impl ::serde::ser::Serialize for RevokeDeviceSessionArg {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 #[non_exhaustive] // structs may have more fields added in the future.
 pub struct RevokeDeviceSessionBatchArg {
     pub revoke_devices: Vec<RevokeDeviceSessionArg>,
@@ -20770,7 +20770,7 @@ impl ::serde::ser::Serialize for RevokeDeviceSessionBatchArg {
 }
 
 
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 #[non_exhaustive] // variants may be added in the future
 pub enum RevokeDeviceSessionBatchError {
     /// Catch-all used for unrecognized values returned from the server. Encountering this value
@@ -20824,7 +20824,7 @@ impl ::std::fmt::Display for RevokeDeviceSessionBatchError {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 #[non_exhaustive] // structs may have more fields added in the future.
 pub struct RevokeDeviceSessionBatchResult {
     pub revoke_devices_status: Vec<RevokeDeviceSessionStatus>,
@@ -20913,7 +20913,7 @@ impl ::serde::ser::Serialize for RevokeDeviceSessionBatchResult {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 #[non_exhaustive] // variants may be added in the future
 pub enum RevokeDeviceSessionError {
     /// Device session not found.
@@ -20997,7 +20997,7 @@ impl ::std::fmt::Display for RevokeDeviceSessionError {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 #[non_exhaustive] // structs may have more fields added in the future.
 pub struct RevokeDeviceSessionStatus {
     /// Result of the revoking request.
@@ -21105,7 +21105,7 @@ impl ::serde::ser::Serialize for RevokeDeviceSessionStatus {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 #[non_exhaustive] // structs may have more fields added in the future.
 pub struct RevokeLinkedApiAppArg {
     /// The application's unique id.
@@ -21227,7 +21227,7 @@ impl ::serde::ser::Serialize for RevokeLinkedApiAppArg {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 #[non_exhaustive] // structs may have more fields added in the future.
 pub struct RevokeLinkedApiAppBatchArg {
     pub revoke_linked_app: Vec<RevokeLinkedApiAppArg>,
@@ -21318,7 +21318,7 @@ impl ::serde::ser::Serialize for RevokeLinkedApiAppBatchArg {
 
 /// Error returned by
 /// [`linked_apps_revoke_linked_app_batch()`](linked_apps_revoke_linked_app_batch).
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 #[non_exhaustive] // variants may be added in the future
 pub enum RevokeLinkedAppBatchError {
     /// Catch-all used for unrecognized values returned from the server. Encountering this value
@@ -21372,7 +21372,7 @@ impl ::std::fmt::Display for RevokeLinkedAppBatchError {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 #[non_exhaustive] // structs may have more fields added in the future.
 pub struct RevokeLinkedAppBatchResult {
     pub revoke_linked_app_status: Vec<RevokeLinkedAppStatus>,
@@ -21462,7 +21462,7 @@ impl ::serde::ser::Serialize for RevokeLinkedAppBatchResult {
 }
 
 /// Error returned by [`linked_apps_revoke_linked_app()`](linked_apps_revoke_linked_app).
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 #[non_exhaustive] // variants may be added in the future
 pub enum RevokeLinkedAppError {
     /// Application not found.
@@ -21559,7 +21559,7 @@ impl ::std::fmt::Display for RevokeLinkedAppError {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 #[non_exhaustive] // structs may have more fields added in the future.
 pub struct RevokeLinkedAppStatus {
     /// Result of the revoking request.
@@ -21667,7 +21667,7 @@ impl ::serde::ser::Serialize for RevokeLinkedAppStatus {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 #[non_exhaustive] // structs may have more fields added in the future.
 pub struct SetCustomQuotaArg {
     /// List of users and their custom quotas.
@@ -21758,7 +21758,7 @@ impl ::serde::ser::Serialize for SetCustomQuotaArg {
 }
 
 /// Error returned when setting member custom quota.
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 #[non_exhaustive] // variants may be added in the future
 pub enum SetCustomQuotaError {
     /// A maximum of 1000 users can be set for a single call.
@@ -21843,7 +21843,7 @@ impl ::std::fmt::Display for SetCustomQuotaError {
 }
 
 /// Describes the number of users in a specific storage bucket.
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 #[non_exhaustive] // structs may have more fields added in the future.
 pub struct StorageBucket {
     /// The name of the storage bucket. For example, '1G' is a bucket of users with storage size up
@@ -21947,7 +21947,7 @@ impl ::serde::ser::Serialize for StorageBucket {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 #[non_exhaustive] // variants may be added in the future
 pub enum TeamFolderAccessError {
     /// The team folder ID is invalid.
@@ -22032,7 +22032,7 @@ impl ::std::fmt::Display for TeamFolderAccessError {
 }
 
 
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 #[non_exhaustive] // variants may be added in the future
 pub enum TeamFolderActivateError {
     AccessError(TeamFolderAccessError),
@@ -22138,7 +22138,7 @@ impl ::std::fmt::Display for TeamFolderActivateError {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 #[non_exhaustive] // structs may have more fields added in the future.
 pub struct TeamFolderArchiveArg {
     /// The ID of the team folder.
@@ -22247,7 +22247,7 @@ impl ::serde::ser::Serialize for TeamFolderArchiveArg {
 }
 
 
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 #[non_exhaustive] // variants may be added in the future
 pub enum TeamFolderArchiveError {
     AccessError(TeamFolderAccessError),
@@ -22353,7 +22353,7 @@ impl ::std::fmt::Display for TeamFolderArchiveError {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 pub enum TeamFolderArchiveJobStatus {
     /// The asynchronous job is still in progress.
     InProgress,
@@ -22432,7 +22432,7 @@ impl ::serde::ser::Serialize for TeamFolderArchiveJobStatus {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 pub enum TeamFolderArchiveLaunch {
     /// This response indicates that the processing is asynchronous. The string is an id that can be
     /// used to obtain the status of the asynchronous job.
@@ -22497,7 +22497,7 @@ impl ::serde::ser::Serialize for TeamFolderArchiveLaunch {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 #[non_exhaustive] // structs may have more fields added in the future.
 pub struct TeamFolderCreateArg {
     /// Name for the new team folder.
@@ -22606,7 +22606,7 @@ impl ::serde::ser::Serialize for TeamFolderCreateArg {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 #[non_exhaustive] // variants may be added in the future
 pub enum TeamFolderCreateError {
     /// The provided name cannot be used.
@@ -22720,7 +22720,7 @@ impl ::std::fmt::Display for TeamFolderCreateError {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 pub enum TeamFolderGetInfoItem {
     /// An ID that was provided as a parameter to [`team_folder_get_info()`](team_folder_get_info)
     /// did not match any of the team's team folders.
@@ -22786,7 +22786,7 @@ impl ::serde::ser::Serialize for TeamFolderGetInfoItem {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 #[non_exhaustive] // structs may have more fields added in the future.
 pub struct TeamFolderIdArg {
     /// The ID of the team folder.
@@ -22876,7 +22876,7 @@ impl ::serde::ser::Serialize for TeamFolderIdArg {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 #[non_exhaustive] // structs may have more fields added in the future.
 pub struct TeamFolderIdListArg {
     /// The list of team folder IDs.
@@ -22966,7 +22966,7 @@ impl ::serde::ser::Serialize for TeamFolderIdListArg {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 #[non_exhaustive] // variants may be added in the future
 pub enum TeamFolderInvalidStatusError {
     /// The folder is active and the operation did not succeed.
@@ -23063,7 +23063,7 @@ impl ::std::fmt::Display for TeamFolderInvalidStatusError {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 #[non_exhaustive] // structs may have more fields added in the future.
 pub struct TeamFolderListArg {
     /// The maximum number of results to return per request.
@@ -23149,7 +23149,7 @@ impl ::serde::ser::Serialize for TeamFolderListArg {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 #[non_exhaustive] // structs may have more fields added in the future.
 pub struct TeamFolderListContinueArg {
     /// Indicates from what point to get the next set of team folders.
@@ -23239,7 +23239,7 @@ impl ::serde::ser::Serialize for TeamFolderListContinueArg {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 #[non_exhaustive] // variants may be added in the future
 pub enum TeamFolderListContinueError {
     /// The cursor is invalid.
@@ -23310,7 +23310,7 @@ impl ::std::fmt::Display for TeamFolderListContinueError {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 #[non_exhaustive] // structs may have more fields added in the future.
 pub struct TeamFolderListError {
     pub access_error: TeamFolderAccessError,
@@ -23401,7 +23401,7 @@ impl ::serde::ser::Serialize for TeamFolderListError {
 
 /// Result for [`team_folder_list()`](team_folder_list) and
 /// [`team_folder_list_continue()`](team_folder_list_continue).
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 #[non_exhaustive] // structs may have more fields added in the future.
 pub struct TeamFolderListResult {
     /// List of all team folders in the authenticated team.
@@ -23520,7 +23520,7 @@ impl ::serde::ser::Serialize for TeamFolderListResult {
 }
 
 /// Properties of a team folder.
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 #[non_exhaustive] // structs may have more fields added in the future.
 pub struct TeamFolderMetadata {
     /// The ID of the team folder.
@@ -23683,7 +23683,7 @@ impl ::serde::ser::Serialize for TeamFolderMetadata {
 }
 
 
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 #[non_exhaustive] // variants may be added in the future
 pub enum TeamFolderPermanentlyDeleteError {
     AccessError(TeamFolderAccessError),
@@ -23789,7 +23789,7 @@ impl ::std::fmt::Display for TeamFolderPermanentlyDeleteError {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 #[non_exhaustive] // structs may have more fields added in the future.
 pub struct TeamFolderRenameArg {
     /// The ID of the team folder.
@@ -23892,7 +23892,7 @@ impl ::serde::ser::Serialize for TeamFolderRenameArg {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 #[non_exhaustive] // variants may be added in the future
 pub enum TeamFolderRenameError {
     AccessError(TeamFolderAccessError),
@@ -24037,7 +24037,7 @@ impl ::std::fmt::Display for TeamFolderRenameError {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 #[non_exhaustive] // variants may be added in the future
 pub enum TeamFolderStatus {
     /// The team folder and sub-folders are available to all members.
@@ -24122,7 +24122,7 @@ impl ::serde::ser::Serialize for TeamFolderStatus {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 #[non_exhaustive] // variants may be added in the future
 pub enum TeamFolderTeamSharedDropboxError {
     /// This action is not allowed for a shared team root.
@@ -24193,7 +24193,7 @@ impl ::std::fmt::Display for TeamFolderTeamSharedDropboxError {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 #[non_exhaustive] // structs may have more fields added in the future.
 pub struct TeamFolderUpdateSyncSettingsArg {
     /// The ID of the team folder.
@@ -24323,7 +24323,7 @@ impl ::serde::ser::Serialize for TeamFolderUpdateSyncSettingsArg {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 #[non_exhaustive] // variants may be added in the future
 pub enum TeamFolderUpdateSyncSettingsError {
     AccessError(TeamFolderAccessError),
@@ -24446,7 +24446,7 @@ impl ::std::fmt::Display for TeamFolderUpdateSyncSettingsError {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 #[non_exhaustive] // structs may have more fields added in the future.
 pub struct TeamGetInfoResult {
     /// The name of the team.
@@ -24594,7 +24594,7 @@ impl ::serde::ser::Serialize for TeamGetInfoResult {
 }
 
 /// Information about a team member.
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 #[non_exhaustive] // structs may have more fields added in the future.
 pub struct TeamMemberInfo {
     /// Profile of a user as a member of a team.
@@ -24698,7 +24698,7 @@ impl ::serde::ser::Serialize for TeamMemberInfo {
 }
 
 /// Profile of a user as a member of a team.
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 #[non_exhaustive] // structs may have more fields added in the future.
 pub struct TeamMemberProfile {
     /// ID of user as a member of a team.
@@ -25059,7 +25059,7 @@ impl ::serde::ser::Serialize for TeamMemberProfile {
 }
 
 /// The user's status as a member of a specific team.
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 pub enum TeamMemberStatus {
     /// User has successfully joined the team.
     Active,
@@ -25148,7 +25148,7 @@ impl ::serde::ser::Serialize for TeamMemberStatus {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 pub enum TeamMembershipType {
     /// User uses a license and has full access to team resources like the shared quota.
     Full,
@@ -25212,7 +25212,7 @@ impl ::serde::ser::Serialize for TeamMembershipType {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 #[non_exhaustive] // structs may have more fields added in the future.
 pub struct TeamNamespacesListArg {
     /// Specifying a value here has no effect.
@@ -25298,7 +25298,7 @@ impl ::serde::ser::Serialize for TeamNamespacesListArg {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 #[non_exhaustive] // structs may have more fields added in the future.
 pub struct TeamNamespacesListContinueArg {
     /// Indicates from what point to get the next set of team-accessible namespaces.
@@ -25388,7 +25388,7 @@ impl ::serde::ser::Serialize for TeamNamespacesListContinueArg {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 #[non_exhaustive] // variants may be added in the future
 pub enum TeamNamespacesListContinueError {
     /// Argument passed in is invalid.
@@ -25472,7 +25472,7 @@ impl ::std::fmt::Display for TeamNamespacesListContinueError {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 #[non_exhaustive] // variants may be added in the future
 pub enum TeamNamespacesListError {
     /// Argument passed in is invalid.
@@ -25544,7 +25544,7 @@ impl ::std::fmt::Display for TeamNamespacesListError {
 }
 
 /// Result for [`namespaces_list()`](namespaces_list).
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 #[non_exhaustive] // structs may have more fields added in the future.
 pub struct TeamNamespacesListResult {
     /// List of all namespaces the team can access.
@@ -25661,7 +25661,7 @@ impl ::serde::ser::Serialize for TeamNamespacesListResult {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 #[non_exhaustive] // variants may be added in the future
 pub enum TeamReportFailureReason {
     /// We couldn't create the report, but we think this was a fluke. Everything should work if you
@@ -25749,7 +25749,7 @@ impl ::serde::ser::Serialize for TeamReportFailureReason {
 }
 
 /// Error returned by [`token_get_authenticated_admin()`](token_get_authenticated_admin).
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 #[non_exhaustive] // variants may be added in the future
 pub enum TokenGetAuthenticatedAdminError {
     /// The current token is not associated with a team admin, because mappings were not recorded
@@ -25837,7 +25837,7 @@ impl ::std::fmt::Display for TokenGetAuthenticatedAdminError {
 }
 
 /// Results for [`token_get_authenticated_admin()`](token_get_authenticated_admin).
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 #[non_exhaustive] // structs may have more fields added in the future.
 pub struct TokenGetAuthenticatedAdminResult {
     /// The admin who authorized the token.
@@ -25928,7 +25928,7 @@ impl ::serde::ser::Serialize for TokenGetAuthenticatedAdminResult {
 }
 
 /// The value for [`Feature::UploadApiRateLimit`](Feature::UploadApiRateLimit).
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 #[non_exhaustive] // variants may be added in the future
 pub enum UploadApiRateLimitValue {
     /// This team has unlimited upload API quota. So far both server version account and legacy
@@ -26008,7 +26008,7 @@ impl ::serde::ser::Serialize for UploadApiRateLimitValue {
 /// Result of trying to add secondary emails to a user. 'success' is the only value indicating that
 /// a user was successfully retrieved for adding secondary emails. The other values explain the type
 /// of error that occurred, and include the user for which the error occured.
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 #[non_exhaustive] // variants may be added in the future
 pub enum UserAddResult {
     /// Describes a user and the results for each attempt to add a secondary email.
@@ -26117,7 +26117,7 @@ impl ::serde::ser::Serialize for UserAddResult {
 }
 
 /// User and their required custom quota in GB (1 TB = 1024 GB).
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 #[non_exhaustive] // structs may have more fields added in the future.
 pub struct UserCustomQuotaArg {
     pub user: UserSelectorArg,
@@ -26220,7 +26220,7 @@ impl ::serde::ser::Serialize for UserCustomQuotaArg {
 
 /// User and their custom quota in GB (1 TB = 1024 GB).  No quota returns if the user has no custom
 /// quota set.
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 #[non_exhaustive] // structs may have more fields added in the future.
 pub struct UserCustomQuotaResult {
     pub user: UserSelectorArg,
@@ -26326,7 +26326,7 @@ impl ::serde::ser::Serialize for UserCustomQuotaResult {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 #[non_exhaustive] // structs may have more fields added in the future.
 pub struct UserDeleteEmailsResult {
     pub user: UserSelectorArg,
@@ -26430,7 +26430,7 @@ impl ::serde::ser::Serialize for UserDeleteEmailsResult {
 /// Result of trying to delete a user's secondary emails. 'success' is the only value indicating
 /// that a user was successfully retrieved for deleting secondary emails. The other values explain
 /// the type of error that occurred, and include the user for which the error occured.
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 #[non_exhaustive] // variants may be added in the future
 pub enum UserDeleteResult {
     /// Describes a user and the results for each attempt to delete a secondary email.
@@ -26504,7 +26504,7 @@ impl ::serde::ser::Serialize for UserDeleteResult {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 #[non_exhaustive] // structs may have more fields added in the future.
 pub struct UserResendEmailsResult {
     pub user: UserSelectorArg,
@@ -26608,7 +26608,7 @@ impl ::serde::ser::Serialize for UserResendEmailsResult {
 /// Result of trying to resend verification emails to a user. 'success' is the only value indicating
 /// that a user was successfully retrieved for sending verification emails. The other values explain
 /// the type of error that occurred, and include the user for which the error occured.
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 #[non_exhaustive] // variants may be added in the future
 pub enum UserResendResult {
     /// Describes a user and the results for each attempt to resend verification emails.
@@ -26683,7 +26683,7 @@ impl ::serde::ser::Serialize for UserResendResult {
 }
 
 /// User and a list of secondary emails.
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 #[non_exhaustive] // structs may have more fields added in the future.
 pub struct UserSecondaryEmailsArg {
     pub user: UserSelectorArg,
@@ -26784,7 +26784,7 @@ impl ::serde::ser::Serialize for UserSecondaryEmailsArg {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 #[non_exhaustive] // structs may have more fields added in the future.
 pub struct UserSecondaryEmailsResult {
     pub user: UserSelectorArg,
@@ -26886,7 +26886,7 @@ impl ::serde::ser::Serialize for UserSecondaryEmailsResult {
 }
 
 /// Argument for selecting a single user, either by team_member_id, external_id or email.
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 pub enum UserSelectorArg {
     TeamMemberId(super::team_common::TeamMemberId),
     ExternalId(super::team_common::MemberExternalId),
@@ -26973,7 +26973,7 @@ impl ::serde::ser::Serialize for UserSelectorArg {
 
 /// Error that can be returned whenever a struct derived from [`UserSelectorArg`](UserSelectorArg)
 /// is used.
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 pub enum UserSelectorError {
     /// No matching user found. The provided team_member_id, email, or external_id does not exist on
     /// this team.
@@ -27037,7 +27037,7 @@ impl ::std::fmt::Display for UserSelectorError {
 }
 
 /// Argument for selecting a list of users, either by team_member_ids, external_ids or emails.
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 pub enum UsersSelectorArg {
     /// List of member IDs.
     TeamMemberIds(Vec<super::team_common::TeamMemberId>),

--- a/src/generated/team_common.rs
+++ b/src/generated/team_common.rs
@@ -15,7 +15,7 @@ pub type TeamId = String;
 pub type TeamMemberId = String;
 
 /// The group type determines how a group is managed.
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 #[non_exhaustive] // variants may be added in the future
 pub enum GroupManagementType {
     /// A group which is managed by selected users.
@@ -101,7 +101,7 @@ impl ::serde::ser::Serialize for GroupManagementType {
 }
 
 /// Information about a group.
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 #[non_exhaustive] // structs may have more fields added in the future.
 pub struct GroupSummary {
     pub group_name: String,
@@ -256,7 +256,7 @@ impl ::serde::ser::Serialize for GroupSummary {
 }
 
 /// The group type determines how a group is created and managed.
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 #[non_exhaustive] // variants may be added in the future
 pub enum GroupType {
     /// A group to which team members are automatically added. Applicable to [team
@@ -330,7 +330,7 @@ impl ::serde::ser::Serialize for GroupType {
 }
 
 /// The type of the space limit imposed on a team member.
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 #[non_exhaustive] // variants may be added in the future
 pub enum MemberSpaceLimitType {
     /// The team member does not have imposed space limit.
@@ -418,7 +418,7 @@ impl ::serde::ser::Serialize for MemberSpaceLimitType {
 }
 
 /// Time range.
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 #[non_exhaustive] // structs may have more fields added in the future.
 pub struct TimeRange {
     /// Optional starting time (inclusive).

--- a/src/generated/team_policies.rs
+++ b/src/generated/team_policies.rs
@@ -7,7 +7,7 @@
     clippy::doc_markdown,
 )]
 
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 #[non_exhaustive] // variants may be added in the future
 pub enum CameraUploadsPolicyState {
     /// Background camera uploads are disabled.
@@ -79,7 +79,7 @@ impl ::serde::ser::Serialize for CameraUploadsPolicyState {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 #[non_exhaustive] // variants may be added in the future
 pub enum ComputerBackupPolicyState {
     /// Computer Backup feature is disabled.
@@ -164,7 +164,7 @@ impl ::serde::ser::Serialize for ComputerBackupPolicyState {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 #[non_exhaustive] // variants may be added in the future
 pub enum EmmState {
     /// Emm token is disabled.
@@ -249,7 +249,7 @@ impl ::serde::ser::Serialize for EmmState {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 #[non_exhaustive] // variants may be added in the future
 pub enum FileLockingPolicyState {
     /// File locking feature is disabled.
@@ -321,7 +321,7 @@ impl ::serde::ser::Serialize for FileLockingPolicyState {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 pub enum GroupCreation {
     /// Team admins and members can create groups.
     AdminsAndMembers,
@@ -384,7 +384,7 @@ impl ::serde::ser::Serialize for GroupCreation {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 #[non_exhaustive] // variants may be added in the future
 pub enum OfficeAddInPolicy {
     /// Office Add-In is disabled.
@@ -456,7 +456,7 @@ impl ::serde::ser::Serialize for OfficeAddInPolicy {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 #[non_exhaustive] // variants may be added in the future
 pub enum PaperDefaultFolderPolicy {
     /// Everyone in team will be the default option when creating a folder in Paper.
@@ -528,7 +528,7 @@ impl ::serde::ser::Serialize for PaperDefaultFolderPolicy {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 #[non_exhaustive] // variants may be added in the future
 pub enum PaperDeploymentPolicy {
     /// All team members have access to Paper.
@@ -601,7 +601,7 @@ impl ::serde::ser::Serialize for PaperDeploymentPolicy {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 #[non_exhaustive] // variants may be added in the future
 pub enum PaperDesktopPolicy {
     /// Do not allow team members to use Paper Desktop.
@@ -673,7 +673,7 @@ impl ::serde::ser::Serialize for PaperDesktopPolicy {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 #[non_exhaustive] // variants may be added in the future
 pub enum PaperEnabledPolicy {
     /// Paper is disabled.
@@ -758,7 +758,7 @@ impl ::serde::ser::Serialize for PaperEnabledPolicy {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 #[non_exhaustive] // variants may be added in the future
 pub enum PasswordControlMode {
     /// Password is disabled.
@@ -830,7 +830,7 @@ impl ::serde::ser::Serialize for PasswordControlMode {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 #[non_exhaustive] // variants may be added in the future
 pub enum PasswordStrengthPolicy {
     /// User passwords will adhere to the minimal password strength policy.
@@ -915,7 +915,7 @@ impl ::serde::ser::Serialize for PasswordStrengthPolicy {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 pub enum RolloutMethod {
     /// Unlink all.
     UnlinkAll,
@@ -992,7 +992,7 @@ impl ::serde::ser::Serialize for RolloutMethod {
 }
 
 /// Policy governing which shared folders a team member can join.
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 #[non_exhaustive] // variants may be added in the future
 pub enum SharedFolderJoinPolicy {
     /// Team members can only join folders shared by teammates.
@@ -1065,7 +1065,7 @@ impl ::serde::ser::Serialize for SharedFolderJoinPolicy {
 }
 
 /// Policy governing who can be a member of a folder shared by a team member.
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 #[non_exhaustive] // variants may be added in the future
 pub enum SharedFolderMemberPolicy {
     /// Only a teammate can be a member of a folder shared by a team member.
@@ -1139,7 +1139,7 @@ impl ::serde::ser::Serialize for SharedFolderMemberPolicy {
 
 /// Policy governing the visibility of shared links. This policy can apply to newly created shared
 /// links, or all shared links.
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 #[non_exhaustive] // variants may be added in the future
 pub enum SharedLinkCreatePolicy {
     /// By default, anyone can access newly created shared links. No login will be required to
@@ -1227,7 +1227,7 @@ impl ::serde::ser::Serialize for SharedLinkCreatePolicy {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 #[non_exhaustive] // variants may be added in the future
 pub enum ShowcaseDownloadPolicy {
     /// Do not allow files to be downloaded from Showcases.
@@ -1299,7 +1299,7 @@ impl ::serde::ser::Serialize for ShowcaseDownloadPolicy {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 #[non_exhaustive] // variants may be added in the future
 pub enum ShowcaseEnabledPolicy {
     /// Showcase is disabled.
@@ -1371,7 +1371,7 @@ impl ::serde::ser::Serialize for ShowcaseEnabledPolicy {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 #[non_exhaustive] // variants may be added in the future
 pub enum ShowcaseExternalSharingPolicy {
     /// Do not allow showcases to be shared with people not on the team.
@@ -1443,7 +1443,7 @@ impl ::serde::ser::Serialize for ShowcaseExternalSharingPolicy {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 #[non_exhaustive] // variants may be added in the future
 pub enum SmartSyncPolicy {
     /// The specified content will be synced as local files by default.
@@ -1515,7 +1515,7 @@ impl ::serde::ser::Serialize for SmartSyncPolicy {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 #[non_exhaustive] // variants may be added in the future
 pub enum SmarterSmartSyncPolicyState {
     /// Smarter Smart Sync feature is disabled.
@@ -1587,7 +1587,7 @@ impl ::serde::ser::Serialize for SmarterSmartSyncPolicyState {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 #[non_exhaustive] // variants may be added in the future
 pub enum SsoPolicy {
     /// Users will be able to sign in with their Dropbox credentials.
@@ -1672,7 +1672,7 @@ impl ::serde::ser::Serialize for SsoPolicy {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 #[non_exhaustive] // variants may be added in the future
 pub enum SuggestMembersPolicy {
     /// Suggest members is disabled.
@@ -1745,7 +1745,7 @@ impl ::serde::ser::Serialize for SuggestMembersPolicy {
 }
 
 /// Policies governing team members.
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 #[non_exhaustive] // structs may have more fields added in the future.
 pub struct TeamMemberPolicies {
     /// Policies governing sharing.
@@ -1885,7 +1885,7 @@ impl ::serde::ser::Serialize for TeamMemberPolicies {
 }
 
 /// Policies governing sharing within and outside of the team.
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 #[non_exhaustive] // structs may have more fields added in the future.
 pub struct TeamSharingPolicies {
     /// Who can join folders shared by team members.
@@ -2005,7 +2005,7 @@ impl ::serde::ser::Serialize for TeamSharingPolicies {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 #[non_exhaustive] // variants may be added in the future
 pub enum TwoStepVerificationPolicy {
     /// Enabled require two factor authorization.
@@ -2077,7 +2077,7 @@ impl ::serde::ser::Serialize for TwoStepVerificationPolicy {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 #[non_exhaustive] // variants may be added in the future
 pub enum TwoStepVerificationState {
     /// Enabled require two factor authorization.

--- a/src/generated/users.rs
+++ b/src/generated/users.rs
@@ -81,7 +81,7 @@ pub fn get_space_usage(
 
 /// The amount of detail revealed about an account depends on the user being queried and the user
 /// making the query.
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 #[non_exhaustive] // structs may have more fields added in the future.
 pub struct Account {
     /// The user's unique Dropbox ID.
@@ -249,7 +249,7 @@ impl ::serde::ser::Serialize for Account {
 }
 
 /// Basic information about any account.
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 #[non_exhaustive] // structs may have more fields added in the future.
 pub struct BasicAccount {
     /// The user's unique Dropbox ID.
@@ -451,7 +451,7 @@ impl ::serde::ser::Serialize for BasicAccount {
 }
 
 /// The value for [`UserFeature::FileLocking`](UserFeature::FileLocking).
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 #[non_exhaustive] // variants may be added in the future
 pub enum FileLockingValue {
     /// When this value is True, the user can lock files in shared directories. When the value is
@@ -517,7 +517,7 @@ impl ::serde::ser::Serialize for FileLockingValue {
 }
 
 /// Detailed information about the current user's account.
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 #[non_exhaustive] // structs may have more fields added in the future.
 pub struct FullAccount {
     /// The user's unique Dropbox ID.
@@ -812,7 +812,7 @@ impl ::serde::ser::Serialize for FullAccount {
 }
 
 /// Detailed information about a team.
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 #[non_exhaustive] // structs may have more fields added in the future.
 pub struct FullTeam {
     /// The team's unique ID.
@@ -946,7 +946,7 @@ impl ::serde::ser::Serialize for FullTeam {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 #[non_exhaustive] // structs may have more fields added in the future.
 pub struct GetAccountArg {
     /// A user's account identifier.
@@ -1036,7 +1036,7 @@ impl ::serde::ser::Serialize for GetAccountArg {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 #[non_exhaustive] // structs may have more fields added in the future.
 pub struct GetAccountBatchArg {
     /// List of user account identifiers.  Should not contain any duplicate account IDs.
@@ -1126,7 +1126,7 @@ impl ::serde::ser::Serialize for GetAccountBatchArg {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 #[non_exhaustive] // variants may be added in the future
 pub enum GetAccountBatchError {
     /// The value is an account ID specified in
@@ -1202,7 +1202,7 @@ impl ::std::fmt::Display for GetAccountBatchError {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 #[non_exhaustive] // variants may be added in the future
 pub enum GetAccountError {
     /// The specified [`GetAccountArg::account_id`](GetAccountArg) does not exist.
@@ -1273,7 +1273,7 @@ impl ::std::fmt::Display for GetAccountError {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 #[non_exhaustive] // structs may have more fields added in the future.
 pub struct IndividualSpaceAllocation {
     /// The total space allocated to the user's account (bytes).
@@ -1364,7 +1364,7 @@ impl ::serde::ser::Serialize for IndividualSpaceAllocation {
 }
 
 /// Representations for a person's name to assist with internationalization.
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 #[non_exhaustive] // structs may have more fields added in the future.
 pub struct Name {
     /// Also known as a first name.
@@ -1514,7 +1514,7 @@ impl ::serde::ser::Serialize for Name {
 }
 
 /// The value for [`UserFeature::PaperAsFiles`](UserFeature::PaperAsFiles).
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 #[non_exhaustive] // variants may be added in the future
 pub enum PaperAsFilesValue {
     /// When this value is true, the user's Paper docs are accessible in Dropbox with the .paper
@@ -1581,7 +1581,7 @@ impl ::serde::ser::Serialize for PaperAsFilesValue {
 }
 
 /// Space is allocated differently based on the type of account.
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 #[non_exhaustive] // variants may be added in the future
 pub enum SpaceAllocation {
     /// The user's space allocation applies only to their individual account.
@@ -1650,7 +1650,7 @@ impl ::serde::ser::Serialize for SpaceAllocation {
 }
 
 /// Information about a user's space usage and quota.
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 #[non_exhaustive] // structs may have more fields added in the future.
 pub struct SpaceUsage {
     /// The user's total space usage (bytes).
@@ -1754,7 +1754,7 @@ impl ::serde::ser::Serialize for SpaceUsage {
 }
 
 /// Information about a team.
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 #[non_exhaustive] // structs may have more fields added in the future.
 pub struct Team {
     /// The team's unique ID.
@@ -1857,7 +1857,7 @@ impl ::serde::ser::Serialize for Team {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 #[non_exhaustive] // structs may have more fields added in the future.
 pub struct TeamSpaceAllocation {
     /// The total space currently used by the user's team (bytes).
@@ -2007,7 +2007,7 @@ impl ::serde::ser::Serialize for TeamSpaceAllocation {
 }
 
 /// A set of features that a Dropbox User account may have configured.
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 #[non_exhaustive] // variants may be added in the future
 pub enum UserFeature {
     /// This feature contains information about how the user's Paper files are stored.
@@ -2080,7 +2080,7 @@ impl ::serde::ser::Serialize for UserFeature {
 }
 
 /// Values that correspond to entries in [`UserFeature`](UserFeature).
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 #[non_exhaustive] // variants may be added in the future
 pub enum UserFeatureValue {
     PaperAsFiles(PaperAsFilesValue),
@@ -2158,7 +2158,7 @@ impl ::serde::ser::Serialize for UserFeatureValue {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 #[non_exhaustive] // structs may have more fields added in the future.
 pub struct UserFeaturesGetValuesBatchArg {
     /// A list of features in [`UserFeature`](UserFeature). If the list is empty, this route will
@@ -2249,7 +2249,7 @@ impl ::serde::ser::Serialize for UserFeaturesGetValuesBatchArg {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 #[non_exhaustive] // variants may be added in the future
 pub enum UserFeaturesGetValuesBatchError {
     /// At least one [`UserFeature`](UserFeature) must be included in the
@@ -2321,7 +2321,7 @@ impl ::std::fmt::Display for UserFeaturesGetValuesBatchError {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 #[non_exhaustive] // structs may have more fields added in the future.
 pub struct UserFeaturesGetValuesBatchResult {
     pub values: Vec<UserFeatureValue>,

--- a/src/generated/users_common.rs
+++ b/src/generated/users_common.rs
@@ -12,7 +12,7 @@
 pub type AccountId = String;
 
 /// What type of account this user has.
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 pub enum AccountType {
     /// The basic account type.
     Basic,


### PR DESCRIPTION
In addition to `Debug`. These traits are useful in many situations and can safely be implemented for every type in the SDK because they are essentially POD (plain old data) types and we have no private fields or special logic assigned to them.

It would be nice to implement `Eq` and `Hash`, but these can't be derived for types containing `f64`, of which there are a few in the SDK. We could implement them for types not containing these fields, but for the sake of forwards-compatibility, it's better to stick with the minimum set that can be implemented for every type.

<!--
Thank you for your pull request. Please provide a description below.
-->

## **Checklist**

**General Contributing**
<!-- Change [ ] to [x] if you have: -->
- [x] I have read the Code of Conduct and signed the [CLA](https://opensource.dropbox.com/cla/).
- [x] I have added an entry to the `RELEASE_NOTES.md` file, or believe it's not necessary for this change.

**Validation**
<!-- Describe which tests cover the changes you've made, and any additional manual validation you
     did to ensure the correctness of this change. Does this change warrant addition of new tests?
     Does this change have performance implications? Etc. -->
All tests now include an `assert_eq!` check that a `clone()` of the instance matches the original instance, which exercises both `PartialEq` and `Clone` traits.

Tests for serializable types (all types except enums only containing an `Other` variant) now also include an `assert_eq!` statement that checks the re-serialized instance.