### PR TITLE
Several improvements to error types

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,3 +1,11 @@
+# v0.9.1
+xxxx-yy-zz
+* Removed the deprecated `description` function from Error impl for error types.
+* Added a `cause()` method to the Error impl for error types if they have any variants which
+  contain error values.
+* Improved the `Display` impl for Error types by using the documentation strings provided,
+  including recursing into nested errors or values if present.
+
 # v0.9.0
 2020-11-30
 * All structs and enums except ones marked `union_closed` in the spec are now marked with

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,10 +1,14 @@
 # v0.9.1
 xxxx-yy-zz
-* Removed the deprecated `description` function from Error impl for error types.
-* Added a `cause()` method to the Error impl for error types if they have any variants which
-  contain error values.
-* Improved the `Display` impl for Error types by using the documentation strings provided,
-  including recursing into nested errors or values if present.
+* Several improvements to error types:
+  * Removed the deprecated `description` function from `Error` impl for error types.
+  * Added a `cause()` method to the Error impl for error types if they have any variants which
+    contain error values.
+  * Improved the `Display` impl for Error types by using the documentation strings provided,
+    including recursing into nested errors or values if present.
+  * Routes with no error type defined now return a new `NoError` type instead of `()`. This new type
+    implements `Error`, so now all routes' error types are guaranteed to be `Error`, and hence,
+    `Display` as well. (You should never actually see instances of this type.)
 
 # v0.9.0
 2020-11-30

--- a/generator/rust.py
+++ b/generator/rust.py
@@ -102,7 +102,7 @@ class RustHelperBackend(CodeBackend):
             or (isinstance(typ, ir.Struct) \
                 and typ.has_enumerated_subtypes() and not typ.is_catch_all())
 
-    def get_union_variants(self, typ):
+    def get_enum_variants(self, typ):
         if isinstance(typ, ir.Union):
             return typ.all_fields
         elif isinstance(typ, ir.Struct) and typ.has_enumerated_subtypes():

--- a/generator/rust.stoneg.py
+++ b/generator/rust.stoneg.py
@@ -224,6 +224,8 @@ class RustBackend(RustHelperBackend):
 
         arg_void = isinstance(fn.arg_data_type, ir.Void)
         style = fn.attrs.get('style', 'rpc')
+        error_type = u'crate::NoError' if ir.is_void_type(fn.error_data_type) \
+            else self._rust_type(fn.error_data_type)
         if style == 'rpc':
             with self.emit_rust_function_def(
                     route_name,
@@ -232,7 +234,7 @@ class RustBackend(RustHelperBackend):
                             [u'arg: &{}'.format(self._rust_type(fn.arg_data_type))]),
                     u'crate::Result<Result<{}, {}>>'.format(
                         self._rust_type(fn.result_data_type),
-                        self._rust_type(fn.error_data_type)),
+                        error_type),
                     access=u'pub'):
                 self.emit_rust_fn_call(
                     u'crate::client_helpers::request',
@@ -252,7 +254,7 @@ class RustBackend(RustHelperBackend):
                             u'range_end: Option<u64>'],
                     u'crate::Result<Result<crate::client_trait::HttpRequestResult<{}>, {}>>'.format(
                         self._rust_type(fn.result_data_type),
-                        self._rust_type(fn.error_data_type)),
+                        error_type),
                     access=u'pub'):
                 self.emit_rust_fn_call(
                     u'crate::client_helpers::request_with_body',
@@ -273,7 +275,7 @@ class RustBackend(RustHelperBackend):
                         + [u'body: &[u8]'],
                     u'crate::Result<Result<{}, {}>>'.format(
                         self._rust_type(fn.result_data_type),
-                        self._rust_type(fn.error_data_type)),
+                        error_type),
                     access=u'pub'):
                 self.emit_rust_fn_call(
                     u'crate::client_helpers::request',

--- a/generator/test.stoneg.py
+++ b/generator/test.stoneg.py
@@ -162,7 +162,7 @@ class TestBackend(RustHelperBackend):
             self.emit(u'match x {')
             with self.indent():
                 var_exps = []
-                for variant in self.get_union_variants(typ):
+                for variant in self.get_enum_variants(typ):
                     v_name = self.enum_variant_name(variant)
                     var_exp = u'::dropbox_sdk::{}::{}::{}'.format(
                         ns_name, type_name, v_name)

--- a/src/generated/account.rs
+++ b/src/generated/account.rs
@@ -286,9 +286,6 @@ impl ::serde::ser::Serialize for SetProfilePhotoError {
 }
 
 impl ::std::error::Error for SetProfilePhotoError {
-    fn description(&self) -> &str {
-        "SetProfilePhotoError"
-    }
 }
 
 impl ::std::fmt::Display for SetProfilePhotoError {

--- a/src/generated/account.rs
+++ b/src/generated/account.rs
@@ -290,7 +290,14 @@ impl ::std::error::Error for SetProfilePhotoError {
 
 impl ::std::fmt::Display for SetProfilePhotoError {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
-        write!(f, "{:?}", *self)
+        match self {
+            SetProfilePhotoError::FileTypeError => f.write_str("File cannot be set as profile photo."),
+            SetProfilePhotoError::FileSizeError => f.write_str("File cannot exceed 10 MB."),
+            SetProfilePhotoError::DimensionError => f.write_str("Image must be larger than 128 x 128."),
+            SetProfilePhotoError::ThumbnailError => f.write_str("Image could not be thumbnailed."),
+            SetProfilePhotoError::TransientError => f.write_str("Temporary infrastructure failure, please retry."),
+            _ => write!(f, "{:?}", *self),
+        }
     }
 }
 

--- a/src/generated/auth.rs
+++ b/src/generated/auth.rs
@@ -116,8 +116,12 @@ impl ::serde::ser::Serialize for AccessError {
 }
 
 impl ::std::error::Error for AccessError {
-    fn description(&self) -> &str {
-        "AccessError"
+    fn source(&self) -> Option<&(dyn ::std::error::Error + 'static)> {
+        match self {
+            AccessError::InvalidAccountType(inner) => Some(inner),
+            AccessError::PaperAccessDenied(inner) => Some(inner),
+            _ => None,
+        }
     }
 }
 
@@ -264,9 +268,6 @@ impl ::serde::ser::Serialize for AuthError {
 }
 
 impl ::std::error::Error for AuthError {
-    fn description(&self) -> &str {
-        "AuthError"
-    }
 }
 
 impl ::std::fmt::Display for AuthError {
@@ -348,9 +349,6 @@ impl ::serde::ser::Serialize for InvalidAccountTypeError {
 }
 
 impl ::std::error::Error for InvalidAccountTypeError {
-    fn description(&self) -> &str {
-        "InvalidAccountTypeError"
-    }
 }
 
 impl ::std::fmt::Display for InvalidAccountTypeError {
@@ -432,9 +430,6 @@ impl ::serde::ser::Serialize for PaperAccessError {
 }
 
 impl ::std::error::Error for PaperAccessError {
-    fn description(&self) -> &str {
-        "PaperAccessError"
-    }
 }
 
 impl ::std::fmt::Display for PaperAccessError {
@@ -800,9 +795,6 @@ impl ::serde::ser::Serialize for TokenFromOAuth1Error {
 }
 
 impl ::std::error::Error for TokenFromOAuth1Error {
-    fn description(&self) -> &str {
-        "TokenFromOAuth1Error"
-    }
 }
 
 impl ::std::fmt::Display for TokenFromOAuth1Error {

--- a/src/generated/auth.rs
+++ b/src/generated/auth.rs
@@ -24,7 +24,7 @@ pub fn token_from_oauth1(
 /// Disables the access token used to authenticate the call.
 pub fn token_revoke(
     client: &impl crate::client_trait::UserAuthClient,
-) -> crate::Result<Result<(), ()>> {
+) -> crate::Result<Result<(), crate::NoError>> {
     crate::client_helpers::request(
         client,
         crate::client_trait::Endpoint::Api,

--- a/src/generated/auth.rs
+++ b/src/generated/auth.rs
@@ -127,7 +127,11 @@ impl ::std::error::Error for AccessError {
 
 impl ::std::fmt::Display for AccessError {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
-        write!(f, "{:?}", *self)
+        match self {
+            AccessError::InvalidAccountType(inner) => write!(f, "Current account type cannot access the resource: {}", inner),
+            AccessError::PaperAccessDenied(inner) => write!(f, "Current account cannot access Paper: {}", inner),
+            _ => write!(f, "{:?}", *self),
+        }
     }
 }
 
@@ -272,7 +276,16 @@ impl ::std::error::Error for AuthError {
 
 impl ::std::fmt::Display for AuthError {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
-        write!(f, "{:?}", *self)
+        match self {
+            AuthError::InvalidAccessToken => f.write_str("The access token is invalid."),
+            AuthError::InvalidSelectUser => f.write_str("The user specified in 'Dropbox-API-Select-User' is no longer on the team."),
+            AuthError::InvalidSelectAdmin => f.write_str("The user specified in 'Dropbox-API-Select-Admin' is not a Dropbox Business team admin."),
+            AuthError::UserSuspended => f.write_str("The user has been suspended."),
+            AuthError::ExpiredAccessToken => f.write_str("The access token has expired."),
+            AuthError::MissingScope(inner) => write!(f, "The access token does not have the required scope to access the route: {:?}", inner),
+            AuthError::RouteAccessDenied => f.write_str("The route is not available to public."),
+            _ => write!(f, "{:?}", *self),
+        }
     }
 }
 
@@ -353,7 +366,11 @@ impl ::std::error::Error for InvalidAccountTypeError {
 
 impl ::std::fmt::Display for InvalidAccountTypeError {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
-        write!(f, "{:?}", *self)
+        match self {
+            InvalidAccountTypeError::Endpoint => f.write_str("Current account type doesn't have permission to access this route endpoint."),
+            InvalidAccountTypeError::Feature => f.write_str("Current account type doesn't have permission to access this feature."),
+            _ => write!(f, "{:?}", *self),
+        }
     }
 }
 
@@ -434,7 +451,11 @@ impl ::std::error::Error for PaperAccessError {
 
 impl ::std::fmt::Display for PaperAccessError {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
-        write!(f, "{:?}", *self)
+        match self {
+            PaperAccessError::PaperDisabled => f.write_str("Paper is disabled."),
+            PaperAccessError::NotPaperUser => f.write_str("The provided user has not used Paper yet."),
+            _ => write!(f, "{:?}", *self),
+        }
     }
 }
 
@@ -799,7 +820,11 @@ impl ::std::error::Error for TokenFromOAuth1Error {
 
 impl ::std::fmt::Display for TokenFromOAuth1Error {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
-        write!(f, "{:?}", *self)
+        match self {
+            TokenFromOAuth1Error::InvalidOauth1TokenInfo => f.write_str("Part or all of the OAuth 1.0 access token info is invalid."),
+            TokenFromOAuth1Error::AppIdMismatch => f.write_str("The authorized app does not match the app associated with the supplied access token."),
+            _ => write!(f, "{:?}", *self),
+        }
     }
 }
 

--- a/src/generated/check.rs
+++ b/src/generated/check.rs
@@ -15,7 +15,7 @@
 pub fn app(
     client: &impl crate::client_trait::AppAuthClient,
     arg: &EchoArg,
-) -> crate::Result<Result<EchoResult, ()>> {
+) -> crate::Result<Result<EchoResult, crate::NoError>> {
     crate::client_helpers::request(
         client,
         crate::client_trait::Endpoint::Api,
@@ -32,7 +32,7 @@ pub fn app(
 pub fn user(
     client: &impl crate::client_trait::UserAuthClient,
     arg: &EchoArg,
-) -> crate::Result<Result<EchoResult, ()>> {
+) -> crate::Result<Result<EchoResult, crate::NoError>> {
     crate::client_helpers::request(
         client,
         crate::client_trait::Endpoint::Api,

--- a/src/generated/common.rs
+++ b/src/generated/common.rs
@@ -199,7 +199,11 @@ impl ::std::error::Error for PathRootError {
 
 impl ::std::fmt::Display for PathRootError {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
-        write!(f, "{:?}", *self)
+        match self {
+            PathRootError::InvalidRoot(inner) => write!(f, "The root namespace id in Dropbox-API-Path-Root header is not valid. The value of this error is use's latest root info: {:?}", inner),
+            PathRootError::NoPermission => f.write_str("You don't have permission to access the namespace id in Dropbox-API-Path-Root  header."),
+            _ => write!(f, "{:?}", *self),
+        }
     }
 }
 

--- a/src/generated/common.rs
+++ b/src/generated/common.rs
@@ -195,9 +195,6 @@ impl ::serde::ser::Serialize for PathRootError {
 }
 
 impl ::std::error::Error for PathRootError {
-    fn description(&self) -> &str {
-        "PathRootError"
-    }
 }
 
 impl ::std::fmt::Display for PathRootError {

--- a/src/generated/contacts.rs
+++ b/src/generated/contacts.rs
@@ -11,7 +11,7 @@
 /// imported. New contacts will be added when you share.
 pub fn delete_manual_contacts(
     client: &impl crate::client_trait::UserAuthClient,
-) -> crate::Result<Result<(), ()>> {
+) -> crate::Result<Result<(), crate::NoError>> {
     crate::client_helpers::request(
         client,
         crate::client_trait::Endpoint::Api,

--- a/src/generated/contacts.rs
+++ b/src/generated/contacts.rs
@@ -190,9 +190,6 @@ impl ::serde::ser::Serialize for DeleteManualContactsError {
 }
 
 impl ::std::error::Error for DeleteManualContactsError {
-    fn description(&self) -> &str {
-        "DeleteManualContactsError"
-    }
 }
 
 impl ::std::fmt::Display for DeleteManualContactsError {

--- a/src/generated/contacts.rs
+++ b/src/generated/contacts.rs
@@ -194,7 +194,10 @@ impl ::std::error::Error for DeleteManualContactsError {
 
 impl ::std::fmt::Display for DeleteManualContactsError {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
-        write!(f, "{:?}", *self)
+        match self {
+            DeleteManualContactsError::ContactsNotFound(inner) => write!(f, "Can't delete contacts from this list. Make sure the list only has manually added contacts. The deletion was cancelled: {:?}", inner),
+            _ => write!(f, "{:?}", *self),
+        }
     }
 }
 

--- a/src/generated/dbx_async.rs
+++ b/src/generated/dbx_async.rs
@@ -370,9 +370,6 @@ impl ::serde::ser::Serialize for PollError {
 }
 
 impl ::std::error::Error for PollError {
-    fn description(&self) -> &str {
-        "PollError"
-    }
 }
 
 impl ::std::fmt::Display for PollError {

--- a/src/generated/dbx_async.rs
+++ b/src/generated/dbx_async.rs
@@ -374,7 +374,11 @@ impl ::std::error::Error for PollError {
 
 impl ::std::fmt::Display for PollError {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
-        write!(f, "{:?}", *self)
+        match self {
+            PollError::InvalidAsyncJobId => f.write_str("The job ID is invalid."),
+            PollError::InternalError => f.write_str("Something went wrong with the job on Dropbox's end. You'll need to verify that the action you were taking succeeded, and if not, try again. This should happen very rarely."),
+            _ => write!(f, "{:?}", *self),
+        }
     }
 }
 

--- a/src/generated/file_properties.rs
+++ b/src/generated/file_properties.rs
@@ -570,6 +570,7 @@ impl ::std::fmt::Display for AddPropertiesError {
         match self {
             AddPropertiesError::TemplateNotFound(inner) => write!(f, "Template does not exist for the given identifier: {:?}", inner),
             AddPropertiesError::RestrictedContent => f.write_str("You do not have permission to modify this template."),
+            AddPropertiesError::Path(inner) => write!(f, "{}", inner),
             AddPropertiesError::UnsupportedFolder => f.write_str("This folder cannot be tagged. Tagging folders is not supported for team-owned templates."),
             AddPropertiesError::PropertyFieldTooLarge => f.write_str("One or more of the supplied property field values is too large."),
             AddPropertiesError::DoesNotFitTemplate => f.write_str("One or more of the supplied property fields does not conform to the template specifications."),
@@ -1156,6 +1157,7 @@ impl ::std::fmt::Display for InvalidPropertyGroupError {
         match self {
             InvalidPropertyGroupError::TemplateNotFound(inner) => write!(f, "Template does not exist for the given identifier: {:?}", inner),
             InvalidPropertyGroupError::RestrictedContent => f.write_str("You do not have permission to modify this template."),
+            InvalidPropertyGroupError::Path(inner) => write!(f, "{}", inner),
             InvalidPropertyGroupError::UnsupportedFolder => f.write_str("This folder cannot be tagged. Tagging folders is not supported for team-owned templates."),
             InvalidPropertyGroupError::PropertyFieldTooLarge => f.write_str("One or more of the supplied property field values is too large."),
             InvalidPropertyGroupError::DoesNotFitTemplate => f.write_str("One or more of the supplied property fields does not conform to the template specifications."),
@@ -1509,6 +1511,7 @@ impl ::std::error::Error for LookupError {
 impl ::std::fmt::Display for LookupError {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match self {
+            LookupError::MalformedPath(inner) => write!(f, "{:?}", inner),
             LookupError::NotFound => f.write_str("There is nothing at the given path."),
             LookupError::NotFile => f.write_str("We were expecting a file, but the given path refers to something that isn't a file."),
             LookupError::NotFolder => f.write_str("We were expecting a folder, but the given path refers to something that isn't a folder."),
@@ -1887,6 +1890,7 @@ impl ::std::fmt::Display for PropertiesError {
         match self {
             PropertiesError::TemplateNotFound(inner) => write!(f, "Template does not exist for the given identifier: {:?}", inner),
             PropertiesError::RestrictedContent => f.write_str("You do not have permission to modify this template."),
+            PropertiesError::Path(inner) => write!(f, "{}", inner),
             PropertiesError::UnsupportedFolder => f.write_str("This folder cannot be tagged. Tagging folders is not supported for team-owned templates."),
             _ => write!(f, "{:?}", *self),
         }
@@ -2234,7 +2238,10 @@ impl ::std::error::Error for PropertiesSearchError {
 
 impl ::std::fmt::Display for PropertiesSearchError {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
-        write!(f, "{:?}", *self)
+        match self {
+            PropertiesSearchError::PropertyGroupLookup(inner) => write!(f, "{}", inner),
+            _ => write!(f, "{:?}", *self),
+        }
     }
 }
 
@@ -3544,7 +3551,9 @@ impl ::std::fmt::Display for RemovePropertiesError {
         match self {
             RemovePropertiesError::TemplateNotFound(inner) => write!(f, "Template does not exist for the given identifier: {:?}", inner),
             RemovePropertiesError::RestrictedContent => f.write_str("You do not have permission to modify this template."),
+            RemovePropertiesError::Path(inner) => write!(f, "{}", inner),
             RemovePropertiesError::UnsupportedFolder => f.write_str("This folder cannot be tagged. Tagging folders is not supported for team-owned templates."),
+            RemovePropertiesError::PropertyGroupLookup(inner) => write!(f, "{}", inner),
             _ => write!(f, "{:?}", *self),
         }
     }
@@ -4221,10 +4230,12 @@ impl ::std::fmt::Display for UpdatePropertiesError {
         match self {
             UpdatePropertiesError::TemplateNotFound(inner) => write!(f, "Template does not exist for the given identifier: {:?}", inner),
             UpdatePropertiesError::RestrictedContent => f.write_str("You do not have permission to modify this template."),
+            UpdatePropertiesError::Path(inner) => write!(f, "{}", inner),
             UpdatePropertiesError::UnsupportedFolder => f.write_str("This folder cannot be tagged. Tagging folders is not supported for team-owned templates."),
             UpdatePropertiesError::PropertyFieldTooLarge => f.write_str("One or more of the supplied property field values is too large."),
             UpdatePropertiesError::DoesNotFitTemplate => f.write_str("One or more of the supplied property fields does not conform to the template specifications."),
             UpdatePropertiesError::DuplicatePropertyGroups => f.write_str("There are 2 or more property groups referring to the same templates in the input."),
+            UpdatePropertiesError::PropertyGroupLookup(inner) => write!(f, "{}", inner),
             _ => write!(f, "{:?}", *self),
         }
     }

--- a/src/generated/file_properties.rs
+++ b/src/generated/file_properties.rs
@@ -1511,7 +1511,7 @@ impl ::std::error::Error for LookupError {
 impl ::std::fmt::Display for LookupError {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match self {
-            LookupError::MalformedPath(inner) => write!(f, "{:?}", inner),
+            LookupError::MalformedPath(inner) => write!(f, "malformed_path: {:?}", inner),
             LookupError::NotFound => f.write_str("There is nothing at the given path."),
             LookupError::NotFile => f.write_str("We were expecting a file, but the given path refers to something that isn't a file."),
             LookupError::NotFolder => f.write_str("We were expecting a folder, but the given path refers to something that isn't a folder."),

--- a/src/generated/file_properties.rs
+++ b/src/generated/file_properties.rs
@@ -557,8 +557,11 @@ impl ::serde::ser::Serialize for AddPropertiesError {
 }
 
 impl ::std::error::Error for AddPropertiesError {
-    fn description(&self) -> &str {
-        "AddPropertiesError"
+    fn source(&self) -> Option<&(dyn ::std::error::Error + 'static)> {
+        match self {
+            AddPropertiesError::Path(inner) => Some(inner),
+            _ => None,
+        }
     }
 }
 
@@ -1131,8 +1134,11 @@ impl ::serde::ser::Serialize for InvalidPropertyGroupError {
 }
 
 impl ::std::error::Error for InvalidPropertyGroupError {
-    fn description(&self) -> &str {
-        "InvalidPropertyGroupError"
+    fn source(&self) -> Option<&(dyn ::std::error::Error + 'static)> {
+        match self {
+            InvalidPropertyGroupError::Path(inner) => Some(inner),
+            _ => None,
+        }
     }
 }
 
@@ -1354,9 +1360,6 @@ impl ::serde::ser::Serialize for LookUpPropertiesError {
 }
 
 impl ::std::error::Error for LookUpPropertiesError {
-    fn description(&self) -> &str {
-        "LookUpPropertiesError"
-    }
 }
 
 impl ::std::fmt::Display for LookUpPropertiesError {
@@ -1481,9 +1484,6 @@ impl ::serde::ser::Serialize for LookupError {
 }
 
 impl ::std::error::Error for LookupError {
-    fn description(&self) -> &str {
-        "LookupError"
-    }
 }
 
 impl ::std::fmt::Display for LookupError {
@@ -1622,9 +1622,6 @@ impl ::serde::ser::Serialize for ModifyTemplateError {
 }
 
 impl ::std::error::Error for ModifyTemplateError {
-    fn description(&self) -> &str {
-        "ModifyTemplateError"
-    }
 }
 
 impl ::std::fmt::Display for ModifyTemplateError {
@@ -1843,8 +1840,11 @@ impl ::serde::ser::Serialize for PropertiesError {
 }
 
 impl ::std::error::Error for PropertiesError {
-    fn description(&self) -> &str {
-        "PropertiesError"
+    fn source(&self) -> Option<&(dyn ::std::error::Error + 'static)> {
+        match self {
+            PropertiesError::Path(inner) => Some(inner),
+            _ => None,
+        }
     }
 }
 
@@ -2114,9 +2114,6 @@ impl ::serde::ser::Serialize for PropertiesSearchContinueError {
 }
 
 impl ::std::error::Error for PropertiesSearchContinueError {
-    fn description(&self) -> &str {
-        "PropertiesSearchContinueError"
-    }
 }
 
 impl ::std::fmt::Display for PropertiesSearchContinueError {
@@ -2188,8 +2185,11 @@ impl ::serde::ser::Serialize for PropertiesSearchError {
 }
 
 impl ::std::error::Error for PropertiesSearchError {
-    fn description(&self) -> &str {
-        "PropertiesSearchError"
+    fn source(&self) -> Option<&(dyn ::std::error::Error + 'static)> {
+        match self {
+            PropertiesSearchError::PropertyGroupLookup(inner) => Some(inner),
+            _ => None,
+        }
     }
 }
 
@@ -3491,8 +3491,12 @@ impl ::serde::ser::Serialize for RemovePropertiesError {
 }
 
 impl ::std::error::Error for RemovePropertiesError {
-    fn description(&self) -> &str {
-        "RemovePropertiesError"
+    fn source(&self) -> Option<&(dyn ::std::error::Error + 'static)> {
+        match self {
+            RemovePropertiesError::Path(inner) => Some(inner),
+            RemovePropertiesError::PropertyGroupLookup(inner) => Some(inner),
+            _ => None,
+        }
     }
 }
 
@@ -3670,9 +3674,6 @@ impl ::serde::ser::Serialize for TemplateError {
 }
 
 impl ::std::error::Error for TemplateError {
-    fn description(&self) -> &str {
-        "TemplateError"
-    }
 }
 
 impl ::std::fmt::Display for TemplateError {
@@ -4158,8 +4159,12 @@ impl ::serde::ser::Serialize for UpdatePropertiesError {
 }
 
 impl ::std::error::Error for UpdatePropertiesError {
-    fn description(&self) -> &str {
-        "UpdatePropertiesError"
+    fn source(&self) -> Option<&(dyn ::std::error::Error + 'static)> {
+        match self {
+            UpdatePropertiesError::Path(inner) => Some(inner),
+            UpdatePropertiesError::PropertyGroupLookup(inner) => Some(inner),
+            _ => None,
+        }
     }
 }
 

--- a/src/generated/file_properties.rs
+++ b/src/generated/file_properties.rs
@@ -567,7 +567,16 @@ impl ::std::error::Error for AddPropertiesError {
 
 impl ::std::fmt::Display for AddPropertiesError {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
-        write!(f, "{:?}", *self)
+        match self {
+            AddPropertiesError::TemplateNotFound(inner) => write!(f, "Template does not exist for the given identifier: {:?}", inner),
+            AddPropertiesError::RestrictedContent => f.write_str("You do not have permission to modify this template."),
+            AddPropertiesError::UnsupportedFolder => f.write_str("This folder cannot be tagged. Tagging folders is not supported for team-owned templates."),
+            AddPropertiesError::PropertyFieldTooLarge => f.write_str("One or more of the supplied property field values is too large."),
+            AddPropertiesError::DoesNotFitTemplate => f.write_str("One or more of the supplied property fields does not conform to the template specifications."),
+            AddPropertiesError::DuplicatePropertyGroups => f.write_str("There are 2 or more property groups referring to the same templates in the input."),
+            AddPropertiesError::PropertyGroupAlreadyExists => f.write_str("A property group associated with this template and file already exists."),
+            _ => write!(f, "{:?}", *self),
+        }
     }
 }
 
@@ -1144,7 +1153,15 @@ impl ::std::error::Error for InvalidPropertyGroupError {
 
 impl ::std::fmt::Display for InvalidPropertyGroupError {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
-        write!(f, "{:?}", *self)
+        match self {
+            InvalidPropertyGroupError::TemplateNotFound(inner) => write!(f, "Template does not exist for the given identifier: {:?}", inner),
+            InvalidPropertyGroupError::RestrictedContent => f.write_str("You do not have permission to modify this template."),
+            InvalidPropertyGroupError::UnsupportedFolder => f.write_str("This folder cannot be tagged. Tagging folders is not supported for team-owned templates."),
+            InvalidPropertyGroupError::PropertyFieldTooLarge => f.write_str("One or more of the supplied property field values is too large."),
+            InvalidPropertyGroupError::DoesNotFitTemplate => f.write_str("One or more of the supplied property fields does not conform to the template specifications."),
+            InvalidPropertyGroupError::DuplicatePropertyGroups => f.write_str("There are 2 or more property groups referring to the same templates in the input."),
+            _ => write!(f, "{:?}", *self),
+        }
     }
 }
 
@@ -1364,7 +1381,10 @@ impl ::std::error::Error for LookUpPropertiesError {
 
 impl ::std::fmt::Display for LookUpPropertiesError {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
-        write!(f, "{:?}", *self)
+        match self {
+            LookUpPropertiesError::PropertyGroupNotFound => f.write_str("No property group was found."),
+            _ => write!(f, "{:?}", *self),
+        }
     }
 }
 
@@ -1488,7 +1508,13 @@ impl ::std::error::Error for LookupError {
 
 impl ::std::fmt::Display for LookupError {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
-        write!(f, "{:?}", *self)
+        match self {
+            LookupError::NotFound => f.write_str("There is nothing at the given path."),
+            LookupError::NotFile => f.write_str("We were expecting a file, but the given path refers to something that isn't a file."),
+            LookupError::NotFolder => f.write_str("We were expecting a folder, but the given path refers to something that isn't a folder."),
+            LookupError::RestrictedContent => f.write_str("The file cannot be transferred because the content is restricted.  For example, sometimes there are legal restrictions due to copyright claims."),
+            _ => write!(f, "{:?}", *self),
+        }
     }
 }
 
@@ -1626,7 +1652,15 @@ impl ::std::error::Error for ModifyTemplateError {
 
 impl ::std::fmt::Display for ModifyTemplateError {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
-        write!(f, "{:?}", *self)
+        match self {
+            ModifyTemplateError::TemplateNotFound(inner) => write!(f, "Template does not exist for the given identifier: {:?}", inner),
+            ModifyTemplateError::RestrictedContent => f.write_str("You do not have permission to modify this template."),
+            ModifyTemplateError::ConflictingPropertyNames => f.write_str("A property field key with that name already exists in the template."),
+            ModifyTemplateError::TooManyProperties => f.write_str("There are too many properties in the changed template. The maximum number of properties per template is 32."),
+            ModifyTemplateError::TooManyTemplates => f.write_str("There are too many templates for the team."),
+            ModifyTemplateError::TemplateAttributeTooLarge => f.write_str("The template name, description or one or more of the property field keys is too large."),
+            _ => write!(f, "{:?}", *self),
+        }
     }
 }
 
@@ -1850,7 +1884,12 @@ impl ::std::error::Error for PropertiesError {
 
 impl ::std::fmt::Display for PropertiesError {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
-        write!(f, "{:?}", *self)
+        match self {
+            PropertiesError::TemplateNotFound(inner) => write!(f, "Template does not exist for the given identifier: {:?}", inner),
+            PropertiesError::RestrictedContent => f.write_str("You do not have permission to modify this template."),
+            PropertiesError::UnsupportedFolder => f.write_str("This folder cannot be tagged. Tagging folders is not supported for team-owned templates."),
+            _ => write!(f, "{:?}", *self),
+        }
     }
 }
 
@@ -3502,7 +3541,12 @@ impl ::std::error::Error for RemovePropertiesError {
 
 impl ::std::fmt::Display for RemovePropertiesError {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
-        write!(f, "{:?}", *self)
+        match self {
+            RemovePropertiesError::TemplateNotFound(inner) => write!(f, "Template does not exist for the given identifier: {:?}", inner),
+            RemovePropertiesError::RestrictedContent => f.write_str("You do not have permission to modify this template."),
+            RemovePropertiesError::UnsupportedFolder => f.write_str("This folder cannot be tagged. Tagging folders is not supported for team-owned templates."),
+            _ => write!(f, "{:?}", *self),
+        }
     }
 }
 
@@ -3678,7 +3722,11 @@ impl ::std::error::Error for TemplateError {
 
 impl ::std::fmt::Display for TemplateError {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
-        write!(f, "{:?}", *self)
+        match self {
+            TemplateError::TemplateNotFound(inner) => write!(f, "Template does not exist for the given identifier: {:?}", inner),
+            TemplateError::RestrictedContent => f.write_str("You do not have permission to modify this template."),
+            _ => write!(f, "{:?}", *self),
+        }
     }
 }
 
@@ -4170,7 +4218,15 @@ impl ::std::error::Error for UpdatePropertiesError {
 
 impl ::std::fmt::Display for UpdatePropertiesError {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
-        write!(f, "{:?}", *self)
+        match self {
+            UpdatePropertiesError::TemplateNotFound(inner) => write!(f, "Template does not exist for the given identifier: {:?}", inner),
+            UpdatePropertiesError::RestrictedContent => f.write_str("You do not have permission to modify this template."),
+            UpdatePropertiesError::UnsupportedFolder => f.write_str("This folder cannot be tagged. Tagging folders is not supported for team-owned templates."),
+            UpdatePropertiesError::PropertyFieldTooLarge => f.write_str("One or more of the supplied property field values is too large."),
+            UpdatePropertiesError::DoesNotFitTemplate => f.write_str("One or more of the supplied property fields does not conform to the template specifications."),
+            UpdatePropertiesError::DuplicatePropertyGroups => f.write_str("There are 2 or more property groups referring to the same templates in the input."),
+            _ => write!(f, "{:?}", *self),
+        }
     }
 }
 

--- a/src/generated/file_requests.rs
+++ b/src/generated/file_requests.rs
@@ -205,7 +205,10 @@ impl ::std::error::Error for CountFileRequestsError {
 
 impl ::std::fmt::Display for CountFileRequestsError {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
-        write!(f, "{:?}", *self)
+        match self {
+            CountFileRequestsError::DisabledForTeam => f.write_str("This user's Dropbox Business team doesn't allow file requests."),
+            _ => write!(f, "{:?}", *self),
+        }
     }
 }
 
@@ -635,7 +638,17 @@ impl ::std::error::Error for CreateFileRequestError {
 
 impl ::std::fmt::Display for CreateFileRequestError {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
-        write!(f, "{:?}", *self)
+        match self {
+            CreateFileRequestError::DisabledForTeam => f.write_str("This user's Dropbox Business team doesn't allow file requests."),
+            CreateFileRequestError::NotFound => f.write_str("This file request ID was not found."),
+            CreateFileRequestError::NotAFolder => f.write_str("The specified path is not a folder."),
+            CreateFileRequestError::AppLacksAccess => f.write_str("This file request is not accessible to this app. Apps with the app folder permission can only access file requests in their app folder."),
+            CreateFileRequestError::NoPermission => f.write_str("This user doesn't have permission to access or modify this file request."),
+            CreateFileRequestError::ValidationError => f.write_str("There was an error validating the request. For example, the title was invalid, or there were disallowed characters in the destination path."),
+            CreateFileRequestError::InvalidLocation => f.write_str("File requests are not available on the specified folder."),
+            CreateFileRequestError::RateLimit => f.write_str("The user has reached the rate limit for creating file requests. The limit is currently 4000 file requests total."),
+            _ => write!(f, "{:?}", *self),
+        }
     }
 }
 
@@ -786,7 +799,15 @@ impl ::std::error::Error for DeleteAllClosedFileRequestsError {
 
 impl ::std::fmt::Display for DeleteAllClosedFileRequestsError {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
-        write!(f, "{:?}", *self)
+        match self {
+            DeleteAllClosedFileRequestsError::DisabledForTeam => f.write_str("This user's Dropbox Business team doesn't allow file requests."),
+            DeleteAllClosedFileRequestsError::NotFound => f.write_str("This file request ID was not found."),
+            DeleteAllClosedFileRequestsError::NotAFolder => f.write_str("The specified path is not a folder."),
+            DeleteAllClosedFileRequestsError::AppLacksAccess => f.write_str("This file request is not accessible to this app. Apps with the app folder permission can only access file requests in their app folder."),
+            DeleteAllClosedFileRequestsError::NoPermission => f.write_str("This user doesn't have permission to access or modify this file request."),
+            DeleteAllClosedFileRequestsError::ValidationError => f.write_str("There was an error validating the request. For example, the title was invalid, or there were disallowed characters in the destination path."),
+            _ => write!(f, "{:?}", *self),
+        }
     }
 }
 
@@ -1132,7 +1153,16 @@ impl ::std::error::Error for DeleteFileRequestError {
 
 impl ::std::fmt::Display for DeleteFileRequestError {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
-        write!(f, "{:?}", *self)
+        match self {
+            DeleteFileRequestError::DisabledForTeam => f.write_str("This user's Dropbox Business team doesn't allow file requests."),
+            DeleteFileRequestError::NotFound => f.write_str("This file request ID was not found."),
+            DeleteFileRequestError::NotAFolder => f.write_str("The specified path is not a folder."),
+            DeleteFileRequestError::AppLacksAccess => f.write_str("This file request is not accessible to this app. Apps with the app folder permission can only access file requests in their app folder."),
+            DeleteFileRequestError::NoPermission => f.write_str("This user doesn't have permission to access or modify this file request."),
+            DeleteFileRequestError::ValidationError => f.write_str("There was an error validating the request. For example, the title was invalid, or there were disallowed characters in the destination path."),
+            DeleteFileRequestError::FileRequestOpen => f.write_str("One or more file requests currently open."),
+            _ => write!(f, "{:?}", *self),
+        }
     }
 }
 
@@ -1704,7 +1734,15 @@ impl ::std::error::Error for FileRequestError {
 
 impl ::std::fmt::Display for FileRequestError {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
-        write!(f, "{:?}", *self)
+        match self {
+            FileRequestError::DisabledForTeam => f.write_str("This user's Dropbox Business team doesn't allow file requests."),
+            FileRequestError::NotFound => f.write_str("This file request ID was not found."),
+            FileRequestError::NotAFolder => f.write_str("The specified path is not a folder."),
+            FileRequestError::AppLacksAccess => f.write_str("This file request is not accessible to this app. Apps with the app folder permission can only access file requests in their app folder."),
+            FileRequestError::NoPermission => f.write_str("This user doesn't have permission to access or modify this file request."),
+            FileRequestError::ValidationError => f.write_str("There was an error validating the request. For example, the title was invalid, or there were disallowed characters in the destination path."),
+            _ => write!(f, "{:?}", *self),
+        }
     }
 }
 
@@ -1773,7 +1811,10 @@ impl ::std::error::Error for GeneralFileRequestsError {
 
 impl ::std::fmt::Display for GeneralFileRequestsError {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
-        write!(f, "{:?}", *self)
+        match self {
+            GeneralFileRequestsError::DisabledForTeam => f.write_str("This user's Dropbox Business team doesn't allow file requests."),
+            _ => write!(f, "{:?}", *self),
+        }
     }
 }
 
@@ -2015,7 +2056,15 @@ impl ::std::error::Error for GetFileRequestError {
 
 impl ::std::fmt::Display for GetFileRequestError {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
-        write!(f, "{:?}", *self)
+        match self {
+            GetFileRequestError::DisabledForTeam => f.write_str("This user's Dropbox Business team doesn't allow file requests."),
+            GetFileRequestError::NotFound => f.write_str("This file request ID was not found."),
+            GetFileRequestError::NotAFolder => f.write_str("The specified path is not a folder."),
+            GetFileRequestError::AppLacksAccess => f.write_str("This file request is not accessible to this app. Apps with the app folder permission can only access file requests in their app folder."),
+            GetFileRequestError::NoPermission => f.write_str("This user doesn't have permission to access or modify this file request."),
+            GetFileRequestError::ValidationError => f.write_str("There was an error validating the request. For example, the title was invalid, or there were disallowed characters in the destination path."),
+            _ => write!(f, "{:?}", *self),
+        }
     }
 }
 
@@ -2380,7 +2429,11 @@ impl ::std::error::Error for ListFileRequestsContinueError {
 
 impl ::std::fmt::Display for ListFileRequestsContinueError {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
-        write!(f, "{:?}", *self)
+        match self {
+            ListFileRequestsContinueError::DisabledForTeam => f.write_str("This user's Dropbox Business team doesn't allow file requests."),
+            ListFileRequestsContinueError::InvalidCursor => f.write_str("The cursor is invalid."),
+            _ => write!(f, "{:?}", *self),
+        }
     }
 }
 
@@ -2449,7 +2502,10 @@ impl ::std::error::Error for ListFileRequestsError {
 
 impl ::std::fmt::Display for ListFileRequestsError {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
-        write!(f, "{:?}", *self)
+        match self {
+            ListFileRequestsError::DisabledForTeam => f.write_str("This user's Dropbox Business team doesn't allow file requests."),
+            _ => write!(f, "{:?}", *self),
+        }
     }
 }
 
@@ -3067,7 +3123,15 @@ impl ::std::error::Error for UpdateFileRequestError {
 
 impl ::std::fmt::Display for UpdateFileRequestError {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
-        write!(f, "{:?}", *self)
+        match self {
+            UpdateFileRequestError::DisabledForTeam => f.write_str("This user's Dropbox Business team doesn't allow file requests."),
+            UpdateFileRequestError::NotFound => f.write_str("This file request ID was not found."),
+            UpdateFileRequestError::NotAFolder => f.write_str("The specified path is not a folder."),
+            UpdateFileRequestError::AppLacksAccess => f.write_str("This file request is not accessible to this app. Apps with the app folder permission can only access file requests in their app folder."),
+            UpdateFileRequestError::NoPermission => f.write_str("This user doesn't have permission to access or modify this file request."),
+            UpdateFileRequestError::ValidationError => f.write_str("There was an error validating the request. For example, the title was invalid, or there were disallowed characters in the destination path."),
+            _ => write!(f, "{:?}", *self),
+        }
     }
 }
 

--- a/src/generated/file_requests.rs
+++ b/src/generated/file_requests.rs
@@ -201,9 +201,6 @@ impl ::serde::ser::Serialize for CountFileRequestsError {
 }
 
 impl ::std::error::Error for CountFileRequestsError {
-    fn description(&self) -> &str {
-        "CountFileRequestsError"
-    }
 }
 
 impl ::std::fmt::Display for CountFileRequestsError {
@@ -634,9 +631,6 @@ impl ::serde::ser::Serialize for CreateFileRequestError {
 }
 
 impl ::std::error::Error for CreateFileRequestError {
-    fn description(&self) -> &str {
-        "CreateFileRequestError"
-    }
 }
 
 impl ::std::fmt::Display for CreateFileRequestError {
@@ -788,9 +782,6 @@ impl ::serde::ser::Serialize for DeleteAllClosedFileRequestsError {
 }
 
 impl ::std::error::Error for DeleteAllClosedFileRequestsError {
-    fn description(&self) -> &str {
-        "DeleteAllClosedFileRequestsError"
-    }
 }
 
 impl ::std::fmt::Display for DeleteAllClosedFileRequestsError {
@@ -1137,9 +1128,6 @@ impl ::serde::ser::Serialize for DeleteFileRequestError {
 }
 
 impl ::std::error::Error for DeleteFileRequestError {
-    fn description(&self) -> &str {
-        "DeleteFileRequestError"
-    }
 }
 
 impl ::std::fmt::Display for DeleteFileRequestError {
@@ -1712,9 +1700,6 @@ impl ::serde::ser::Serialize for FileRequestError {
 }
 
 impl ::std::error::Error for FileRequestError {
-    fn description(&self) -> &str {
-        "FileRequestError"
-    }
 }
 
 impl ::std::fmt::Display for FileRequestError {
@@ -1784,9 +1769,6 @@ impl ::serde::ser::Serialize for GeneralFileRequestsError {
 }
 
 impl ::std::error::Error for GeneralFileRequestsError {
-    fn description(&self) -> &str {
-        "GeneralFileRequestsError"
-    }
 }
 
 impl ::std::fmt::Display for GeneralFileRequestsError {
@@ -2029,9 +2011,6 @@ impl ::serde::ser::Serialize for GetFileRequestError {
 }
 
 impl ::std::error::Error for GetFileRequestError {
-    fn description(&self) -> &str {
-        "GetFileRequestError"
-    }
 }
 
 impl ::std::fmt::Display for GetFileRequestError {
@@ -2397,9 +2376,6 @@ impl ::serde::ser::Serialize for ListFileRequestsContinueError {
 }
 
 impl ::std::error::Error for ListFileRequestsContinueError {
-    fn description(&self) -> &str {
-        "ListFileRequestsContinueError"
-    }
 }
 
 impl ::std::fmt::Display for ListFileRequestsContinueError {
@@ -2469,9 +2445,6 @@ impl ::serde::ser::Serialize for ListFileRequestsError {
 }
 
 impl ::std::error::Error for ListFileRequestsError {
-    fn description(&self) -> &str {
-        "ListFileRequestsError"
-    }
 }
 
 impl ::std::fmt::Display for ListFileRequestsError {
@@ -3090,9 +3063,6 @@ impl ::serde::ser::Serialize for UpdateFileRequestError {
 }
 
 impl ::std::error::Error for UpdateFileRequestError {
-    fn description(&self) -> &str {
-        "UpdateFileRequestError"
-    }
 }
 
 impl ::std::fmt::Display for UpdateFileRequestError {

--- a/src/generated/files.rs
+++ b/src/generated/files.rs
@@ -1421,7 +1421,10 @@ impl ::std::error::Error for AlphaGetMetadataError {
 
 impl ::std::fmt::Display for AlphaGetMetadataError {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
-        write!(f, "{:?}", *self)
+        match self {
+            AlphaGetMetadataError::Path(inner) => write!(f, "{}", inner),
+            AlphaGetMetadataError::PropertiesError(inner) => write!(f, "{}", inner),
+        }
     }
 }
 
@@ -2751,7 +2754,10 @@ impl ::std::error::Error for CreateFolderEntryError {
 
 impl ::std::fmt::Display for CreateFolderEntryError {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
-        write!(f, "{:?}", *self)
+        match self {
+            CreateFolderEntryError::Path(inner) => write!(f, "{}", inner),
+            _ => write!(f, "{:?}", *self),
+        }
     }
 }
 
@@ -2908,7 +2914,9 @@ impl ::std::error::Error for CreateFolderError {
 
 impl ::std::fmt::Display for CreateFolderError {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
-        write!(f, "{:?}", *self)
+        match self {
+            CreateFolderError::Path(inner) => write!(f, "{}", inner),
+        }
     }
 }
 
@@ -3794,6 +3802,8 @@ impl ::std::error::Error for DeleteError {
 impl ::std::fmt::Display for DeleteError {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match self {
+            DeleteError::PathLookup(inner) => write!(f, "{}", inner),
+            DeleteError::PathWrite(inner) => write!(f, "{}", inner),
             DeleteError::TooManyWriteOperations => f.write_str("There are too many write operations in user's Dropbox. Please retry this request."),
             DeleteError::TooManyFiles => f.write_str("There are too many files in one request. Please retry with fewer files."),
             _ => write!(f, "{:?}", *self),
@@ -4341,7 +4351,10 @@ impl ::std::error::Error for DownloadError {
 
 impl ::std::fmt::Display for DownloadError {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
-        write!(f, "{:?}", *self)
+        match self {
+            DownloadError::Path(inner) => write!(f, "{}", inner),
+            _ => write!(f, "{:?}", *self),
+        }
     }
 }
 
@@ -4535,6 +4548,7 @@ impl ::std::error::Error for DownloadZipError {
 impl ::std::fmt::Display for DownloadZipError {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match self {
+            DownloadZipError::Path(inner) => write!(f, "{}", inner),
             DownloadZipError::TooLarge => f.write_str("The folder or a file is too large to download."),
             DownloadZipError::TooManyFiles => f.write_str("The folder has too many files to download."),
             _ => write!(f, "{:?}", *self),
@@ -4821,6 +4835,7 @@ impl ::std::error::Error for ExportError {
 impl ::std::fmt::Display for ExportError {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match self {
+            ExportError::Path(inner) => write!(f, "{}", inner),
             ExportError::RetryError => f.write_str("The exportable content is not yet available. Please retry later."),
             _ => write!(f, "{:?}", *self),
         }
@@ -6815,7 +6830,10 @@ impl ::std::error::Error for GetCopyReferenceError {
 
 impl ::std::fmt::Display for GetCopyReferenceError {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
-        write!(f, "{:?}", *self)
+        match self {
+            GetCopyReferenceError::Path(inner) => write!(f, "{}", inner),
+            _ => write!(f, "{:?}", *self),
+        }
     }
 }
 
@@ -7171,7 +7189,9 @@ impl ::std::error::Error for GetMetadataError {
 
 impl ::std::fmt::Display for GetMetadataError {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
-        write!(f, "{:?}", *self)
+        match self {
+            GetMetadataError::Path(inner) => write!(f, "{}", inner),
+        }
     }
 }
 
@@ -7366,7 +7386,10 @@ impl ::std::error::Error for GetTemporaryLinkError {
 
 impl ::std::fmt::Display for GetTemporaryLinkError {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
-        write!(f, "{:?}", *self)
+        match self {
+            GetTemporaryLinkError::Path(inner) => write!(f, "{}", inner),
+            _ => write!(f, "{:?}", *self),
+        }
     }
 }
 
@@ -8749,7 +8772,10 @@ impl ::std::error::Error for ListFolderContinueError {
 
 impl ::std::fmt::Display for ListFolderContinueError {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
-        write!(f, "{:?}", *self)
+        match self {
+            ListFolderContinueError::Path(inner) => write!(f, "{}", inner),
+            _ => write!(f, "{:?}", *self),
+        }
     }
 }
 
@@ -8843,7 +8869,11 @@ impl ::std::error::Error for ListFolderError {
 
 impl ::std::fmt::Display for ListFolderError {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
-        write!(f, "{:?}", *self)
+        match self {
+            ListFolderError::Path(inner) => write!(f, "{}", inner),
+            ListFolderError::TemplateError(inner) => write!(f, "{}", inner),
+            _ => write!(f, "{:?}", *self),
+        }
     }
 }
 
@@ -9546,7 +9576,10 @@ impl ::std::error::Error for ListRevisionsError {
 
 impl ::std::fmt::Display for ListRevisionsError {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
-        write!(f, "{:?}", *self)
+        match self {
+            ListRevisionsError::Path(inner) => write!(f, "{}", inner),
+            _ => write!(f, "{:?}", *self),
+        }
     }
 }
 
@@ -10604,6 +10637,7 @@ impl ::std::error::Error for LookupError {
 impl ::std::fmt::Display for LookupError {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match self {
+            LookupError::MalformedPath(inner) => write!(f, "{:?}", inner),
             LookupError::NotFound => f.write_str("There is nothing at the given path."),
             LookupError::NotFile => f.write_str("We were expecting a file, but the given path refers to something that isn't a file."),
             LookupError::NotFolder => f.write_str("We were expecting a folder, but the given path refers to something that isn't a folder."),
@@ -12433,6 +12467,9 @@ impl ::std::error::Error for RelocationBatchError {
 impl ::std::fmt::Display for RelocationBatchError {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match self {
+            RelocationBatchError::FromLookup(inner) => write!(f, "{}", inner),
+            RelocationBatchError::FromWrite(inner) => write!(f, "{}", inner),
+            RelocationBatchError::To(inner) => write!(f, "{}", inner),
             RelocationBatchError::CantCopySharedFolder => f.write_str("Shared folders can't be copied."),
             RelocationBatchError::CantNestSharedFolder => f.write_str("Your move operation would result in nested shared folders.  This is not allowed."),
             RelocationBatchError::CantMoveFolderIntoItself => f.write_str("You cannot move a folder into itself."),
@@ -13416,6 +13453,9 @@ impl ::std::error::Error for RelocationError {
 impl ::std::fmt::Display for RelocationError {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match self {
+            RelocationError::FromLookup(inner) => write!(f, "{}", inner),
+            RelocationError::FromWrite(inner) => write!(f, "{}", inner),
+            RelocationError::To(inner) => write!(f, "{}", inner),
             RelocationError::CantCopySharedFolder => f.write_str("Shared folders can't be copied."),
             RelocationError::CantNestSharedFolder => f.write_str("Your move operation would result in nested shared folders.  This is not allowed."),
             RelocationError::CantMoveFolderIntoItself => f.write_str("You cannot move a folder into itself."),
@@ -14083,6 +14123,7 @@ impl ::std::error::Error for SaveCopyReferenceError {
 impl ::std::fmt::Display for SaveCopyReferenceError {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match self {
+            SaveCopyReferenceError::Path(inner) => write!(f, "{}", inner),
             SaveCopyReferenceError::InvalidCopyReference => f.write_str("The copy reference is invalid."),
             SaveCopyReferenceError::NoPermission => f.write_str("You don't have permission to save the given copy reference. Please make sure this app is same app which created the copy reference and the source user is still linked to the app."),
             SaveCopyReferenceError::NotFound => f.write_str("The file referenced by the copy reference cannot be found."),
@@ -14399,6 +14440,7 @@ impl ::std::error::Error for SaveUrlError {
 impl ::std::fmt::Display for SaveUrlError {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match self {
+            SaveUrlError::Path(inner) => write!(f, "{}", inner),
             SaveUrlError::DownloadFailed => f.write_str("Failed downloading the given URL. The URL may be  password-protected and the password provided was incorrect,  or the link may be disabled."),
             SaveUrlError::InvalidUrl => f.write_str("The given URL is invalid."),
             SaveUrlError::NotFound => f.write_str("The file where the URL is saved to no longer exists."),
@@ -14816,6 +14858,8 @@ impl ::std::error::Error for SearchError {
 impl ::std::fmt::Display for SearchError {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match self {
+            SearchError::Path(inner) => write!(f, "{}", inner),
+            SearchError::InvalidArgument(inner) => write!(f, "{:?}", inner),
             SearchError::InternalError => f.write_str("Something went wrong, please try again."),
             _ => write!(f, "{:?}", *self),
         }
@@ -16938,6 +16982,7 @@ impl ::std::error::Error for SyncSettingsError {
 impl ::std::fmt::Display for SyncSettingsError {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match self {
+            SyncSettingsError::Path(inner) => write!(f, "{}", inner),
             SyncSettingsError::UnsupportedCombination => f.write_str("Setting this combination of sync settings simultaneously is not supported."),
             SyncSettingsError::UnsupportedConfiguration => f.write_str("The specified configuration is not supported."),
             _ => write!(f, "{:?}", *self),
@@ -20152,6 +20197,7 @@ impl ::std::error::Error for WriteError {
 impl ::std::fmt::Display for WriteError {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match self {
+            WriteError::MalformedPath(inner) => write!(f, "{:?}", inner),
             WriteError::Conflict(inner) => write!(f, "Couldn't write to the target path because there was something in the way: {}", inner),
             WriteError::NoWritePermission => f.write_str("The user doesn't have permissions to write to the target location."),
             WriteError::InsufficientSpace => f.write_str("The user doesn't have enough available space (bytes) to write more data."),

--- a/src/generated/files.rs
+++ b/src/generated/files.rs
@@ -1411,8 +1411,11 @@ impl ::serde::ser::Serialize for AlphaGetMetadataError {
 }
 
 impl ::std::error::Error for AlphaGetMetadataError {
-    fn description(&self) -> &str {
-        "AlphaGetMetadataError"
+    fn source(&self) -> Option<&(dyn ::std::error::Error + 'static)> {
+        match self {
+            AlphaGetMetadataError::Path(inner) => Some(inner),
+            AlphaGetMetadataError::PropertiesError(inner) => Some(inner),
+        }
     }
 }
 
@@ -2347,9 +2350,6 @@ impl ::serde::ser::Serialize for CreateFolderBatchError {
 }
 
 impl ::std::error::Error for CreateFolderBatchError {
-    fn description(&self) -> &str {
-        "CreateFolderBatchError"
-    }
 }
 
 impl ::std::fmt::Display for CreateFolderBatchError {
@@ -2738,8 +2738,11 @@ impl ::serde::ser::Serialize for CreateFolderEntryError {
 }
 
 impl ::std::error::Error for CreateFolderEntryError {
-    fn description(&self) -> &str {
-        "CreateFolderEntryError"
+    fn source(&self) -> Option<&(dyn ::std::error::Error + 'static)> {
+        match self {
+            CreateFolderEntryError::Path(inner) => Some(inner),
+            _ => None,
+        }
     }
 }
 
@@ -2893,8 +2896,10 @@ impl ::serde::ser::Serialize for CreateFolderError {
 }
 
 impl ::std::error::Error for CreateFolderError {
-    fn description(&self) -> &str {
-        "CreateFolderError"
+    fn source(&self) -> Option<&(dyn ::std::error::Error + 'static)> {
+        match self {
+            CreateFolderError::Path(inner) => Some(inner),
+        }
     }
 }
 
@@ -3254,9 +3259,6 @@ impl ::serde::ser::Serialize for DeleteBatchError {
 }
 
 impl ::std::error::Error for DeleteBatchError {
-    fn description(&self) -> &str {
-        "DeleteBatchError"
-    }
 }
 
 impl ::std::fmt::Display for DeleteBatchError {
@@ -3777,8 +3779,12 @@ impl ::serde::ser::Serialize for DeleteError {
 }
 
 impl ::std::error::Error for DeleteError {
-    fn description(&self) -> &str {
-        "DeleteError"
+    fn source(&self) -> Option<&(dyn ::std::error::Error + 'static)> {
+        match self {
+            DeleteError::PathLookup(inner) => Some(inner),
+            DeleteError::PathWrite(inner) => Some(inner),
+            _ => None,
+        }
     }
 }
 
@@ -4318,8 +4324,11 @@ impl ::serde::ser::Serialize for DownloadError {
 }
 
 impl ::std::error::Error for DownloadError {
-    fn description(&self) -> &str {
-        "DownloadError"
+    fn source(&self) -> Option<&(dyn ::std::error::Error + 'static)> {
+        match self {
+            DownloadError::Path(inner) => Some(inner),
+            _ => None,
+        }
     }
 }
 
@@ -4508,8 +4517,11 @@ impl ::serde::ser::Serialize for DownloadZipError {
 }
 
 impl ::std::error::Error for DownloadZipError {
-    fn description(&self) -> &str {
-        "DownloadZipError"
+    fn source(&self) -> Option<&(dyn ::std::error::Error + 'static)> {
+        match self {
+            DownloadZipError::Path(inner) => Some(inner),
+            _ => None,
+        }
     }
 }
 
@@ -4787,8 +4799,11 @@ impl ::serde::ser::Serialize for ExportError {
 }
 
 impl ::std::error::Error for ExportError {
-    fn description(&self) -> &str {
-        "ExportError"
+    fn source(&self) -> Option<&(dyn ::std::error::Error + 'static)> {
+        match self {
+            ExportError::Path(inner) => Some(inner),
+            _ => None,
+        }
     }
 }
 
@@ -6776,8 +6791,11 @@ impl ::serde::ser::Serialize for GetCopyReferenceError {
 }
 
 impl ::std::error::Error for GetCopyReferenceError {
-    fn description(&self) -> &str {
-        "GetCopyReferenceError"
+    fn source(&self) -> Option<&(dyn ::std::error::Error + 'static)> {
+        match self {
+            GetCopyReferenceError::Path(inner) => Some(inner),
+            _ => None,
+        }
     }
 }
 
@@ -7130,8 +7148,10 @@ impl ::serde::ser::Serialize for GetMetadataError {
 }
 
 impl ::std::error::Error for GetMetadataError {
-    fn description(&self) -> &str {
-        "GetMetadataError"
+    fn source(&self) -> Option<&(dyn ::std::error::Error + 'static)> {
+        match self {
+            GetMetadataError::Path(inner) => Some(inner),
+        }
     }
 }
 
@@ -7322,8 +7342,11 @@ impl ::serde::ser::Serialize for GetTemporaryLinkError {
 }
 
 impl ::std::error::Error for GetTemporaryLinkError {
-    fn description(&self) -> &str {
-        "GetTemporaryLinkError"
+    fn source(&self) -> Option<&(dyn ::std::error::Error + 'static)> {
+        match self {
+            GetTemporaryLinkError::Path(inner) => Some(inner),
+            _ => None,
+        }
     }
 }
 
@@ -7787,9 +7810,6 @@ impl ::serde::ser::Serialize for GetThumbnailBatchError {
 }
 
 impl ::std::error::Error for GetThumbnailBatchError {
-    fn description(&self) -> &str {
-        "GetThumbnailBatchError"
-    }
 }
 
 impl ::std::fmt::Display for GetThumbnailBatchError {
@@ -8702,8 +8722,11 @@ impl ::serde::ser::Serialize for ListFolderContinueError {
 }
 
 impl ::std::error::Error for ListFolderContinueError {
-    fn description(&self) -> &str {
-        "ListFolderContinueError"
+    fn source(&self) -> Option<&(dyn ::std::error::Error + 'static)> {
+        match self {
+            ListFolderContinueError::Path(inner) => Some(inner),
+            _ => None,
+        }
     }
 }
 
@@ -8792,8 +8815,12 @@ impl ::serde::ser::Serialize for ListFolderError {
 }
 
 impl ::std::error::Error for ListFolderError {
-    fn description(&self) -> &str {
-        "ListFolderError"
+    fn source(&self) -> Option<&(dyn ::std::error::Error + 'static)> {
+        match self {
+            ListFolderError::Path(inner) => Some(inner),
+            ListFolderError::TemplateError(inner) => Some(inner),
+            _ => None,
+        }
     }
 }
 
@@ -9067,9 +9094,6 @@ impl ::serde::ser::Serialize for ListFolderLongpollError {
 }
 
 impl ::std::error::Error for ListFolderLongpollError {
-    fn description(&self) -> &str {
-        "ListFolderLongpollError"
-    }
 }
 
 impl ::std::fmt::Display for ListFolderLongpollError {
@@ -9495,8 +9519,11 @@ impl ::serde::ser::Serialize for ListRevisionsError {
 }
 
 impl ::std::error::Error for ListRevisionsError {
-    fn description(&self) -> &str {
-        "ListRevisionsError"
+    fn source(&self) -> Option<&(dyn ::std::error::Error + 'static)> {
+        match self {
+            ListRevisionsError::Path(inner) => Some(inner),
+            _ => None,
+        }
     }
 }
 
@@ -10217,8 +10244,11 @@ impl ::serde::ser::Serialize for LockFileError {
 }
 
 impl ::std::error::Error for LockFileError {
-    fn description(&self) -> &str {
-        "LockFileError"
+    fn source(&self) -> Option<&(dyn ::std::error::Error + 'static)> {
+        match self {
+            LockFileError::PathLookup(inner) => Some(inner),
+            _ => None,
+        }
     }
 }
 
@@ -10542,9 +10572,6 @@ impl ::serde::ser::Serialize for LookupError {
 }
 
 impl ::std::error::Error for LookupError {
-    fn description(&self) -> &str {
-        "LookupError"
-    }
 }
 
 impl ::std::fmt::Display for LookupError {
@@ -11165,9 +11192,6 @@ impl ::serde::ser::Serialize for MoveIntoVaultError {
 }
 
 impl ::std::error::Error for MoveIntoVaultError {
-    fn description(&self) -> &str {
-        "MoveIntoVaultError"
-    }
 }
 
 impl ::std::fmt::Display for MoveIntoVaultError {
@@ -11573,8 +11597,11 @@ impl ::serde::ser::Serialize for PreviewError {
 }
 
 impl ::std::error::Error for PreviewError {
-    fn description(&self) -> &str {
-        "PreviewError"
+    fn source(&self) -> Option<&(dyn ::std::error::Error + 'static)> {
+        match self {
+            PreviewError::Path(inner) => Some(inner),
+            _ => None,
+        }
     }
 }
 
@@ -12349,8 +12376,14 @@ impl ::serde::ser::Serialize for RelocationBatchError {
 }
 
 impl ::std::error::Error for RelocationBatchError {
-    fn description(&self) -> &str {
-        "RelocationBatchError"
+    fn source(&self) -> Option<&(dyn ::std::error::Error + 'static)> {
+        match self {
+            RelocationBatchError::FromLookup(inner) => Some(inner),
+            RelocationBatchError::FromWrite(inner) => Some(inner),
+            RelocationBatchError::To(inner) => Some(inner),
+            RelocationBatchError::CantMoveIntoVault(inner) => Some(inner),
+            _ => None,
+        }
     }
 }
 
@@ -13315,8 +13348,14 @@ impl ::serde::ser::Serialize for RelocationError {
 }
 
 impl ::std::error::Error for RelocationError {
-    fn description(&self) -> &str {
-        "RelocationError"
+    fn source(&self) -> Option<&(dyn ::std::error::Error + 'static)> {
+        match self {
+            RelocationError::FromLookup(inner) => Some(inner),
+            RelocationError::FromWrite(inner) => Some(inner),
+            RelocationError::To(inner) => Some(inner),
+            RelocationError::CantMoveIntoVault(inner) => Some(inner),
+            _ => None,
+        }
     }
 }
 
@@ -13729,8 +13768,12 @@ impl ::serde::ser::Serialize for RestoreError {
 }
 
 impl ::std::error::Error for RestoreError {
-    fn description(&self) -> &str {
-        "RestoreError"
+    fn source(&self) -> Option<&(dyn ::std::error::Error + 'static)> {
+        match self {
+            RestoreError::PathLookup(inner) => Some(inner),
+            RestoreError::PathWrite(inner) => Some(inner),
+            _ => None,
+        }
     }
 }
 
@@ -13959,8 +14002,11 @@ impl ::serde::ser::Serialize for SaveCopyReferenceError {
 }
 
 impl ::std::error::Error for SaveCopyReferenceError {
-    fn description(&self) -> &str {
-        "SaveCopyReferenceError"
+    fn source(&self) -> Option<&(dyn ::std::error::Error + 'static)> {
+        match self {
+            SaveCopyReferenceError::Path(inner) => Some(inner),
+            _ => None,
+        }
     }
 }
 
@@ -14266,8 +14312,11 @@ impl ::serde::ser::Serialize for SaveUrlError {
 }
 
 impl ::std::error::Error for SaveUrlError {
-    fn description(&self) -> &str {
-        "SaveUrlError"
+    fn source(&self) -> Option<&(dyn ::std::error::Error + 'static)> {
+        match self {
+            SaveUrlError::Path(inner) => Some(inner),
+            _ => None,
+        }
     }
 }
 
@@ -14675,8 +14724,11 @@ impl ::serde::ser::Serialize for SearchError {
 }
 
 impl ::std::error::Error for SearchError {
-    fn description(&self) -> &str {
-        "SearchError"
+    fn source(&self) -> Option<&(dyn ::std::error::Error + 'static)> {
+        match self {
+            SearchError::Path(inner) => Some(inner),
+            _ => None,
+        }
     }
 }
 
@@ -16791,8 +16843,11 @@ impl ::serde::ser::Serialize for SyncSettingsError {
 }
 
 impl ::std::error::Error for SyncSettingsError {
-    fn description(&self) -> &str {
-        "SyncSettingsError"
+    fn source(&self) -> Option<&(dyn ::std::error::Error + 'static)> {
+        match self {
+            SyncSettingsError::Path(inner) => Some(inner),
+            _ => None,
+        }
     }
 }
 
@@ -17041,8 +17096,11 @@ impl ::serde::ser::Serialize for ThumbnailError {
 }
 
 impl ::std::error::Error for ThumbnailError {
-    fn description(&self) -> &str {
-        "ThumbnailError"
+    fn source(&self) -> Option<&(dyn ::std::error::Error + 'static)> {
+        match self {
+            ThumbnailError::Path(inner) => Some(inner),
+            _ => None,
+        }
     }
 }
 
@@ -17618,8 +17676,11 @@ impl ::serde::ser::Serialize for ThumbnailV2Error {
 }
 
 impl ::std::error::Error for ThumbnailV2Error {
-    fn description(&self) -> &str {
-        "ThumbnailV2Error"
+    fn source(&self) -> Option<&(dyn ::std::error::Error + 'static)> {
+        match self {
+            ThumbnailV2Error::Path(inner) => Some(inner),
+            _ => None,
+        }
     }
 }
 
@@ -17885,8 +17946,11 @@ impl ::serde::ser::Serialize for UploadError {
 }
 
 impl ::std::error::Error for UploadError {
-    fn description(&self) -> &str {
-        "UploadError"
+    fn source(&self) -> Option<&(dyn ::std::error::Error + 'static)> {
+        match self {
+            UploadError::PropertiesError(inner) => Some(inner),
+            _ => None,
+        }
     }
 }
 
@@ -18834,8 +18898,13 @@ impl ::serde::ser::Serialize for UploadSessionFinishError {
 }
 
 impl ::std::error::Error for UploadSessionFinishError {
-    fn description(&self) -> &str {
-        "UploadSessionFinishError"
+    fn source(&self) -> Option<&(dyn ::std::error::Error + 'static)> {
+        match self {
+            UploadSessionFinishError::LookupFailed(inner) => Some(inner),
+            UploadSessionFinishError::Path(inner) => Some(inner),
+            UploadSessionFinishError::PropertiesError(inner) => Some(inner),
+            _ => None,
+        }
     }
 }
 
@@ -18986,9 +19055,6 @@ impl ::serde::ser::Serialize for UploadSessionLookupError {
 }
 
 impl ::std::error::Error for UploadSessionLookupError {
-    fn description(&self) -> &str {
-        "UploadSessionLookupError"
-    }
 }
 
 impl ::std::fmt::Display for UploadSessionLookupError {
@@ -19266,9 +19332,6 @@ impl ::serde::ser::Serialize for UploadSessionStartError {
 }
 
 impl ::std::error::Error for UploadSessionStartError {
-    fn description(&self) -> &str {
-        "UploadSessionStartError"
-    }
 }
 
 impl ::std::fmt::Display for UploadSessionStartError {
@@ -19773,9 +19836,6 @@ impl ::serde::ser::Serialize for WriteConflictError {
 }
 
 impl ::std::error::Error for WriteConflictError {
-    fn description(&self) -> &str {
-        "WriteConflictError"
-    }
 }
 
 impl ::std::fmt::Display for WriteConflictError {
@@ -19948,8 +20008,11 @@ impl ::serde::ser::Serialize for WriteError {
 }
 
 impl ::std::error::Error for WriteError {
-    fn description(&self) -> &str {
-        "WriteError"
+    fn source(&self) -> Option<&(dyn ::std::error::Error + 'static)> {
+        match self {
+            WriteError::Conflict(inner) => Some(inner),
+            _ => None,
+        }
     }
 }
 

--- a/src/generated/files.rs
+++ b/src/generated/files.rs
@@ -18184,6 +18184,25 @@ impl ::serde::ser::Serialize for UploadErrorWithProperties {
     }
 }
 
+impl ::std::error::Error for UploadErrorWithProperties {
+    fn source(&self) -> Option<&(dyn ::std::error::Error + 'static)> {
+        match self {
+            UploadErrorWithProperties::PropertiesError(inner) => Some(inner),
+            _ => None,
+        }
+    }
+}
+
+impl ::std::fmt::Display for UploadErrorWithProperties {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
+        match self {
+            UploadErrorWithProperties::Path(inner) => write!(f, "Unable to save the uploaded contents to a file: {:?}", inner),
+            UploadErrorWithProperties::PropertiesError(inner) => write!(f, "The supplied property group is invalid. The file has uploaded without property groups: {}", inner),
+            _ => write!(f, "{:?}", *self),
+        }
+    }
+}
+
 #[derive(Debug, Clone, PartialEq)]
 #[non_exhaustive] // structs may have more fields added in the future.
 pub struct UploadSessionAppendArg {

--- a/src/generated/files.rs
+++ b/src/generated/files.rs
@@ -97,7 +97,7 @@ pub fn copy(
 pub fn copy_batch_v2(
     client: &impl crate::client_trait::UserAuthClient,
     arg: &CopyBatchArg,
-) -> crate::Result<Result<RelocationBatchV2Launch, ()>> {
+) -> crate::Result<Result<RelocationBatchV2Launch, crate::NoError>> {
     crate::client_helpers::request(
         client,
         crate::client_trait::Endpoint::Api,
@@ -113,7 +113,7 @@ pub fn copy_batch_v2(
 pub fn copy_batch(
     client: &impl crate::client_trait::UserAuthClient,
     arg: &RelocationBatchArg,
-) -> crate::Result<Result<RelocationBatchLaunch, ()>> {
+) -> crate::Result<Result<RelocationBatchLaunch, crate::NoError>> {
     crate::client_helpers::request(
         client,
         crate::client_trait::Endpoint::Api,
@@ -220,7 +220,7 @@ pub fn create_folder(
 pub fn create_folder_batch(
     client: &impl crate::client_trait::UserAuthClient,
     arg: &CreateFolderBatchArg,
-) -> crate::Result<Result<CreateFolderBatchLaunch, ()>> {
+) -> crate::Result<Result<CreateFolderBatchLaunch, crate::NoError>> {
     crate::client_helpers::request(
         client,
         crate::client_trait::Endpoint::Api,
@@ -287,7 +287,7 @@ pub fn delete(
 pub fn delete_batch(
     client: &impl crate::client_trait::UserAuthClient,
     arg: &DeleteBatchArg,
-) -> crate::Result<Result<DeleteBatchLaunch, ()>> {
+) -> crate::Result<Result<DeleteBatchLaunch, crate::NoError>> {
     crate::client_helpers::request(
         client,
         crate::client_trait::Endpoint::Api,
@@ -475,7 +475,7 @@ pub fn get_temporary_link(
 pub fn get_temporary_upload_link(
     client: &impl crate::client_trait::UserAuthClient,
     arg: &GetTemporaryUploadLinkArg,
-) -> crate::Result<Result<GetTemporaryUploadLinkResult, ()>> {
+) -> crate::Result<Result<GetTemporaryUploadLinkResult, crate::NoError>> {
     crate::client_helpers::request(
         client,
         crate::client_trait::Endpoint::Api,
@@ -718,7 +718,7 @@ pub fn do_move(
 pub fn move_batch_v2(
     client: &impl crate::client_trait::UserAuthClient,
     arg: &MoveBatchArg,
-) -> crate::Result<Result<RelocationBatchV2Launch, ()>> {
+) -> crate::Result<Result<RelocationBatchV2Launch, crate::NoError>> {
     crate::client_helpers::request(
         client,
         crate::client_trait::Endpoint::Api,
@@ -734,7 +734,7 @@ pub fn move_batch_v2(
 pub fn move_batch(
     client: &impl crate::client_trait::UserAuthClient,
     arg: &RelocationBatchArg,
-) -> crate::Result<Result<RelocationBatchLaunch, ()>> {
+) -> crate::Result<Result<RelocationBatchLaunch, crate::NoError>> {
     crate::client_helpers::request(
         client,
         crate::client_trait::Endpoint::Api,
@@ -1080,7 +1080,7 @@ pub fn upload_session_finish(
 pub fn upload_session_finish_batch(
     client: &impl crate::client_trait::UserAuthClient,
     arg: &UploadSessionFinishBatchArg,
-) -> crate::Result<Result<UploadSessionFinishBatchLaunch, ()>> {
+) -> crate::Result<Result<UploadSessionFinishBatchLaunch, crate::NoError>> {
     crate::client_helpers::request(
         client,
         crate::client_trait::Endpoint::Api,

--- a/src/generated/files.rs
+++ b/src/generated/files.rs
@@ -2354,7 +2354,10 @@ impl ::std::error::Error for CreateFolderBatchError {
 
 impl ::std::fmt::Display for CreateFolderBatchError {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
-        write!(f, "{:?}", *self)
+        match self {
+            CreateFolderBatchError::TooManyFiles => f.write_str("The operation would involve too many files or folders."),
+            _ => write!(f, "{:?}", *self),
+        }
     }
 }
 
@@ -3790,7 +3793,11 @@ impl ::std::error::Error for DeleteError {
 
 impl ::std::fmt::Display for DeleteError {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
-        write!(f, "{:?}", *self)
+        match self {
+            DeleteError::TooManyWriteOperations => f.write_str("There are too many write operations in user's Dropbox. Please retry this request."),
+            DeleteError::TooManyFiles => f.write_str("There are too many files in one request. Please retry with fewer files."),
+            _ => write!(f, "{:?}", *self),
+        }
     }
 }
 
@@ -4527,7 +4534,11 @@ impl ::std::error::Error for DownloadZipError {
 
 impl ::std::fmt::Display for DownloadZipError {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
-        write!(f, "{:?}", *self)
+        match self {
+            DownloadZipError::TooLarge => f.write_str("The folder or a file is too large to download."),
+            DownloadZipError::TooManyFiles => f.write_str("The folder has too many files to download."),
+            _ => write!(f, "{:?}", *self),
+        }
     }
 }
 
@@ -4809,7 +4820,10 @@ impl ::std::error::Error for ExportError {
 
 impl ::std::fmt::Display for ExportError {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
-        write!(f, "{:?}", *self)
+        match self {
+            ExportError::RetryError => f.write_str("The exportable content is not yet available. Please retry later."),
+            _ => write!(f, "{:?}", *self),
+        }
     }
 }
 
@@ -7814,7 +7828,10 @@ impl ::std::error::Error for GetThumbnailBatchError {
 
 impl ::std::fmt::Display for GetThumbnailBatchError {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
-        write!(f, "{:?}", *self)
+        match self {
+            GetThumbnailBatchError::TooManyFiles => f.write_str("The operation involves more than 25 files."),
+            _ => write!(f, "{:?}", *self),
+        }
     }
 }
 
@@ -10254,7 +10271,17 @@ impl ::std::error::Error for LockFileError {
 
 impl ::std::fmt::Display for LockFileError {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
-        write!(f, "{:?}", *self)
+        match self {
+            LockFileError::PathLookup(inner) => write!(f, "Could not find the specified resource: {}", inner),
+            LockFileError::TooManyWriteOperations => f.write_str("There are too many write operations in user's Dropbox. Please retry this request."),
+            LockFileError::TooManyFiles => f.write_str("There are too many files in one request. Please retry with fewer files."),
+            LockFileError::NoWritePermission => f.write_str("The user does not have permissions to change the lock state or access the file."),
+            LockFileError::CannotBeLocked => f.write_str("Item is a type that cannot be locked."),
+            LockFileError::FileNotShared => f.write_str("Requested file is not currently shared."),
+            LockFileError::LockConflict(inner) => write!(f, "The user action conflicts with an existing lock on the file: {:?}", inner),
+            LockFileError::InternalError => f.write_str("Something went wrong with the job on Dropbox's end. You'll need to verify that the action you were taking succeeded, and if not, try again. This should happen very rarely."),
+            _ => write!(f, "{:?}", *self),
+        }
     }
 }
 
@@ -10576,7 +10603,15 @@ impl ::std::error::Error for LookupError {
 
 impl ::std::fmt::Display for LookupError {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
-        write!(f, "{:?}", *self)
+        match self {
+            LookupError::NotFound => f.write_str("There is nothing at the given path."),
+            LookupError::NotFile => f.write_str("We were expecting a file, but the given path refers to something that isn't a file."),
+            LookupError::NotFolder => f.write_str("We were expecting a folder, but the given path refers to something that isn't a folder."),
+            LookupError::RestrictedContent => f.write_str("The file cannot be transferred because the content is restricted.  For example, sometimes there are legal restrictions due to copyright claims."),
+            LookupError::UnsupportedContentType => f.write_str("This operation is not supported for this content type."),
+            LookupError::Locked => f.write_str("The given path is locked."),
+            _ => write!(f, "{:?}", *self),
+        }
     }
 }
 
@@ -11196,7 +11231,10 @@ impl ::std::error::Error for MoveIntoVaultError {
 
 impl ::std::fmt::Display for MoveIntoVaultError {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
-        write!(f, "{:?}", *self)
+        match self {
+            MoveIntoVaultError::IsSharedFolder => f.write_str("Moving shared folder into Vault is not allowed."),
+            _ => write!(f, "{:?}", *self),
+        }
     }
 }
 
@@ -11607,7 +11645,12 @@ impl ::std::error::Error for PreviewError {
 
 impl ::std::fmt::Display for PreviewError {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
-        write!(f, "{:?}", *self)
+        match self {
+            PreviewError::Path(inner) => write!(f, "An error occurs when downloading metadata for the file: {}", inner),
+            PreviewError::InProgress => f.write_str("This preview generation is still in progress and the file is not ready  for preview yet."),
+            PreviewError::UnsupportedExtension => f.write_str("The file extension is not supported preview generation."),
+            PreviewError::UnsupportedContent => f.write_str("The file content is not supported for preview generation."),
+        }
     }
 }
 
@@ -12389,7 +12432,18 @@ impl ::std::error::Error for RelocationBatchError {
 
 impl ::std::fmt::Display for RelocationBatchError {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
-        write!(f, "{:?}", *self)
+        match self {
+            RelocationBatchError::CantCopySharedFolder => f.write_str("Shared folders can't be copied."),
+            RelocationBatchError::CantNestSharedFolder => f.write_str("Your move operation would result in nested shared folders.  This is not allowed."),
+            RelocationBatchError::CantMoveFolderIntoItself => f.write_str("You cannot move a folder into itself."),
+            RelocationBatchError::TooManyFiles => f.write_str("The operation would involve more than 10,000 files and folders."),
+            RelocationBatchError::InsufficientQuota => f.write_str("The current user does not have enough space to move or copy the files."),
+            RelocationBatchError::InternalError => f.write_str("Something went wrong with the job on Dropbox's end. You'll need to verify that the action you were taking succeeded, and if not, try again. This should happen very rarely."),
+            RelocationBatchError::CantMoveSharedFolder => f.write_str("Can't move the shared folder to the given destination."),
+            RelocationBatchError::CantMoveIntoVault(inner) => write!(f, "Some content cannot be moved into Vault under certain circumstances, see detailed error: {}", inner),
+            RelocationBatchError::TooManyWriteOperations => f.write_str("There are too many write operations in user's Dropbox. Please retry this request."),
+            _ => write!(f, "{:?}", *self),
+        }
     }
 }
 
@@ -13361,7 +13415,17 @@ impl ::std::error::Error for RelocationError {
 
 impl ::std::fmt::Display for RelocationError {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
-        write!(f, "{:?}", *self)
+        match self {
+            RelocationError::CantCopySharedFolder => f.write_str("Shared folders can't be copied."),
+            RelocationError::CantNestSharedFolder => f.write_str("Your move operation would result in nested shared folders.  This is not allowed."),
+            RelocationError::CantMoveFolderIntoItself => f.write_str("You cannot move a folder into itself."),
+            RelocationError::TooManyFiles => f.write_str("The operation would involve more than 10,000 files and folders."),
+            RelocationError::InsufficientQuota => f.write_str("The current user does not have enough space to move or copy the files."),
+            RelocationError::InternalError => f.write_str("Something went wrong with the job on Dropbox's end. You'll need to verify that the action you were taking succeeded, and if not, try again. This should happen very rarely."),
+            RelocationError::CantMoveSharedFolder => f.write_str("Can't move the shared folder to the given destination."),
+            RelocationError::CantMoveIntoVault(inner) => write!(f, "Some content cannot be moved into Vault under certain circumstances, see detailed error: {}", inner),
+            _ => write!(f, "{:?}", *self),
+        }
     }
 }
 
@@ -13779,7 +13843,13 @@ impl ::std::error::Error for RestoreError {
 
 impl ::std::fmt::Display for RestoreError {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
-        write!(f, "{:?}", *self)
+        match self {
+            RestoreError::PathLookup(inner) => write!(f, "An error occurs when downloading metadata for the file: {}", inner),
+            RestoreError::PathWrite(inner) => write!(f, "An error occurs when trying to restore the file to that path: {}", inner),
+            RestoreError::InvalidRevision => f.write_str("The revision is invalid. It may not exist or may point to a deleted file."),
+            RestoreError::InProgress => f.write_str("The restore is currently executing, but has not yet completed."),
+            _ => write!(f, "{:?}", *self),
+        }
     }
 }
 
@@ -14012,7 +14082,13 @@ impl ::std::error::Error for SaveCopyReferenceError {
 
 impl ::std::fmt::Display for SaveCopyReferenceError {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
-        write!(f, "{:?}", *self)
+        match self {
+            SaveCopyReferenceError::InvalidCopyReference => f.write_str("The copy reference is invalid."),
+            SaveCopyReferenceError::NoPermission => f.write_str("You don't have permission to save the given copy reference. Please make sure this app is same app which created the copy reference and the source user is still linked to the app."),
+            SaveCopyReferenceError::NotFound => f.write_str("The file referenced by the copy reference cannot be found."),
+            SaveCopyReferenceError::TooManyFiles => f.write_str("The operation would involve more than 10,000 files and folders."),
+            _ => write!(f, "{:?}", *self),
+        }
     }
 }
 
@@ -14322,7 +14398,12 @@ impl ::std::error::Error for SaveUrlError {
 
 impl ::std::fmt::Display for SaveUrlError {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
-        write!(f, "{:?}", *self)
+        match self {
+            SaveUrlError::DownloadFailed => f.write_str("Failed downloading the given URL. The URL may be  password-protected and the password provided was incorrect,  or the link may be disabled."),
+            SaveUrlError::InvalidUrl => f.write_str("The given URL is invalid."),
+            SaveUrlError::NotFound => f.write_str("The file where the URL is saved to no longer exists."),
+            _ => write!(f, "{:?}", *self),
+        }
     }
 }
 
@@ -14734,7 +14815,10 @@ impl ::std::error::Error for SearchError {
 
 impl ::std::fmt::Display for SearchError {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
-        write!(f, "{:?}", *self)
+        match self {
+            SearchError::InternalError => f.write_str("Something went wrong, please try again."),
+            _ => write!(f, "{:?}", *self),
+        }
     }
 }
 
@@ -16853,7 +16937,11 @@ impl ::std::error::Error for SyncSettingsError {
 
 impl ::std::fmt::Display for SyncSettingsError {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
-        write!(f, "{:?}", *self)
+        match self {
+            SyncSettingsError::UnsupportedCombination => f.write_str("Setting this combination of sync settings simultaneously is not supported."),
+            SyncSettingsError::UnsupportedConfiguration => f.write_str("The specified configuration is not supported."),
+            _ => write!(f, "{:?}", *self),
+        }
     }
 }
 
@@ -17106,7 +17194,12 @@ impl ::std::error::Error for ThumbnailError {
 
 impl ::std::fmt::Display for ThumbnailError {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
-        write!(f, "{:?}", *self)
+        match self {
+            ThumbnailError::Path(inner) => write!(f, "An error occurs when downloading metadata for the image: {}", inner),
+            ThumbnailError::UnsupportedExtension => f.write_str("The file extension doesn't allow conversion to a thumbnail."),
+            ThumbnailError::UnsupportedImage => f.write_str("The image cannot be converted to a thumbnail."),
+            ThumbnailError::ConversionError => f.write_str("An error occurs during thumbnail conversion."),
+        }
     }
 }
 
@@ -17686,7 +17779,15 @@ impl ::std::error::Error for ThumbnailV2Error {
 
 impl ::std::fmt::Display for ThumbnailV2Error {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
-        write!(f, "{:?}", *self)
+        match self {
+            ThumbnailV2Error::Path(inner) => write!(f, "An error occurred when downloading metadata for the image: {}", inner),
+            ThumbnailV2Error::UnsupportedExtension => f.write_str("The file extension doesn't allow conversion to a thumbnail."),
+            ThumbnailV2Error::UnsupportedImage => f.write_str("The image cannot be converted to a thumbnail."),
+            ThumbnailV2Error::ConversionError => f.write_str("An error occurred during thumbnail conversion."),
+            ThumbnailV2Error::AccessDenied => f.write_str("Access to this shared link is forbidden."),
+            ThumbnailV2Error::NotFound => f.write_str("The shared link does not exist."),
+            _ => write!(f, "{:?}", *self),
+        }
     }
 }
 
@@ -17956,7 +18057,11 @@ impl ::std::error::Error for UploadError {
 
 impl ::std::fmt::Display for UploadError {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
-        write!(f, "{:?}", *self)
+        match self {
+            UploadError::Path(inner) => write!(f, "Unable to save the uploaded contents to a file: {:?}", inner),
+            UploadError::PropertiesError(inner) => write!(f, "The supplied property group is invalid. The file has uploaded without property groups: {}", inner),
+            _ => write!(f, "{:?}", *self),
+        }
     }
 }
 
@@ -18910,7 +19015,17 @@ impl ::std::error::Error for UploadSessionFinishError {
 
 impl ::std::fmt::Display for UploadSessionFinishError {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
-        write!(f, "{:?}", *self)
+        match self {
+            UploadSessionFinishError::LookupFailed(inner) => write!(f, "The session arguments are incorrect; the value explains the reason: {}", inner),
+            UploadSessionFinishError::Path(inner) => write!(f, "Unable to save the uploaded contents to a file. Data has already been appended to the upload session. Please retry with empty data body and updated offset: {}", inner),
+            UploadSessionFinishError::PropertiesError(inner) => write!(f, "The supplied property group is invalid. The file has uploaded without property groups: {}", inner),
+            UploadSessionFinishError::TooManySharedFolderTargets => f.write_str("The batch request commits files into too many different shared folders. Please limit your batch request to files contained in a single shared folder."),
+            UploadSessionFinishError::TooManyWriteOperations => f.write_str("There are too many write operations happening in the user's Dropbox. You should retry uploading this file."),
+            UploadSessionFinishError::ConcurrentSessionDataNotAllowed => f.write_str("Uploading data not allowed when finishing concurrent upload session."),
+            UploadSessionFinishError::ConcurrentSessionNotClosed => f.write_str("Concurrent upload sessions need to be closed before finishing."),
+            UploadSessionFinishError::ConcurrentSessionMissingData => f.write_str("Not all pieces of data were uploaded before trying to finish the session."),
+            _ => write!(f, "{:?}", *self),
+        }
     }
 }
 
@@ -19059,7 +19174,16 @@ impl ::std::error::Error for UploadSessionLookupError {
 
 impl ::std::fmt::Display for UploadSessionLookupError {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
-        write!(f, "{:?}", *self)
+        match self {
+            UploadSessionLookupError::NotFound => f.write_str("The upload session ID was not found or has expired. Upload sessions are valid for 48 hours."),
+            UploadSessionLookupError::IncorrectOffset(inner) => write!(f, "The specified offset was incorrect. See the value for the correct offset. This error may occur when a previous request was received and processed successfully but the client did not receive the response, e.g. due to a network error: {:?}", inner),
+            UploadSessionLookupError::Closed => f.write_str("You are attempting to append data to an upload session that has already been closed (i.e. committed)."),
+            UploadSessionLookupError::NotClosed => f.write_str("The session must be closed before calling upload_session/finish_batch."),
+            UploadSessionLookupError::TooLarge => f.write_str("You can not append to the upload session because the size of a file should not reach the max file size limit (i.e. 350GB)."),
+            UploadSessionLookupError::ConcurrentSessionInvalidOffset => f.write_str("For concurrent upload sessions, offset needs to be multiple of 4194304 bytes."),
+            UploadSessionLookupError::ConcurrentSessionInvalidDataSize => f.write_str("For concurrent upload sessions, only chunks with size multiple of 4194304 bytes can be uploaded."),
+            _ => write!(f, "{:?}", *self),
+        }
     }
 }
 
@@ -19336,7 +19460,11 @@ impl ::std::error::Error for UploadSessionStartError {
 
 impl ::std::fmt::Display for UploadSessionStartError {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
-        write!(f, "{:?}", *self)
+        match self {
+            UploadSessionStartError::ConcurrentSessionDataNotAllowed => f.write_str("Uploading data not allowed when starting concurrent upload session."),
+            UploadSessionStartError::ConcurrentSessionCloseNotAllowed => f.write_str("Can not start a closed concurrent upload session."),
+            _ => write!(f, "{:?}", *self),
+        }
     }
 }
 
@@ -19840,7 +19968,12 @@ impl ::std::error::Error for WriteConflictError {
 
 impl ::std::fmt::Display for WriteConflictError {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
-        write!(f, "{:?}", *self)
+        match self {
+            WriteConflictError::File => f.write_str("There's a file in the way."),
+            WriteConflictError::Folder => f.write_str("There's a folder in the way."),
+            WriteConflictError::FileAncestor => f.write_str("There's a file at an ancestor path, so we couldn't create the required parent folders."),
+            _ => write!(f, "{:?}", *self),
+        }
     }
 }
 
@@ -20018,7 +20151,16 @@ impl ::std::error::Error for WriteError {
 
 impl ::std::fmt::Display for WriteError {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
-        write!(f, "{:?}", *self)
+        match self {
+            WriteError::Conflict(inner) => write!(f, "Couldn't write to the target path because there was something in the way: {}", inner),
+            WriteError::NoWritePermission => f.write_str("The user doesn't have permissions to write to the target location."),
+            WriteError::InsufficientSpace => f.write_str("The user doesn't have enough available space (bytes) to write more data."),
+            WriteError::DisallowedName => f.write_str("Dropbox will not save the file or folder because of its name."),
+            WriteError::TeamFolder => f.write_str("This endpoint cannot move or delete team folders."),
+            WriteError::OperationSuppressed => f.write_str("This file operation is not allowed at this path."),
+            WriteError::TooManyWriteOperations => f.write_str("There are too many write operations in user's Dropbox. Please retry this request."),
+            _ => write!(f, "{:?}", *self),
+        }
     }
 }
 

--- a/src/generated/files.rs
+++ b/src/generated/files.rs
@@ -10637,7 +10637,7 @@ impl ::std::error::Error for LookupError {
 impl ::std::fmt::Display for LookupError {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match self {
-            LookupError::MalformedPath(inner) => write!(f, "{:?}", inner),
+            LookupError::MalformedPath(inner) => write!(f, "malformed_path: {:?}", inner),
             LookupError::NotFound => f.write_str("There is nothing at the given path."),
             LookupError::NotFile => f.write_str("We were expecting a file, but the given path refers to something that isn't a file."),
             LookupError::NotFolder => f.write_str("We were expecting a folder, but the given path refers to something that isn't a folder."),
@@ -14859,7 +14859,8 @@ impl ::std::fmt::Display for SearchError {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match self {
             SearchError::Path(inner) => write!(f, "{}", inner),
-            SearchError::InvalidArgument(inner) => write!(f, "{:?}", inner),
+            SearchError::InvalidArgument(None) => f.write_str("invalid_argument"),
+            SearchError::InvalidArgument(Some(inner)) => write!(f, "invalid_argument: {:?}", inner),
             SearchError::InternalError => f.write_str("Something went wrong, please try again."),
             _ => write!(f, "{:?}", *self),
         }
@@ -20216,7 +20217,7 @@ impl ::std::error::Error for WriteError {
 impl ::std::fmt::Display for WriteError {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match self {
-            WriteError::MalformedPath(inner) => write!(f, "{:?}", inner),
+            WriteError::MalformedPath(inner) => write!(f, "malformed_path: {:?}", inner),
             WriteError::Conflict(inner) => write!(f, "Couldn't write to the target path because there was something in the way: {}", inner),
             WriteError::NoWritePermission => f.write_str("The user doesn't have permissions to write to the target location."),
             WriteError::InsufficientSpace => f.write_str("The user doesn't have enough available space (bytes) to write more data."),

--- a/src/generated/paper.rs
+++ b/src/generated/paper.rs
@@ -155,7 +155,7 @@ pub fn docs_get_folder_info(
 pub fn docs_list(
     client: &impl crate::client_trait::UserAuthClient,
     arg: &ListPaperDocsArgs,
-) -> crate::Result<Result<ListPaperDocsResponse, ()>> {
+) -> crate::Result<Result<ListPaperDocsResponse, crate::NoError>> {
     crate::client_helpers::request(
         client,
         crate::client_trait::Endpoint::Api,

--- a/src/generated/paper.rs
+++ b/src/generated/paper.rs
@@ -1052,9 +1052,6 @@ impl ::serde::ser::Serialize for DocLookupError {
 }
 
 impl ::std::error::Error for DocLookupError {
-    fn description(&self) -> &str {
-        "DocLookupError"
-    }
 }
 
 impl ::std::fmt::Display for DocLookupError {
@@ -1847,8 +1844,11 @@ impl ::serde::ser::Serialize for ListDocsCursorError {
 }
 
 impl ::std::error::Error for ListDocsCursorError {
-    fn description(&self) -> &str {
-        "ListDocsCursorError"
+    fn source(&self) -> Option<&(dyn ::std::error::Error + 'static)> {
+        match self {
+            ListDocsCursorError::CursorError(inner) => Some(inner),
+            _ => None,
+        }
     }
 }
 
@@ -2534,8 +2534,11 @@ impl ::serde::ser::Serialize for ListUsersCursorError {
 }
 
 impl ::std::error::Error for ListUsersCursorError {
-    fn description(&self) -> &str {
-        "ListUsersCursorError"
+    fn source(&self) -> Option<&(dyn ::std::error::Error + 'static)> {
+        match self {
+            ListUsersCursorError::CursorError(inner) => Some(inner),
+            _ => None,
+        }
     }
 }
 
@@ -3346,9 +3349,6 @@ impl ::serde::ser::Serialize for PaperApiBaseError {
 }
 
 impl ::std::error::Error for PaperApiBaseError {
-    fn description(&self) -> &str {
-        "PaperApiBaseError"
-    }
 }
 
 impl ::std::fmt::Display for PaperApiBaseError {
@@ -3457,9 +3457,6 @@ impl ::serde::ser::Serialize for PaperApiCursorError {
 }
 
 impl ::std::error::Error for PaperApiCursorError {
-    fn description(&self) -> &str {
-        "PaperApiCursorError"
-    }
 }
 
 impl ::std::fmt::Display for PaperApiCursorError {
@@ -3693,9 +3690,6 @@ impl ::serde::ser::Serialize for PaperDocCreateError {
 }
 
 impl ::std::error::Error for PaperDocCreateError {
-    fn description(&self) -> &str {
-        "PaperDocCreateError"
-    }
 }
 
 impl ::std::fmt::Display for PaperDocCreateError {
@@ -4517,9 +4511,6 @@ impl ::serde::ser::Serialize for PaperDocUpdateError {
 }
 
 impl ::std::error::Error for PaperDocUpdateError {
-    fn description(&self) -> &str {
-        "PaperDocUpdateError"
-    }
 }
 
 impl ::std::fmt::Display for PaperDocUpdateError {
@@ -4833,9 +4824,6 @@ impl ::serde::ser::Serialize for PaperFolderCreateError {
 }
 
 impl ::std::error::Error for PaperFolderCreateError {
-    fn description(&self) -> &str {
-        "PaperFolderCreateError"
-    }
 }
 
 impl ::std::fmt::Display for PaperFolderCreateError {

--- a/src/generated/paper.rs
+++ b/src/generated/paper.rs
@@ -1056,7 +1056,10 @@ impl ::std::error::Error for DocLookupError {
 
 impl ::std::fmt::Display for DocLookupError {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
-        write!(f, "{:?}", *self)
+        match self {
+            DocLookupError::DocNotFound => f.write_str("The required doc was not found."),
+            _ => write!(f, "{:?}", *self),
+        }
     }
 }
 
@@ -2544,7 +2547,10 @@ impl ::std::error::Error for ListUsersCursorError {
 
 impl ::std::fmt::Display for ListUsersCursorError {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
-        write!(f, "{:?}", *self)
+        match self {
+            ListUsersCursorError::DocNotFound => f.write_str("The required doc was not found."),
+            _ => write!(f, "{:?}", *self),
+        }
     }
 }
 
@@ -3461,7 +3467,13 @@ impl ::std::error::Error for PaperApiCursorError {
 
 impl ::std::fmt::Display for PaperApiCursorError {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
-        write!(f, "{:?}", *self)
+        match self {
+            PaperApiCursorError::ExpiredCursor => f.write_str("The provided cursor is expired."),
+            PaperApiCursorError::InvalidCursor => f.write_str("The provided cursor is invalid."),
+            PaperApiCursorError::WrongUserInCursor => f.write_str("The provided cursor contains invalid user."),
+            PaperApiCursorError::Reset => f.write_str("Indicates that the cursor has been invalidated. Call the corresponding non-continue endpoint to obtain a new cursor."),
+            _ => write!(f, "{:?}", *self),
+        }
     }
 }
 
@@ -3694,7 +3706,13 @@ impl ::std::error::Error for PaperDocCreateError {
 
 impl ::std::fmt::Display for PaperDocCreateError {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
-        write!(f, "{:?}", *self)
+        match self {
+            PaperDocCreateError::ContentMalformed => f.write_str("The provided content was malformed and cannot be imported to Paper."),
+            PaperDocCreateError::FolderNotFound => f.write_str("The specified Paper folder is cannot be found."),
+            PaperDocCreateError::DocLengthExceeded => f.write_str("The newly created Paper doc would be too large. Please split the content into multiple docs."),
+            PaperDocCreateError::ImageSizeExceeded => f.write_str("The imported document contains an image that is too large. The current limit is 1MB. This only applies to HTML with data URI."),
+            _ => write!(f, "{:?}", *self),
+        }
     }
 }
 
@@ -4515,7 +4533,16 @@ impl ::std::error::Error for PaperDocUpdateError {
 
 impl ::std::fmt::Display for PaperDocUpdateError {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
-        write!(f, "{:?}", *self)
+        match self {
+            PaperDocUpdateError::DocNotFound => f.write_str("The required doc was not found."),
+            PaperDocUpdateError::ContentMalformed => f.write_str("The provided content was malformed and cannot be imported to Paper."),
+            PaperDocUpdateError::RevisionMismatch => f.write_str("The provided revision does not match the document head."),
+            PaperDocUpdateError::DocLengthExceeded => f.write_str("The newly created Paper doc would be too large, split the content into multiple docs."),
+            PaperDocUpdateError::ImageSizeExceeded => f.write_str("The imported document contains an image that is too large. The current limit is 1MB. This only applies to HTML with data URI."),
+            PaperDocUpdateError::DocArchived => f.write_str("This operation is not allowed on archived Paper docs."),
+            PaperDocUpdateError::DocDeleted => f.write_str("This operation is not allowed on deleted Paper docs."),
+            _ => write!(f, "{:?}", *self),
+        }
     }
 }
 
@@ -4828,7 +4855,11 @@ impl ::std::error::Error for PaperFolderCreateError {
 
 impl ::std::fmt::Display for PaperFolderCreateError {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
-        write!(f, "{:?}", *self)
+        match self {
+            PaperFolderCreateError::FolderNotFound => f.write_str("The specified parent Paper folder cannot be found."),
+            PaperFolderCreateError::InvalidFolderId => f.write_str("The folder id cannot be decrypted to valid folder id."),
+            _ => write!(f, "{:?}", *self),
+        }
     }
 }
 

--- a/src/generated/paper.rs
+++ b/src/generated/paper.rs
@@ -1857,7 +1857,10 @@ impl ::std::error::Error for ListDocsCursorError {
 
 impl ::std::fmt::Display for ListDocsCursorError {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
-        write!(f, "{:?}", *self)
+        match self {
+            ListDocsCursorError::CursorError(inner) => write!(f, "{}", inner),
+            _ => write!(f, "{:?}", *self),
+        }
     }
 }
 
@@ -2549,6 +2552,7 @@ impl ::std::fmt::Display for ListUsersCursorError {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match self {
             ListUsersCursorError::DocNotFound => f.write_str("The required doc was not found."),
+            ListUsersCursorError::CursorError(inner) => write!(f, "{}", inner),
             _ => write!(f, "{:?}", *self),
         }
     }

--- a/src/generated/sharing.rs
+++ b/src/generated/sharing.rs
@@ -2913,7 +2913,8 @@ impl ::std::fmt::Display for CreateSharedLinkWithSettingsError {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match self {
             CreateSharedLinkWithSettingsError::Path(inner) => write!(f, "{}", inner),
-            CreateSharedLinkWithSettingsError::SharedLinkAlreadyExists(inner) => write!(f, "{:?}", inner),
+            CreateSharedLinkWithSettingsError::SharedLinkAlreadyExists(None) => f.write_str("shared_link_already_exists"),
+            CreateSharedLinkWithSettingsError::SharedLinkAlreadyExists(Some(inner)) => write!(f, "shared_link_already_exists: {:?}", inner),
             CreateSharedLinkWithSettingsError::SettingsError(inner) => write!(f, "There is an error with the given settings: {}", inner),
             CreateSharedLinkWithSettingsError::AccessDenied => f.write_str("Access to the requested path is forbidden."),
             _ => write!(f, "{:?}", *self),
@@ -5920,7 +5921,7 @@ impl ::std::error::Error for GetSharedLinksError {
 impl ::std::fmt::Display for GetSharedLinksError {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match self {
-            GetSharedLinksError::Path(inner) => write!(f, "{:?}", inner),
+            GetSharedLinksError::Path(inner) => write!(f, "path: {:?}", inner),
             _ => write!(f, "{:?}", *self),
         }
     }

--- a/src/generated/sharing.rs
+++ b/src/generated/sharing.rs
@@ -1230,6 +1230,8 @@ impl ::std::error::Error for AddFileMemberError {
 impl ::std::fmt::Display for AddFileMemberError {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match self {
+            AddFileMemberError::UserError(inner) => write!(f, "{}", inner),
+            AddFileMemberError::AccessError(inner) => write!(f, "{}", inner),
             AddFileMemberError::RateLimit => f.write_str("The user has reached the rate limit for invitations."),
             AddFileMemberError::InvalidComment => f.write_str("The custom message did not pass comment permissions checks."),
             _ => write!(f, "{:?}", *self),
@@ -1627,6 +1629,7 @@ impl ::std::fmt::Display for AddFolderMemberError {
         match self {
             AddFolderMemberError::AccessError(inner) => write!(f, "Unable to access shared folder: {}", inner),
             AddFolderMemberError::BannedMember => f.write_str("The current user has been banned."),
+            AddFolderMemberError::BadMember(inner) => write!(f, "{}", inner),
             AddFolderMemberError::CantShareOutsideTeam => f.write_str("Your team policy does not allow sharing outside of the team."),
             AddFolderMemberError::TooManyMembers(inner) => write!(f, "The value is the member limit that was reached: {:?}", inner),
             AddFolderMemberError::TooManyPendingInvites(inner) => write!(f, "The value is the pending invite limit that was reached: {:?}", inner),
@@ -2665,7 +2668,10 @@ impl ::std::error::Error for CreateSharedLinkError {
 
 impl ::std::fmt::Display for CreateSharedLinkError {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
-        write!(f, "{:?}", *self)
+        match self {
+            CreateSharedLinkError::Path(inner) => write!(f, "{}", inner),
+            _ => write!(f, "{:?}", *self),
+        }
     }
 }
 
@@ -2906,6 +2912,8 @@ impl ::std::error::Error for CreateSharedLinkWithSettingsError {
 impl ::std::fmt::Display for CreateSharedLinkWithSettingsError {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match self {
+            CreateSharedLinkWithSettingsError::Path(inner) => write!(f, "{}", inner),
+            CreateSharedLinkWithSettingsError::SharedLinkAlreadyExists(inner) => write!(f, "{:?}", inner),
             CreateSharedLinkWithSettingsError::SettingsError(inner) => write!(f, "There is an error with the given settings: {}", inner),
             CreateSharedLinkWithSettingsError::AccessDenied => f.write_str("Access to the requested path is forbidden."),
             _ => write!(f, "{:?}", *self),
@@ -5324,7 +5332,11 @@ impl ::std::error::Error for GetFileMetadataError {
 
 impl ::std::fmt::Display for GetFileMetadataError {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
-        write!(f, "{:?}", *self)
+        match self {
+            GetFileMetadataError::UserError(inner) => write!(f, "{}", inner),
+            GetFileMetadataError::AccessError(inner) => write!(f, "{}", inner),
+            _ => write!(f, "{:?}", *self),
+        }
     }
 }
 
@@ -5907,7 +5919,10 @@ impl ::std::error::Error for GetSharedLinksError {
 
 impl ::std::fmt::Display for GetSharedLinksError {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
-        write!(f, "{:?}", *self)
+        match self {
+            GetSharedLinksError::Path(inner) => write!(f, "{:?}", inner),
+            _ => write!(f, "{:?}", *self),
+        }
     }
 }
 
@@ -6953,7 +6968,12 @@ impl ::std::error::Error for JobError {
 
 impl ::std::fmt::Display for JobError {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
-        write!(f, "{:?}", *self)
+        match self {
+            JobError::UnshareFolderError(inner) => write!(f, "{}", inner),
+            JobError::RemoveFolderMemberError(inner) => write!(f, "{}", inner),
+            JobError::RelinquishFolderMembershipError(inner) => write!(f, "{}", inner),
+            _ => write!(f, "{:?}", *self),
+        }
     }
 }
 
@@ -8579,7 +8599,11 @@ impl ::std::error::Error for ListFileMembersContinueError {
 
 impl ::std::fmt::Display for ListFileMembersContinueError {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
-        write!(f, "{:?}", *self)
+        match self {
+            ListFileMembersContinueError::UserError(inner) => write!(f, "{}", inner),
+            ListFileMembersContinueError::AccessError(inner) => write!(f, "{}", inner),
+            _ => write!(f, "{:?}", *self),
+        }
     }
 }
 
@@ -8777,7 +8801,11 @@ impl ::std::error::Error for ListFileMembersError {
 
 impl ::std::fmt::Display for ListFileMembersError {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
-        write!(f, "{:?}", *self)
+        match self {
+            ListFileMembersError::UserError(inner) => write!(f, "{}", inner),
+            ListFileMembersError::AccessError(inner) => write!(f, "{}", inner),
+            _ => write!(f, "{:?}", *self),
+        }
     }
 }
 
@@ -9563,7 +9591,10 @@ impl ::std::error::Error for ListFolderMembersContinueError {
 
 impl ::std::fmt::Display for ListFolderMembersContinueError {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
-        write!(f, "{:?}", *self)
+        match self {
+            ListFolderMembersContinueError::AccessError(inner) => write!(f, "{}", inner),
+            _ => write!(f, "{:?}", *self),
+        }
     }
 }
 
@@ -10263,7 +10294,10 @@ impl ::std::error::Error for ListSharedLinksError {
 
 impl ::std::fmt::Display for ListSharedLinksError {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
-        write!(f, "{:?}", *self)
+        match self {
+            ListSharedLinksError::Path(inner) => write!(f, "{}", inner),
+            _ => write!(f, "{:?}", *self),
+        }
     }
 }
 
@@ -11550,6 +11584,7 @@ impl ::std::error::Error for MountFolderError {
 impl ::std::fmt::Display for MountFolderError {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match self {
+            MountFolderError::AccessError(inner) => write!(f, "{}", inner),
             MountFolderError::InsideSharedFolder => f.write_str("Mounting would cause a shared folder to be inside another, which is disallowed."),
             MountFolderError::InsufficientQuota(inner) => write!(f, "The current user does not have enough space to mount the shared folder: {:?}", inner),
             MountFolderError::AlreadyMounted => f.write_str("The shared folder is already mounted."),
@@ -12324,6 +12359,7 @@ impl ::std::error::Error for RelinquishFileMembershipError {
 impl ::std::fmt::Display for RelinquishFileMembershipError {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match self {
+            RelinquishFileMembershipError::AccessError(inner) => write!(f, "{}", inner),
             RelinquishFileMembershipError::GroupAccess => f.write_str("The current user has access to the shared file via a group.  You can't relinquish membership to a file shared via groups."),
             RelinquishFileMembershipError::NoPermission => f.write_str("The current user does not have permission to perform this action."),
             _ => write!(f, "{:?}", *self),
@@ -12595,6 +12631,7 @@ impl ::std::error::Error for RelinquishFolderMembershipError {
 impl ::std::fmt::Display for RelinquishFolderMembershipError {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match self {
+            RelinquishFolderMembershipError::AccessError(inner) => write!(f, "{}", inner),
             RelinquishFolderMembershipError::FolderOwner => f.write_str("The current user is the owner of the shared folder. Owners cannot relinquish membership to their own folders. Try unsharing or transferring ownership first."),
             RelinquishFolderMembershipError::Mounted => f.write_str("The shared folder is currently mounted.  Unmount the shared folder before relinquishing membership."),
             RelinquishFolderMembershipError::GroupAccess => f.write_str("The current user has access to the shared folder via a group.  You can't relinquish membership to folders shared via groups."),
@@ -12816,6 +12853,8 @@ impl ::std::error::Error for RemoveFileMemberError {
 impl ::std::fmt::Display for RemoveFileMemberError {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match self {
+            RemoveFileMemberError::UserError(inner) => write!(f, "{}", inner),
+            RemoveFileMemberError::AccessError(inner) => write!(f, "{}", inner),
             RemoveFileMemberError::NoExplicitAccess(inner) => write!(f, "This member does not have explicit access to the file and therefore cannot be removed. The return value is the access that a user might have to the file from a parent folder: {:?}", inner),
             _ => write!(f, "{:?}", *self),
         }
@@ -13102,6 +13141,8 @@ impl ::std::error::Error for RemoveFolderMemberError {
 impl ::std::fmt::Display for RemoveFolderMemberError {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match self {
+            RemoveFolderMemberError::AccessError(inner) => write!(f, "{}", inner),
+            RemoveFolderMemberError::MemberError(inner) => write!(f, "{}", inner),
             RemoveFolderMemberError::FolderOwner => f.write_str("The target user is the owner of the shared folder. You can't remove this user until ownership has been transferred to another member."),
             RemoveFolderMemberError::GroupAccess => f.write_str("The target user has access to the shared folder via a group."),
             RemoveFolderMemberError::TeamFolder => f.write_str("This action cannot be performed on a team shared folder."),
@@ -14445,6 +14486,7 @@ impl ::std::error::Error for ShareFolderError {
 impl ::std::fmt::Display for ShareFolderError {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match self {
+            ShareFolderError::BadPath(inner) => write!(f, "{}", inner),
             ShareFolderError::NoPermission => f.write_str("The current user does not have permission to perform this action."),
             _ => write!(f, "{:?}", *self),
         }
@@ -18033,6 +18075,7 @@ impl ::std::error::Error for TransferFolderError {
 impl ::std::fmt::Display for TransferFolderError {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match self {
+            TransferFolderError::AccessError(inner) => write!(f, "{}", inner),
             TransferFolderError::NewOwnerNotAMember => f.write_str("The new designated owner is not currently a member of the shared folder."),
             TransferFolderError::NewOwnerUnmounted => f.write_str("The new designated owner has not added the folder to their Dropbox."),
             TransferFolderError::TeamFolder => f.write_str("This action cannot be performed on a team shared folder."),
@@ -18233,6 +18276,7 @@ impl ::std::error::Error for UnmountFolderError {
 impl ::std::fmt::Display for UnmountFolderError {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match self {
+            UnmountFolderError::AccessError(inner) => write!(f, "{}", inner),
             UnmountFolderError::NoPermission => f.write_str("The current user does not have permission to perform this action."),
             UnmountFolderError::NotUnmountable => f.write_str("The shared folder can't be unmounted. One example where this can occur is when the shared folder's parent folder is also a shared folder that resides in the current user's Dropbox."),
             _ => write!(f, "{:?}", *self),
@@ -18422,7 +18466,11 @@ impl ::std::error::Error for UnshareFileError {
 
 impl ::std::fmt::Display for UnshareFileError {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
-        write!(f, "{:?}", *self)
+        match self {
+            UnshareFileError::UserError(inner) => write!(f, "{}", inner),
+            UnshareFileError::AccessError(inner) => write!(f, "{}", inner),
+            _ => write!(f, "{:?}", *self),
+        }
     }
 }
 
@@ -18649,6 +18697,7 @@ impl ::std::error::Error for UnshareFolderError {
 impl ::std::fmt::Display for UnshareFolderError {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match self {
+            UnshareFolderError::AccessError(inner) => write!(f, "{}", inner),
             UnshareFolderError::TeamFolder => f.write_str("This action cannot be performed on a team shared folder."),
             UnshareFolderError::NoPermission => f.write_str("The current user does not have permission to perform this action."),
             UnshareFolderError::TooManyFiles => f.write_str("This shared folder has too many files to be unshared."),
@@ -19033,6 +19082,8 @@ impl ::std::error::Error for UpdateFolderMemberError {
 impl ::std::fmt::Display for UpdateFolderMemberError {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match self {
+            UpdateFolderMemberError::AccessError(inner) => write!(f, "{}", inner),
+            UpdateFolderMemberError::MemberError(inner) => write!(f, "{}", inner),
             UpdateFolderMemberError::NoExplicitAccess(inner) => write!(f, "If updating the access type required the member to be added to the shared folder and there was an error when adding the member: {}", inner),
             UpdateFolderMemberError::InsufficientPlan => f.write_str("The current user's account doesn't support this action. An example of this is when downgrading a member from editor to viewer. This action can only be performed by users that have upgraded to a Pro or Business plan."),
             UpdateFolderMemberError::NoPermission => f.write_str("The current user does not have permission to perform this action."),
@@ -19385,6 +19436,7 @@ impl ::std::error::Error for UpdateFolderPolicyError {
 impl ::std::fmt::Display for UpdateFolderPolicyError {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match self {
+            UpdateFolderPolicyError::AccessError(inner) => write!(f, "{}", inner),
             UpdateFolderPolicyError::NoPermission => f.write_str("The current user does not have permission to perform this action."),
             UpdateFolderPolicyError::TeamFolder => f.write_str("This action cannot be performed on a team shared folder."),
             _ => write!(f, "{:?}", *self),

--- a/src/generated/sharing.rs
+++ b/src/generated/sharing.rs
@@ -1218,8 +1218,12 @@ impl ::serde::ser::Serialize for AddFileMemberError {
 }
 
 impl ::std::error::Error for AddFileMemberError {
-    fn description(&self) -> &str {
-        "AddFileMemberError"
+    fn source(&self) -> Option<&(dyn ::std::error::Error + 'static)> {
+        match self {
+            AddFileMemberError::UserError(inner) => Some(inner),
+            AddFileMemberError::AccessError(inner) => Some(inner),
+            _ => None,
+        }
     }
 }
 
@@ -1605,8 +1609,12 @@ impl ::serde::ser::Serialize for AddFolderMemberError {
 }
 
 impl ::std::error::Error for AddFolderMemberError {
-    fn description(&self) -> &str {
-        "AddFolderMemberError"
+    fn source(&self) -> Option<&(dyn ::std::error::Error + 'static)> {
+        match self {
+            AddFolderMemberError::AccessError(inner) => Some(inner),
+            AddFolderMemberError::BadMember(inner) => Some(inner),
+            _ => None,
+        }
     }
 }
 
@@ -1865,9 +1873,6 @@ impl ::serde::ser::Serialize for AddMemberSelectorError {
 }
 
 impl ::std::error::Error for AddMemberSelectorError {
-    fn description(&self) -> &str {
-        "AddMemberSelectorError"
-    }
 }
 
 impl ::std::fmt::Display for AddMemberSelectorError {
@@ -2626,8 +2631,11 @@ impl ::serde::ser::Serialize for CreateSharedLinkError {
 }
 
 impl ::std::error::Error for CreateSharedLinkError {
-    fn description(&self) -> &str {
-        "CreateSharedLinkError"
+    fn source(&self) -> Option<&(dyn ::std::error::Error + 'static)> {
+        match self {
+            CreateSharedLinkError::Path(inner) => Some(inner),
+            _ => None,
+        }
     }
 }
 
@@ -2862,8 +2870,12 @@ impl ::serde::ser::Serialize for CreateSharedLinkWithSettingsError {
 }
 
 impl ::std::error::Error for CreateSharedLinkWithSettingsError {
-    fn description(&self) -> &str {
-        "CreateSharedLinkWithSettingsError"
+    fn source(&self) -> Option<&(dyn ::std::error::Error + 'static)> {
+        match self {
+            CreateSharedLinkWithSettingsError::Path(inner) => Some(inner),
+            CreateSharedLinkWithSettingsError::SettingsError(inner) => Some(inner),
+            _ => None,
+        }
     }
 }
 
@@ -3748,8 +3760,11 @@ impl ::serde::ser::Serialize for FileMemberActionError {
 }
 
 impl ::std::error::Error for FileMemberActionError {
-    fn description(&self) -> &str {
-        "FileMemberActionError"
+    fn source(&self) -> Option<&(dyn ::std::error::Error + 'static)> {
+        match self {
+            FileMemberActionError::AccessError(inner) => Some(inner),
+            _ => None,
+        }
     }
 }
 
@@ -5264,8 +5279,12 @@ impl ::serde::ser::Serialize for GetFileMetadataError {
 }
 
 impl ::std::error::Error for GetFileMetadataError {
-    fn description(&self) -> &str {
-        "GetFileMetadataError"
+    fn source(&self) -> Option<&(dyn ::std::error::Error + 'static)> {
+        match self {
+            GetFileMetadataError::UserError(inner) => Some(inner),
+            GetFileMetadataError::AccessError(inner) => Some(inner),
+            _ => None,
+        }
     }
 }
 
@@ -5558,9 +5577,6 @@ impl ::serde::ser::Serialize for GetSharedLinkFileError {
 }
 
 impl ::std::error::Error for GetSharedLinkFileError {
-    fn description(&self) -> &str {
-        "GetSharedLinkFileError"
-    }
 }
 
 impl ::std::fmt::Display for GetSharedLinkFileError {
@@ -5848,9 +5864,6 @@ impl ::serde::ser::Serialize for GetSharedLinksError {
 }
 
 impl ::std::error::Error for GetSharedLinksError {
-    fn description(&self) -> &str {
-        "GetSharedLinksError"
-    }
 }
 
 impl ::std::fmt::Display for GetSharedLinksError {
@@ -6889,8 +6902,13 @@ impl ::serde::ser::Serialize for JobError {
 }
 
 impl ::std::error::Error for JobError {
-    fn description(&self) -> &str {
-        "JobError"
+    fn source(&self) -> Option<&(dyn ::std::error::Error + 'static)> {
+        match self {
+            JobError::UnshareFolderError(inner) => Some(inner),
+            JobError::RemoveFolderMemberError(inner) => Some(inner),
+            JobError::RelinquishFolderMembershipError(inner) => Some(inner),
+            _ => None,
+        }
     }
 }
 
@@ -8511,8 +8529,12 @@ impl ::serde::ser::Serialize for ListFileMembersContinueError {
 }
 
 impl ::std::error::Error for ListFileMembersContinueError {
-    fn description(&self) -> &str {
-        "ListFileMembersContinueError"
+    fn source(&self) -> Option<&(dyn ::std::error::Error + 'static)> {
+        match self {
+            ListFileMembersContinueError::UserError(inner) => Some(inner),
+            ListFileMembersContinueError::AccessError(inner) => Some(inner),
+            _ => None,
+        }
     }
 }
 
@@ -8705,8 +8727,12 @@ impl ::serde::ser::Serialize for ListFileMembersError {
 }
 
 impl ::std::error::Error for ListFileMembersError {
-    fn description(&self) -> &str {
-        "ListFileMembersError"
+    fn source(&self) -> Option<&(dyn ::std::error::Error + 'static)> {
+        match self {
+            ListFileMembersError::UserError(inner) => Some(inner),
+            ListFileMembersError::AccessError(inner) => Some(inner),
+            _ => None,
+        }
     }
 }
 
@@ -9066,8 +9092,11 @@ impl ::serde::ser::Serialize for ListFilesContinueError {
 }
 
 impl ::std::error::Error for ListFilesContinueError {
-    fn description(&self) -> &str {
-        "ListFilesContinueError"
+    fn source(&self) -> Option<&(dyn ::std::error::Error + 'static)> {
+        match self {
+            ListFilesContinueError::UserError(inner) => Some(inner),
+            _ => None,
+        }
     }
 }
 
@@ -9482,8 +9511,11 @@ impl ::serde::ser::Serialize for ListFolderMembersContinueError {
 }
 
 impl ::std::error::Error for ListFolderMembersContinueError {
-    fn description(&self) -> &str {
-        "ListFolderMembersContinueError"
+    fn source(&self) -> Option<&(dyn ::std::error::Error + 'static)> {
+        match self {
+            ListFolderMembersContinueError::AccessError(inner) => Some(inner),
+            _ => None,
+        }
     }
 }
 
@@ -9856,9 +9888,6 @@ impl ::serde::ser::Serialize for ListFoldersContinueError {
 }
 
 impl ::std::error::Error for ListFoldersContinueError {
-    fn description(&self) -> &str {
-        "ListFoldersContinueError"
-    }
 }
 
 impl ::std::fmt::Display for ListFoldersContinueError {
@@ -10182,8 +10211,11 @@ impl ::serde::ser::Serialize for ListSharedLinksError {
 }
 
 impl ::std::error::Error for ListSharedLinksError {
-    fn description(&self) -> &str {
-        "ListSharedLinksError"
+    fn source(&self) -> Option<&(dyn ::std::error::Error + 'static)> {
+        match self {
+            ListSharedLinksError::Path(inner) => Some(inner),
+            _ => None,
+        }
     }
 }
 
@@ -11229,8 +11261,11 @@ impl ::serde::ser::Serialize for ModifySharedLinkSettingsError {
 }
 
 impl ::std::error::Error for ModifySharedLinkSettingsError {
-    fn description(&self) -> &str {
-        "ModifySharedLinkSettingsError"
+    fn source(&self) -> Option<&(dyn ::std::error::Error + 'static)> {
+        match self {
+            ModifySharedLinkSettingsError::SettingsError(inner) => Some(inner),
+            _ => None,
+        }
     }
 }
 
@@ -11457,8 +11492,11 @@ impl ::serde::ser::Serialize for MountFolderError {
 }
 
 impl ::std::error::Error for MountFolderError {
-    fn description(&self) -> &str {
-        "MountFolderError"
+    fn source(&self) -> Option<&(dyn ::std::error::Error + 'static)> {
+        match self {
+            MountFolderError::AccessError(inner) => Some(inner),
+            _ => None,
+        }
     }
 }
 
@@ -12221,8 +12259,11 @@ impl ::serde::ser::Serialize for RelinquishFileMembershipError {
 }
 
 impl ::std::error::Error for RelinquishFileMembershipError {
-    fn description(&self) -> &str {
-        "RelinquishFileMembershipError"
+    fn source(&self) -> Option<&(dyn ::std::error::Error + 'static)> {
+        match self {
+            RelinquishFileMembershipError::AccessError(inner) => Some(inner),
+            _ => None,
+        }
     }
 }
 
@@ -12485,8 +12526,11 @@ impl ::serde::ser::Serialize for RelinquishFolderMembershipError {
 }
 
 impl ::std::error::Error for RelinquishFolderMembershipError {
-    fn description(&self) -> &str {
-        "RelinquishFolderMembershipError"
+    fn source(&self) -> Option<&(dyn ::std::error::Error + 'static)> {
+        match self {
+            RelinquishFolderMembershipError::AccessError(inner) => Some(inner),
+            _ => None,
+        }
     }
 }
 
@@ -12694,8 +12738,12 @@ impl ::serde::ser::Serialize for RemoveFileMemberError {
 }
 
 impl ::std::error::Error for RemoveFileMemberError {
-    fn description(&self) -> &str {
-        "RemoveFileMemberError"
+    fn source(&self) -> Option<&(dyn ::std::error::Error + 'static)> {
+        match self {
+            RemoveFileMemberError::UserError(inner) => Some(inner),
+            RemoveFileMemberError::AccessError(inner) => Some(inner),
+            _ => None,
+        }
     }
 }
 
@@ -12973,8 +13021,12 @@ impl ::serde::ser::Serialize for RemoveFolderMemberError {
 }
 
 impl ::std::error::Error for RemoveFolderMemberError {
-    fn description(&self) -> &str {
-        "RemoveFolderMemberError"
+    fn source(&self) -> Option<&(dyn ::std::error::Error + 'static)> {
+        match self {
+            RemoveFolderMemberError::AccessError(inner) => Some(inner),
+            RemoveFolderMemberError::MemberError(inner) => Some(inner),
+            _ => None,
+        }
     }
 }
 
@@ -13533,9 +13585,6 @@ impl ::serde::ser::Serialize for RevokeSharedLinkError {
 }
 
 impl ::std::error::Error for RevokeSharedLinkError {
-    fn description(&self) -> &str {
-        "RevokeSharedLinkError"
-    }
 }
 
 impl ::std::fmt::Display for RevokeSharedLinkError {
@@ -13729,8 +13778,11 @@ impl ::serde::ser::Serialize for SetAccessInheritanceError {
 }
 
 impl ::std::error::Error for SetAccessInheritanceError {
-    fn description(&self) -> &str {
-        "SetAccessInheritanceError"
+    fn source(&self) -> Option<&(dyn ::std::error::Error + 'static)> {
+        match self {
+            SetAccessInheritanceError::AccessError(inner) => Some(inner),
+            _ => None,
+        }
     }
 }
 
@@ -14297,8 +14349,11 @@ impl ::serde::ser::Serialize for ShareFolderError {
 }
 
 impl ::std::error::Error for ShareFolderError {
-    fn description(&self) -> &str {
-        "ShareFolderError"
+    fn source(&self) -> Option<&(dyn ::std::error::Error + 'static)> {
+        match self {
+            ShareFolderError::BadPath(inner) => Some(inner),
+            _ => None,
+        }
     }
 }
 
@@ -14795,9 +14850,6 @@ impl ::serde::ser::Serialize for SharePathError {
 }
 
 impl ::std::error::Error for SharePathError {
-    fn description(&self) -> &str {
-        "SharePathError"
-    }
 }
 
 impl ::std::fmt::Display for SharePathError {
@@ -15804,9 +15856,6 @@ impl ::serde::ser::Serialize for SharedFolderAccessError {
 }
 
 impl ::std::error::Error for SharedFolderAccessError {
-    fn description(&self) -> &str {
-        "SharedFolderAccessError"
-    }
 }
 
 impl ::std::fmt::Display for SharedFolderAccessError {
@@ -15899,9 +15948,6 @@ impl ::serde::ser::Serialize for SharedFolderMemberError {
 }
 
 impl ::std::error::Error for SharedFolderMemberError {
-    fn description(&self) -> &str {
-        "SharedFolderMemberError"
-    }
 }
 
 impl ::std::fmt::Display for SharedFolderMemberError {
@@ -16869,9 +16915,6 @@ impl ::serde::ser::Serialize for SharedLinkError {
 }
 
 impl ::std::error::Error for SharedLinkError {
-    fn description(&self) -> &str {
-        "SharedLinkError"
-    }
 }
 
 impl ::std::fmt::Display for SharedLinkError {
@@ -17283,9 +17326,6 @@ impl ::serde::ser::Serialize for SharedLinkSettingsError {
 }
 
 impl ::std::error::Error for SharedLinkSettingsError {
-    fn description(&self) -> &str {
-        "SharedLinkSettingsError"
-    }
 }
 
 impl ::std::fmt::Display for SharedLinkSettingsError {
@@ -17407,9 +17447,6 @@ impl ::serde::ser::Serialize for SharingFileAccessError {
 }
 
 impl ::std::error::Error for SharingFileAccessError {
-    fn description(&self) -> &str {
-        "SharingFileAccessError"
-    }
 }
 
 impl ::std::fmt::Display for SharingFileAccessError {
@@ -17481,9 +17518,6 @@ impl ::serde::ser::Serialize for SharingUserError {
 }
 
 impl ::std::error::Error for SharingUserError {
-    fn description(&self) -> &str {
-        "SharingUserError"
-    }
 }
 
 impl ::std::fmt::Display for SharingUserError {
@@ -17861,8 +17895,11 @@ impl ::serde::ser::Serialize for TransferFolderError {
 }
 
 impl ::std::error::Error for TransferFolderError {
-    fn description(&self) -> &str {
-        "TransferFolderError"
+    fn source(&self) -> Option<&(dyn ::std::error::Error + 'static)> {
+        match self {
+            TransferFolderError::AccessError(inner) => Some(inner),
+            _ => None,
+        }
     }
 }
 
@@ -18052,8 +18089,11 @@ impl ::serde::ser::Serialize for UnmountFolderError {
 }
 
 impl ::std::error::Error for UnmountFolderError {
-    fn description(&self) -> &str {
-        "UnmountFolderError"
+    fn source(&self) -> Option<&(dyn ::std::error::Error + 'static)> {
+        match self {
+            UnmountFolderError::AccessError(inner) => Some(inner),
+            _ => None,
+        }
     }
 }
 
@@ -18234,8 +18274,12 @@ impl ::serde::ser::Serialize for UnshareFileError {
 }
 
 impl ::std::error::Error for UnshareFileError {
-    fn description(&self) -> &str {
-        "UnshareFileError"
+    fn source(&self) -> Option<&(dyn ::std::error::Error + 'static)> {
+        match self {
+            UnshareFileError::UserError(inner) => Some(inner),
+            UnshareFileError::AccessError(inner) => Some(inner),
+            _ => None,
+        }
     }
 }
 
@@ -18457,8 +18501,11 @@ impl ::serde::ser::Serialize for UnshareFolderError {
 }
 
 impl ::std::error::Error for UnshareFolderError {
-    fn description(&self) -> &str {
-        "UnshareFolderError"
+    fn source(&self) -> Option<&(dyn ::std::error::Error + 'static)> {
+        match self {
+            UnshareFolderError::AccessError(inner) => Some(inner),
+            _ => None,
+        }
     }
 }
 
@@ -18831,8 +18878,13 @@ impl ::serde::ser::Serialize for UpdateFolderMemberError {
 }
 
 impl ::std::error::Error for UpdateFolderMemberError {
-    fn description(&self) -> &str {
-        "UpdateFolderMemberError"
+    fn source(&self) -> Option<&(dyn ::std::error::Error + 'static)> {
+        match self {
+            UpdateFolderMemberError::AccessError(inner) => Some(inner),
+            UpdateFolderMemberError::MemberError(inner) => Some(inner),
+            UpdateFolderMemberError::NoExplicitAccess(inner) => Some(inner),
+            _ => None,
+        }
     }
 }
 
@@ -19175,8 +19227,11 @@ impl ::serde::ser::Serialize for UpdateFolderPolicyError {
 }
 
 impl ::std::error::Error for UpdateFolderPolicyError {
-    fn description(&self) -> &str {
-        "UpdateFolderPolicyError"
+    fn source(&self) -> Option<&(dyn ::std::error::Error + 'static)> {
+        match self {
+            UpdateFolderPolicyError::AccessError(inner) => Some(inner),
+            _ => None,
+        }
     }
 }
 

--- a/src/generated/sharing.rs
+++ b/src/generated/sharing.rs
@@ -1229,7 +1229,11 @@ impl ::std::error::Error for AddFileMemberError {
 
 impl ::std::fmt::Display for AddFileMemberError {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
-        write!(f, "{:?}", *self)
+        match self {
+            AddFileMemberError::RateLimit => f.write_str("The user has reached the rate limit for invitations."),
+            AddFileMemberError::InvalidComment => f.write_str("The custom message did not pass comment permissions checks."),
+            _ => write!(f, "{:?}", *self),
+        }
     }
 }
 
@@ -1620,7 +1624,20 @@ impl ::std::error::Error for AddFolderMemberError {
 
 impl ::std::fmt::Display for AddFolderMemberError {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
-        write!(f, "{:?}", *self)
+        match self {
+            AddFolderMemberError::AccessError(inner) => write!(f, "Unable to access shared folder: {}", inner),
+            AddFolderMemberError::BannedMember => f.write_str("The current user has been banned."),
+            AddFolderMemberError::CantShareOutsideTeam => f.write_str("Your team policy does not allow sharing outside of the team."),
+            AddFolderMemberError::TooManyMembers(inner) => write!(f, "The value is the member limit that was reached: {:?}", inner),
+            AddFolderMemberError::TooManyPendingInvites(inner) => write!(f, "The value is the pending invite limit that was reached: {:?}", inner),
+            AddFolderMemberError::RateLimit => f.write_str("The current user has hit the limit of invites they can send per day. Try again in 24 hours."),
+            AddFolderMemberError::TooManyInvitees => f.write_str("The current user is trying to share with too many people at once."),
+            AddFolderMemberError::InsufficientPlan => f.write_str("The current user's account doesn't support this action. An example of this is when adding a read-only member. This action can only be performed by users that have upgraded to a Pro or Business plan."),
+            AddFolderMemberError::TeamFolder => f.write_str("This action cannot be performed on a team shared folder."),
+            AddFolderMemberError::NoPermission => f.write_str("The current user does not have permission to perform this action."),
+            AddFolderMemberError::InvalidSharedFolder => f.write_str("Invalid shared folder error will be returned as an access_error."),
+            _ => write!(f, "{:?}", *self),
+        }
     }
 }
 
@@ -1877,7 +1894,14 @@ impl ::std::error::Error for AddMemberSelectorError {
 
 impl ::std::fmt::Display for AddMemberSelectorError {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
-        write!(f, "{:?}", *self)
+        match self {
+            AddMemberSelectorError::AutomaticGroup => f.write_str("Automatically created groups can only be added to team folders."),
+            AddMemberSelectorError::InvalidDropboxId(inner) => write!(f, "The value is the ID that could not be identified: {:?}", inner),
+            AddMemberSelectorError::InvalidEmail(inner) => write!(f, "The value is the e-email address that is malformed: {:?}", inner),
+            AddMemberSelectorError::UnverifiedDropboxId(inner) => write!(f, "The value is the ID of the Dropbox user with an unverified email address. Invite unverified users by email address instead of by their Dropbox ID: {:?}", inner),
+            AddMemberSelectorError::GroupNotOnTeam => f.write_str("Sharing to a group that is not on the current user's team."),
+            _ => write!(f, "{:?}", *self),
+        }
     }
 }
 
@@ -2881,7 +2905,11 @@ impl ::std::error::Error for CreateSharedLinkWithSettingsError {
 
 impl ::std::fmt::Display for CreateSharedLinkWithSettingsError {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
-        write!(f, "{:?}", *self)
+        match self {
+            CreateSharedLinkWithSettingsError::SettingsError(inner) => write!(f, "There is an error with the given settings: {}", inner),
+            CreateSharedLinkWithSettingsError::AccessDenied => f.write_str("Access to the requested path is forbidden."),
+            _ => write!(f, "{:?}", *self),
+        }
     }
 }
 
@@ -3770,7 +3798,13 @@ impl ::std::error::Error for FileMemberActionError {
 
 impl ::std::fmt::Display for FileMemberActionError {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
-        write!(f, "{:?}", *self)
+        match self {
+            FileMemberActionError::InvalidMember => f.write_str("Specified member was not found."),
+            FileMemberActionError::NoPermission => f.write_str("User does not have permission to perform this action on this member."),
+            FileMemberActionError::AccessError(inner) => write!(f, "Specified file was invalid or user does not have access: {}", inner),
+            FileMemberActionError::NoExplicitAccess(inner) => write!(f, "The action cannot be completed because the target member does not have explicit access to the file. The return value is the access that the member has to the file from a parent folder: {:?}", inner),
+            _ => write!(f, "{:?}", *self),
+        }
     }
 }
 
@@ -5581,7 +5615,12 @@ impl ::std::error::Error for GetSharedLinkFileError {
 
 impl ::std::fmt::Display for GetSharedLinkFileError {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
-        write!(f, "{:?}", *self)
+        match self {
+            GetSharedLinkFileError::SharedLinkNotFound => f.write_str("The shared link wasn't found."),
+            GetSharedLinkFileError::SharedLinkAccessDenied => f.write_str("The caller is not allowed to access this shared link."),
+            GetSharedLinkFileError::SharedLinkIsDirectory => f.write_str("Directories cannot be retrieved by this endpoint."),
+            _ => write!(f, "{:?}", *self),
+        }
     }
 }
 
@@ -9102,7 +9141,10 @@ impl ::std::error::Error for ListFilesContinueError {
 
 impl ::std::fmt::Display for ListFilesContinueError {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
-        write!(f, "{:?}", *self)
+        match self {
+            ListFilesContinueError::UserError(inner) => write!(f, "User account had a problem: {}", inner),
+            _ => write!(f, "{:?}", *self),
+        }
     }
 }
 
@@ -11271,7 +11313,12 @@ impl ::std::error::Error for ModifySharedLinkSettingsError {
 
 impl ::std::fmt::Display for ModifySharedLinkSettingsError {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
-        write!(f, "{:?}", *self)
+        match self {
+            ModifySharedLinkSettingsError::SharedLinkNotFound => f.write_str("The shared link wasn't found."),
+            ModifySharedLinkSettingsError::SharedLinkAccessDenied => f.write_str("The caller is not allowed to access this shared link."),
+            ModifySharedLinkSettingsError::SettingsError(inner) => write!(f, "There is an error with the given settings: {}", inner),
+            _ => write!(f, "{:?}", *self),
+        }
     }
 }
 
@@ -11502,7 +11549,14 @@ impl ::std::error::Error for MountFolderError {
 
 impl ::std::fmt::Display for MountFolderError {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
-        write!(f, "{:?}", *self)
+        match self {
+            MountFolderError::InsideSharedFolder => f.write_str("Mounting would cause a shared folder to be inside another, which is disallowed."),
+            MountFolderError::InsufficientQuota(inner) => write!(f, "The current user does not have enough space to mount the shared folder: {:?}", inner),
+            MountFolderError::AlreadyMounted => f.write_str("The shared folder is already mounted."),
+            MountFolderError::NoPermission => f.write_str("The current user does not have permission to perform this action."),
+            MountFolderError::NotMountable => f.write_str("The shared folder is not mountable. One example where this can occur is when the shared folder belongs within a team folder in the user's Dropbox."),
+            _ => write!(f, "{:?}", *self),
+        }
     }
 }
 
@@ -12269,7 +12323,11 @@ impl ::std::error::Error for RelinquishFileMembershipError {
 
 impl ::std::fmt::Display for RelinquishFileMembershipError {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
-        write!(f, "{:?}", *self)
+        match self {
+            RelinquishFileMembershipError::GroupAccess => f.write_str("The current user has access to the shared file via a group.  You can't relinquish membership to a file shared via groups."),
+            RelinquishFileMembershipError::NoPermission => f.write_str("The current user does not have permission to perform this action."),
+            _ => write!(f, "{:?}", *self),
+        }
     }
 }
 
@@ -12536,7 +12594,15 @@ impl ::std::error::Error for RelinquishFolderMembershipError {
 
 impl ::std::fmt::Display for RelinquishFolderMembershipError {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
-        write!(f, "{:?}", *self)
+        match self {
+            RelinquishFolderMembershipError::FolderOwner => f.write_str("The current user is the owner of the shared folder. Owners cannot relinquish membership to their own folders. Try unsharing or transferring ownership first."),
+            RelinquishFolderMembershipError::Mounted => f.write_str("The shared folder is currently mounted.  Unmount the shared folder before relinquishing membership."),
+            RelinquishFolderMembershipError::GroupAccess => f.write_str("The current user has access to the shared folder via a group.  You can't relinquish membership to folders shared via groups."),
+            RelinquishFolderMembershipError::TeamFolder => f.write_str("This action cannot be performed on a team shared folder."),
+            RelinquishFolderMembershipError::NoPermission => f.write_str("The current user does not have permission to perform this action."),
+            RelinquishFolderMembershipError::NoExplicitAccess => f.write_str("The current user only has inherited access to the shared folder.  You can't relinquish inherited membership to folders."),
+            _ => write!(f, "{:?}", *self),
+        }
     }
 }
 
@@ -12749,7 +12815,10 @@ impl ::std::error::Error for RemoveFileMemberError {
 
 impl ::std::fmt::Display for RemoveFileMemberError {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
-        write!(f, "{:?}", *self)
+        match self {
+            RemoveFileMemberError::NoExplicitAccess(inner) => write!(f, "This member does not have explicit access to the file and therefore cannot be removed. The return value is the access that a user might have to the file from a parent folder: {:?}", inner),
+            _ => write!(f, "{:?}", *self),
+        }
     }
 }
 
@@ -13032,7 +13101,14 @@ impl ::std::error::Error for RemoveFolderMemberError {
 
 impl ::std::fmt::Display for RemoveFolderMemberError {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
-        write!(f, "{:?}", *self)
+        match self {
+            RemoveFolderMemberError::FolderOwner => f.write_str("The target user is the owner of the shared folder. You can't remove this user until ownership has been transferred to another member."),
+            RemoveFolderMemberError::GroupAccess => f.write_str("The target user has access to the shared folder via a group."),
+            RemoveFolderMemberError::TeamFolder => f.write_str("This action cannot be performed on a team shared folder."),
+            RemoveFolderMemberError::NoPermission => f.write_str("The current user does not have permission to perform this action."),
+            RemoveFolderMemberError::TooManyFiles => f.write_str("This shared folder has too many files for leaving a copy. You can still remove this user without leaving a copy."),
+            _ => write!(f, "{:?}", *self),
+        }
     }
 }
 
@@ -13589,7 +13665,12 @@ impl ::std::error::Error for RevokeSharedLinkError {
 
 impl ::std::fmt::Display for RevokeSharedLinkError {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
-        write!(f, "{:?}", *self)
+        match self {
+            RevokeSharedLinkError::SharedLinkNotFound => f.write_str("The shared link wasn't found."),
+            RevokeSharedLinkError::SharedLinkAccessDenied => f.write_str("The caller is not allowed to access this shared link."),
+            RevokeSharedLinkError::SharedLinkMalformed => f.write_str("Shared link is malformed."),
+            _ => write!(f, "{:?}", *self),
+        }
     }
 }
 
@@ -13788,7 +13869,11 @@ impl ::std::error::Error for SetAccessInheritanceError {
 
 impl ::std::fmt::Display for SetAccessInheritanceError {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
-        write!(f, "{:?}", *self)
+        match self {
+            SetAccessInheritanceError::AccessError(inner) => write!(f, "Unable to access shared folder: {}", inner),
+            SetAccessInheritanceError::NoPermission => f.write_str("The current user does not have permission to perform this action."),
+            _ => write!(f, "{:?}", *self),
+        }
     }
 }
 
@@ -14359,7 +14444,10 @@ impl ::std::error::Error for ShareFolderError {
 
 impl ::std::fmt::Display for ShareFolderError {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
-        write!(f, "{:?}", *self)
+        match self {
+            ShareFolderError::NoPermission => f.write_str("The current user does not have permission to perform this action."),
+            _ => write!(f, "{:?}", *self),
+        }
     }
 }
 
@@ -14854,7 +14942,24 @@ impl ::std::error::Error for SharePathError {
 
 impl ::std::fmt::Display for SharePathError {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
-        write!(f, "{:?}", *self)
+        match self {
+            SharePathError::IsFile => f.write_str("A file is at the specified path."),
+            SharePathError::InsideSharedFolder => f.write_str("We do not support sharing a folder inside a shared folder."),
+            SharePathError::ContainsSharedFolder => f.write_str("We do not support shared folders that contain shared folders."),
+            SharePathError::ContainsAppFolder => f.write_str("We do not support shared folders that contain app folders."),
+            SharePathError::ContainsTeamFolder => f.write_str("We do not support shared folders that contain team folders."),
+            SharePathError::IsAppFolder => f.write_str("We do not support sharing an app folder."),
+            SharePathError::InsideAppFolder => f.write_str("We do not support sharing a folder inside an app folder."),
+            SharePathError::IsPublicFolder => f.write_str("A public folder can't be shared this way. Use a public link instead."),
+            SharePathError::InsidePublicFolder => f.write_str("A folder inside a public folder can't be shared this way. Use a public link instead."),
+            SharePathError::AlreadyShared(inner) => write!(f, "Folder is already shared. Contains metadata about the existing shared folder: {:?}", inner),
+            SharePathError::InvalidPath => f.write_str("Path is not valid."),
+            SharePathError::IsOsxPackage => f.write_str("We do not support sharing a Mac OS X package."),
+            SharePathError::InsideOsxPackage => f.write_str("We do not support sharing a folder inside a Mac OS X package."),
+            SharePathError::IsVault => f.write_str("We do not support sharing the Vault folder."),
+            SharePathError::IsFamily => f.write_str("We do not support sharing the Family folder."),
+            _ => write!(f, "{:?}", *self),
+        }
     }
 }
 
@@ -15860,7 +15965,13 @@ impl ::std::error::Error for SharedFolderAccessError {
 
 impl ::std::fmt::Display for SharedFolderAccessError {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
-        write!(f, "{:?}", *self)
+        match self {
+            SharedFolderAccessError::InvalidId => f.write_str("This shared folder ID is invalid."),
+            SharedFolderAccessError::NotAMember => f.write_str("The user is not a member of the shared folder thus cannot access it."),
+            SharedFolderAccessError::EmailUnverified => f.write_str("Never set."),
+            SharedFolderAccessError::Unmounted => f.write_str("The shared folder is unmounted."),
+            _ => write!(f, "{:?}", *self),
+        }
     }
 }
 
@@ -15952,7 +16063,12 @@ impl ::std::error::Error for SharedFolderMemberError {
 
 impl ::std::fmt::Display for SharedFolderMemberError {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
-        write!(f, "{:?}", *self)
+        match self {
+            SharedFolderMemberError::InvalidDropboxId => f.write_str("The target dropbox_id is invalid."),
+            SharedFolderMemberError::NotAMember => f.write_str("The target dropbox_id is not a member of the shared folder."),
+            SharedFolderMemberError::NoExplicitAccess(inner) => write!(f, "The target member only has inherited access to the shared folder: {:?}", inner),
+            _ => write!(f, "{:?}", *self),
+        }
     }
 }
 
@@ -16919,7 +17035,11 @@ impl ::std::error::Error for SharedLinkError {
 
 impl ::std::fmt::Display for SharedLinkError {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
-        write!(f, "{:?}", *self)
+        match self {
+            SharedLinkError::SharedLinkNotFound => f.write_str("The shared link wasn't found."),
+            SharedLinkError::SharedLinkAccessDenied => f.write_str("The caller is not allowed to access this shared link."),
+            _ => write!(f, "{:?}", *self),
+        }
     }
 }
 
@@ -17451,7 +17571,14 @@ impl ::std::error::Error for SharingFileAccessError {
 
 impl ::std::fmt::Display for SharingFileAccessError {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
-        write!(f, "{:?}", *self)
+        match self {
+            SharingFileAccessError::NoPermission => f.write_str("Current user does not have sufficient privileges to perform the desired action."),
+            SharingFileAccessError::InvalidFile => f.write_str("File specified was not found."),
+            SharingFileAccessError::IsFolder => f.write_str("A folder can't be shared this way. Use folder sharing or a shared link instead."),
+            SharingFileAccessError::InsidePublicFolder => f.write_str("A file inside a public folder can't be shared this way. Use a public link instead."),
+            SharingFileAccessError::InsideOsxPackage => f.write_str("A Mac OS X package can't be shared this way. Use a shared link instead."),
+            _ => write!(f, "{:?}", *self),
+        }
     }
 }
 
@@ -17905,7 +18032,13 @@ impl ::std::error::Error for TransferFolderError {
 
 impl ::std::fmt::Display for TransferFolderError {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
-        write!(f, "{:?}", *self)
+        match self {
+            TransferFolderError::NewOwnerNotAMember => f.write_str("The new designated owner is not currently a member of the shared folder."),
+            TransferFolderError::NewOwnerUnmounted => f.write_str("The new designated owner has not added the folder to their Dropbox."),
+            TransferFolderError::TeamFolder => f.write_str("This action cannot be performed on a team shared folder."),
+            TransferFolderError::NoPermission => f.write_str("The current user does not have permission to perform this action."),
+            _ => write!(f, "{:?}", *self),
+        }
     }
 }
 
@@ -18099,7 +18232,11 @@ impl ::std::error::Error for UnmountFolderError {
 
 impl ::std::fmt::Display for UnmountFolderError {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
-        write!(f, "{:?}", *self)
+        match self {
+            UnmountFolderError::NoPermission => f.write_str("The current user does not have permission to perform this action."),
+            UnmountFolderError::NotUnmountable => f.write_str("The shared folder can't be unmounted. One example where this can occur is when the shared folder's parent folder is also a shared folder that resides in the current user's Dropbox."),
+            _ => write!(f, "{:?}", *self),
+        }
     }
 }
 
@@ -18511,7 +18648,12 @@ impl ::std::error::Error for UnshareFolderError {
 
 impl ::std::fmt::Display for UnshareFolderError {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
-        write!(f, "{:?}", *self)
+        match self {
+            UnshareFolderError::TeamFolder => f.write_str("This action cannot be performed on a team shared folder."),
+            UnshareFolderError::NoPermission => f.write_str("The current user does not have permission to perform this action."),
+            UnshareFolderError::TooManyFiles => f.write_str("This shared folder has too many files to be unshared."),
+            _ => write!(f, "{:?}", *self),
+        }
     }
 }
 
@@ -18890,7 +19032,12 @@ impl ::std::error::Error for UpdateFolderMemberError {
 
 impl ::std::fmt::Display for UpdateFolderMemberError {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
-        write!(f, "{:?}", *self)
+        match self {
+            UpdateFolderMemberError::NoExplicitAccess(inner) => write!(f, "If updating the access type required the member to be added to the shared folder and there was an error when adding the member: {}", inner),
+            UpdateFolderMemberError::InsufficientPlan => f.write_str("The current user's account doesn't support this action. An example of this is when downgrading a member from editor to viewer. This action can only be performed by users that have upgraded to a Pro or Business plan."),
+            UpdateFolderMemberError::NoPermission => f.write_str("The current user does not have permission to perform this action."),
+            _ => write!(f, "{:?}", *self),
+        }
     }
 }
 
@@ -19237,7 +19384,11 @@ impl ::std::error::Error for UpdateFolderPolicyError {
 
 impl ::std::fmt::Display for UpdateFolderPolicyError {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
-        write!(f, "{:?}", *self)
+        match self {
+            UpdateFolderPolicyError::NoPermission => f.write_str("The current user does not have permission to perform this action."),
+            UpdateFolderPolicyError::TeamFolder => f.write_str("This action cannot be performed on a team shared folder."),
+            _ => write!(f, "{:?}", *self),
+        }
     }
 }
 

--- a/src/generated/sharing.rs
+++ b/src/generated/sharing.rs
@@ -315,7 +315,7 @@ pub fn list_folder_members_continue(
 pub fn list_folders(
     client: &impl crate::client_trait::UserAuthClient,
     arg: &ListFoldersArgs,
-) -> crate::Result<Result<ListFoldersResult, ()>> {
+) -> crate::Result<Result<ListFoldersResult, crate::NoError>> {
     crate::client_helpers::request(
         client,
         crate::client_trait::Endpoint::Api,
@@ -345,7 +345,7 @@ pub fn list_folders_continue(
 pub fn list_mountable_folders(
     client: &impl crate::client_trait::UserAuthClient,
     arg: &ListFoldersArgs,
-) -> crate::Result<Result<ListFoldersResult, ()>> {
+) -> crate::Result<Result<ListFoldersResult, crate::NoError>> {
     crate::client_helpers::request(
         client,
         crate::client_trait::Endpoint::Api,

--- a/src/generated/team.rs
+++ b/src/generated/team.rs
@@ -1778,9 +1778,6 @@ impl ::serde::ser::Serialize for AddSecondaryEmailsError {
 }
 
 impl ::std::error::Error for AddSecondaryEmailsError {
-    fn description(&self) -> &str {
-        "AddSecondaryEmailsError"
-    }
 }
 
 impl ::std::fmt::Display for AddSecondaryEmailsError {
@@ -2327,8 +2324,13 @@ impl ::serde::ser::Serialize for BaseTeamFolderError {
 }
 
 impl ::std::error::Error for BaseTeamFolderError {
-    fn description(&self) -> &str {
-        "BaseTeamFolderError"
+    fn source(&self) -> Option<&(dyn ::std::error::Error + 'static)> {
+        match self {
+            BaseTeamFolderError::AccessError(inner) => Some(inner),
+            BaseTeamFolderError::StatusError(inner) => Some(inner),
+            BaseTeamFolderError::TeamSharedDropboxError(inner) => Some(inner),
+            _ => None,
+        }
     }
 }
 
@@ -2399,9 +2401,6 @@ impl ::serde::ser::Serialize for CustomQuotaError {
 }
 
 impl ::std::error::Error for CustomQuotaError {
-    fn description(&self) -> &str {
-        "CustomQuotaError"
-    }
 }
 
 impl ::std::fmt::Display for CustomQuotaError {
@@ -2725,9 +2724,6 @@ impl ::serde::ser::Serialize for DateRangeError {
 }
 
 impl ::std::error::Error for DateRangeError {
-    fn description(&self) -> &str {
-        "DateRangeError"
-    }
 }
 
 impl ::std::fmt::Display for DateRangeError {
@@ -4018,9 +4014,6 @@ impl ::serde::ser::Serialize for ExcludedUsersListContinueError {
 }
 
 impl ::std::error::Error for ExcludedUsersListContinueError {
-    fn description(&self) -> &str {
-        "ExcludedUsersListContinueError"
-    }
 }
 
 impl ::std::fmt::Display for ExcludedUsersListContinueError {
@@ -4090,9 +4083,6 @@ impl ::serde::ser::Serialize for ExcludedUsersListError {
 }
 
 impl ::std::error::Error for ExcludedUsersListError {
-    fn description(&self) -> &str {
-        "ExcludedUsersListError"
-    }
 }
 
 impl ::std::fmt::Display for ExcludedUsersListError {
@@ -4389,9 +4379,6 @@ impl ::serde::ser::Serialize for ExcludedUsersUpdateError {
 }
 
 impl ::std::error::Error for ExcludedUsersUpdateError {
-    fn description(&self) -> &str {
-        "ExcludedUsersUpdateError"
-    }
 }
 
 impl ::std::fmt::Display for ExcludedUsersUpdateError {
@@ -4914,9 +4901,6 @@ impl ::serde::ser::Serialize for FeaturesGetValuesBatchError {
 }
 
 impl ::std::error::Error for FeaturesGetValuesBatchError {
-    fn description(&self) -> &str {
-        "FeaturesGetValuesBatchError"
-    }
 }
 
 impl ::std::fmt::Display for FeaturesGetValuesBatchError {
@@ -6084,9 +6068,6 @@ impl ::serde::ser::Serialize for GroupCreateError {
 }
 
 impl ::std::error::Error for GroupCreateError {
-    fn description(&self) -> &str {
-        "GroupCreateError"
-    }
 }
 
 impl ::std::fmt::Display for GroupCreateError {
@@ -6181,9 +6162,6 @@ impl ::serde::ser::Serialize for GroupDeleteError {
 }
 
 impl ::std::error::Error for GroupDeleteError {
-    fn description(&self) -> &str {
-        "GroupDeleteError"
-    }
 }
 
 impl ::std::fmt::Display for GroupDeleteError {
@@ -6675,9 +6653,6 @@ impl ::serde::ser::Serialize for GroupMemberSelectorError {
 }
 
 impl ::std::error::Error for GroupMemberSelectorError {
-    fn description(&self) -> &str {
-        "GroupMemberSelectorError"
-    }
 }
 
 impl ::std::fmt::Display for GroupMemberSelectorError {
@@ -6785,9 +6760,6 @@ impl ::serde::ser::Serialize for GroupMemberSetAccessTypeError {
 }
 
 impl ::std::error::Error for GroupMemberSetAccessTypeError {
-    fn description(&self) -> &str {
-        "GroupMemberSetAccessTypeError"
-    }
 }
 
 impl ::std::fmt::Display for GroupMemberSetAccessTypeError {
@@ -7086,9 +7058,6 @@ impl ::serde::ser::Serialize for GroupMembersAddError {
 }
 
 impl ::std::error::Error for GroupMembersAddError {
-    fn description(&self) -> &str {
-        "GroupMembersAddError"
-    }
 }
 
 impl ::std::fmt::Display for GroupMembersAddError {
@@ -7461,9 +7430,6 @@ impl ::serde::ser::Serialize for GroupMembersRemoveError {
 }
 
 impl ::std::error::Error for GroupMembersRemoveError {
-    fn description(&self) -> &str {
-        "GroupMembersRemoveError"
-    }
 }
 
 impl ::std::fmt::Display for GroupMembersRemoveError {
@@ -7664,9 +7630,6 @@ impl ::serde::ser::Serialize for GroupMembersSelectorError {
 }
 
 impl ::std::error::Error for GroupMembersSelectorError {
-    fn description(&self) -> &str {
-        "GroupMembersSelectorError"
-    }
 }
 
 impl ::std::fmt::Display for GroupMembersSelectorError {
@@ -7944,9 +7907,6 @@ impl ::serde::ser::Serialize for GroupSelectorError {
 }
 
 impl ::std::error::Error for GroupSelectorError {
-    fn description(&self) -> &str {
-        "GroupSelectorError"
-    }
 }
 
 impl ::std::fmt::Display for GroupSelectorError {
@@ -8030,9 +7990,6 @@ impl ::serde::ser::Serialize for GroupSelectorWithTeamGroupError {
 }
 
 impl ::std::error::Error for GroupSelectorWithTeamGroupError {
-    fn description(&self) -> &str {
-        "GroupSelectorWithTeamGroupError"
-    }
 }
 
 impl ::std::fmt::Display for GroupSelectorWithTeamGroupError {
@@ -8324,9 +8281,6 @@ impl ::serde::ser::Serialize for GroupUpdateError {
 }
 
 impl ::std::error::Error for GroupUpdateError {
-    fn description(&self) -> &str {
-        "GroupUpdateError"
-    }
 }
 
 impl ::std::fmt::Display for GroupUpdateError {
@@ -8395,9 +8349,6 @@ impl ::serde::ser::Serialize for GroupsGetInfoError {
 }
 
 impl ::std::error::Error for GroupsGetInfoError {
-    fn description(&self) -> &str {
-        "GroupsGetInfoError"
-    }
 }
 
 impl ::std::fmt::Display for GroupsGetInfoError {
@@ -8709,9 +8660,6 @@ impl ::serde::ser::Serialize for GroupsListContinueError {
 }
 
 impl ::std::error::Error for GroupsListContinueError {
-    fn description(&self) -> &str {
-        "GroupsListContinueError"
-    }
 }
 
 impl ::std::fmt::Display for GroupsListContinueError {
@@ -9099,9 +9047,6 @@ impl ::serde::ser::Serialize for GroupsMembersListContinueError {
 }
 
 impl ::std::error::Error for GroupsMembersListContinueError {
-    fn description(&self) -> &str {
-        "GroupsMembersListContinueError"
-    }
 }
 
 impl ::std::fmt::Display for GroupsMembersListContinueError {
@@ -9314,9 +9259,6 @@ impl ::serde::ser::Serialize for GroupsPollError {
 }
 
 impl ::std::error::Error for GroupsPollError {
-    fn description(&self) -> &str {
-        "GroupsPollError"
-    }
 }
 
 impl ::std::fmt::Display for GroupsPollError {
@@ -10296,9 +10238,6 @@ impl ::serde::ser::Serialize for LegalHoldsError {
 }
 
 impl ::std::error::Error for LegalHoldsError {
-    fn description(&self) -> &str {
-        "LegalHoldsError"
-    }
 }
 
 impl ::std::fmt::Display for LegalHoldsError {
@@ -10483,9 +10422,6 @@ impl ::serde::ser::Serialize for LegalHoldsGetPolicyError {
 }
 
 impl ::std::error::Error for LegalHoldsGetPolicyError {
-    fn description(&self) -> &str {
-        "LegalHoldsGetPolicyError"
-    }
 }
 
 impl ::std::fmt::Display for LegalHoldsGetPolicyError {
@@ -10905,9 +10841,6 @@ impl ::serde::ser::Serialize for LegalHoldsListHeldRevisionsContinueError {
 }
 
 impl ::std::error::Error for LegalHoldsListHeldRevisionsContinueError {
-    fn description(&self) -> &str {
-        "LegalHoldsListHeldRevisionsContinueError"
-    }
 }
 
 impl ::std::fmt::Display for LegalHoldsListHeldRevisionsContinueError {
@@ -11028,9 +10961,6 @@ impl ::serde::ser::Serialize for LegalHoldsListHeldRevisionsError {
 }
 
 impl ::std::error::Error for LegalHoldsListHeldRevisionsError {
-    fn description(&self) -> &str {
-        "LegalHoldsListHeldRevisionsError"
-    }
 }
 
 impl ::std::fmt::Display for LegalHoldsListHeldRevisionsError {
@@ -11211,9 +11141,6 @@ impl ::serde::ser::Serialize for LegalHoldsListPoliciesError {
 }
 
 impl ::std::error::Error for LegalHoldsListPoliciesError {
-    fn description(&self) -> &str {
-        "LegalHoldsListPoliciesError"
-    }
 }
 
 impl ::std::fmt::Display for LegalHoldsListPoliciesError {
@@ -11645,9 +11572,6 @@ impl ::serde::ser::Serialize for LegalHoldsPolicyCreateError {
 }
 
 impl ::std::error::Error for LegalHoldsPolicyCreateError {
-    fn description(&self) -> &str {
-        "LegalHoldsPolicyCreateError"
-    }
 }
 
 impl ::std::fmt::Display for LegalHoldsPolicyCreateError {
@@ -11859,9 +11783,6 @@ impl ::serde::ser::Serialize for LegalHoldsPolicyReleaseError {
 }
 
 impl ::std::error::Error for LegalHoldsPolicyReleaseError {
-    fn description(&self) -> &str {
-        "LegalHoldsPolicyReleaseError"
-    }
 }
 
 impl ::std::fmt::Display for LegalHoldsPolicyReleaseError {
@@ -12179,9 +12100,6 @@ impl ::serde::ser::Serialize for LegalHoldsPolicyUpdateError {
 }
 
 impl ::std::error::Error for LegalHoldsPolicyUpdateError {
-    fn description(&self) -> &str {
-        "LegalHoldsPolicyUpdateError"
-    }
 }
 
 impl ::std::fmt::Display for LegalHoldsPolicyUpdateError {
@@ -12342,9 +12260,6 @@ impl ::serde::ser::Serialize for ListMemberAppsError {
 }
 
 impl ::std::error::Error for ListMemberAppsError {
-    fn description(&self) -> &str {
-        "ListMemberAppsError"
-    }
 }
 
 impl ::std::fmt::Display for ListMemberAppsError {
@@ -12647,9 +12562,6 @@ impl ::serde::ser::Serialize for ListMemberDevicesError {
 }
 
 impl ::std::error::Error for ListMemberDevicesError {
-    fn description(&self) -> &str {
-        "ListMemberDevicesError"
-    }
 }
 
 impl ::std::fmt::Display for ListMemberDevicesError {
@@ -12935,9 +12847,6 @@ impl ::serde::ser::Serialize for ListMembersAppsError {
 }
 
 impl ::std::error::Error for ListMembersAppsError {
-    fn description(&self) -> &str {
-        "ListMembersAppsError"
-    }
 }
 
 impl ::std::fmt::Display for ListMembersAppsError {
@@ -13278,9 +13187,6 @@ impl ::serde::ser::Serialize for ListMembersDevicesError {
 }
 
 impl ::std::error::Error for ListMembersDevicesError {
-    fn description(&self) -> &str {
-        "ListMembersDevicesError"
-    }
 }
 
 impl ::std::fmt::Display for ListMembersDevicesError {
@@ -13566,9 +13472,6 @@ impl ::serde::ser::Serialize for ListTeamAppsError {
 }
 
 impl ::std::error::Error for ListTeamAppsError {
-    fn description(&self) -> &str {
-        "ListTeamAppsError"
-    }
 }
 
 impl ::std::fmt::Display for ListTeamAppsError {
@@ -13909,9 +13812,6 @@ impl ::serde::ser::Serialize for ListTeamDevicesError {
 }
 
 impl ::std::error::Error for ListTeamDevicesError {
-    fn description(&self) -> &str {
-        "ListTeamDevicesError"
-    }
 }
 
 impl ::std::fmt::Display for ListTeamDevicesError {
@@ -15237,9 +15137,6 @@ impl ::serde::ser::Serialize for MemberSelectorError {
 }
 
 impl ::std::error::Error for MemberSelectorError {
-    fn description(&self) -> &str {
-        "MemberSelectorError"
-    }
 }
 
 impl ::std::fmt::Display for MemberSelectorError {
@@ -15907,9 +15804,6 @@ impl ::serde::ser::Serialize for MembersDeactivateError {
 }
 
 impl ::std::error::Error for MembersDeactivateError {
-    fn description(&self) -> &str {
-        "MembersDeactivateError"
-    }
 }
 
 impl ::std::fmt::Display for MembersDeactivateError {
@@ -16095,9 +15989,6 @@ impl ::serde::ser::Serialize for MembersDeleteProfilePhotoError {
 }
 
 impl ::std::error::Error for MembersDeleteProfilePhotoError {
-    fn description(&self) -> &str {
-        "MembersDeleteProfilePhotoError"
-    }
 }
 
 impl ::std::fmt::Display for MembersDeleteProfilePhotoError {
@@ -16240,9 +16131,6 @@ impl ::serde::ser::Serialize for MembersGetInfoError {
 }
 
 impl ::std::error::Error for MembersGetInfoError {
-    fn description(&self) -> &str {
-        "MembersGetInfoError"
-    }
 }
 
 impl ::std::fmt::Display for MembersGetInfoError {
@@ -16680,9 +16568,6 @@ impl ::serde::ser::Serialize for MembersListContinueError {
 }
 
 impl ::std::error::Error for MembersListContinueError {
-    fn description(&self) -> &str {
-        "MembersListContinueError"
-    }
 }
 
 impl ::std::fmt::Display for MembersListContinueError {
@@ -16735,9 +16620,6 @@ impl ::serde::ser::Serialize for MembersListError {
 }
 
 impl ::std::error::Error for MembersListError {
-    fn description(&self) -> &str {
-        "MembersListError"
-    }
 }
 
 impl ::std::fmt::Display for MembersListError {
@@ -17056,9 +16938,6 @@ impl ::serde::ser::Serialize for MembersRecoverError {
 }
 
 impl ::std::error::Error for MembersRecoverError {
-    fn description(&self) -> &str {
-        "MembersRecoverError"
-    }
 }
 
 impl ::std::fmt::Display for MembersRecoverError {
@@ -17594,9 +17473,6 @@ impl ::serde::ser::Serialize for MembersRemoveError {
 }
 
 impl ::std::error::Error for MembersRemoveError {
-    fn description(&self) -> &str {
-        "MembersRemoveError"
-    }
 }
 
 impl ::std::fmt::Display for MembersRemoveError {
@@ -17680,9 +17556,6 @@ impl ::serde::ser::Serialize for MembersSendWelcomeError {
 }
 
 impl ::std::error::Error for MembersSendWelcomeError {
-    fn description(&self) -> &str {
-        "MembersSendWelcomeError"
-    }
 }
 
 impl ::std::fmt::Display for MembersSendWelcomeError {
@@ -17909,9 +17782,6 @@ impl ::serde::ser::Serialize for MembersSetPermissionsError {
 }
 
 impl ::std::error::Error for MembersSetPermissionsError {
-    fn description(&self) -> &str {
-        "MembersSetPermissionsError"
-    }
 }
 
 impl ::std::fmt::Display for MembersSetPermissionsError {
@@ -18417,9 +18287,6 @@ impl ::serde::ser::Serialize for MembersSetProfileError {
 }
 
 impl ::std::error::Error for MembersSetProfileError {
-    fn description(&self) -> &str {
-        "MembersSetProfileError"
-    }
 }
 
 impl ::std::fmt::Display for MembersSetProfileError {
@@ -18634,8 +18501,11 @@ impl ::serde::ser::Serialize for MembersSetProfilePhotoError {
 }
 
 impl ::std::error::Error for MembersSetProfilePhotoError {
-    fn description(&self) -> &str {
-        "MembersSetProfilePhotoError"
+    fn source(&self) -> Option<&(dyn ::std::error::Error + 'static)> {
+        match self {
+            MembersSetProfilePhotoError::PhotoError(inner) => Some(inner),
+            _ => None,
+        }
     }
 }
 
@@ -18758,9 +18628,6 @@ impl ::serde::ser::Serialize for MembersSuspendError {
 }
 
 impl ::std::error::Error for MembersSuspendError {
-    fn description(&self) -> &str {
-        "MembersSuspendError"
-    }
 }
 
 impl ::std::fmt::Display for MembersSuspendError {
@@ -18960,9 +18827,6 @@ impl ::serde::ser::Serialize for MembersTransferFilesError {
 }
 
 impl ::std::error::Error for MembersTransferFilesError {
-    fn description(&self) -> &str {
-        "MembersTransferFilesError"
-    }
 }
 
 impl ::std::fmt::Display for MembersTransferFilesError {
@@ -19214,9 +19078,6 @@ impl ::serde::ser::Serialize for MembersTransferFormerMembersFilesError {
 }
 
 impl ::std::error::Error for MembersTransferFormerMembersFilesError {
-    fn description(&self) -> &str {
-        "MembersTransferFormerMembersFilesError"
-    }
 }
 
 impl ::std::fmt::Display for MembersTransferFormerMembersFilesError {
@@ -19417,9 +19278,6 @@ impl ::serde::ser::Serialize for MembersUnsuspendError {
 }
 
 impl ::std::error::Error for MembersUnsuspendError {
-    fn description(&self) -> &str {
-        "MembersUnsuspendError"
-    }
 }
 
 impl ::std::fmt::Display for MembersUnsuspendError {
@@ -20813,9 +20671,6 @@ impl ::serde::ser::Serialize for RevokeDeviceSessionBatchError {
 }
 
 impl ::std::error::Error for RevokeDeviceSessionBatchError {
-    fn description(&self) -> &str {
-        "RevokeDeviceSessionBatchError"
-    }
 }
 
 impl ::std::fmt::Display for RevokeDeviceSessionBatchError {
@@ -20986,9 +20841,6 @@ impl ::serde::ser::Serialize for RevokeDeviceSessionError {
 }
 
 impl ::std::error::Error for RevokeDeviceSessionError {
-    fn description(&self) -> &str {
-        "RevokeDeviceSessionError"
-    }
 }
 
 impl ::std::fmt::Display for RevokeDeviceSessionError {
@@ -21361,9 +21213,6 @@ impl ::serde::ser::Serialize for RevokeLinkedAppBatchError {
 }
 
 impl ::std::error::Error for RevokeLinkedAppBatchError {
-    fn description(&self) -> &str {
-        "RevokeLinkedAppBatchError"
-    }
 }
 
 impl ::std::fmt::Display for RevokeLinkedAppBatchError {
@@ -21548,9 +21397,6 @@ impl ::serde::ser::Serialize for RevokeLinkedAppError {
 }
 
 impl ::std::error::Error for RevokeLinkedAppError {
-    fn description(&self) -> &str {
-        "RevokeLinkedAppError"
-    }
 }
 
 impl ::std::fmt::Display for RevokeLinkedAppError {
@@ -21831,9 +21677,6 @@ impl ::serde::ser::Serialize for SetCustomQuotaError {
 }
 
 impl ::std::error::Error for SetCustomQuotaError {
-    fn description(&self) -> &str {
-        "SetCustomQuotaError"
-    }
 }
 
 impl ::std::fmt::Display for SetCustomQuotaError {
@@ -22020,9 +21863,6 @@ impl ::serde::ser::Serialize for TeamFolderAccessError {
 }
 
 impl ::std::error::Error for TeamFolderAccessError {
-    fn description(&self) -> &str {
-        "TeamFolderAccessError"
-    }
 }
 
 impl ::std::fmt::Display for TeamFolderAccessError {
@@ -22127,8 +21967,13 @@ impl ::serde::ser::Serialize for TeamFolderActivateError {
 }
 
 impl ::std::error::Error for TeamFolderActivateError {
-    fn description(&self) -> &str {
-        "TeamFolderActivateError"
+    fn source(&self) -> Option<&(dyn ::std::error::Error + 'static)> {
+        match self {
+            TeamFolderActivateError::AccessError(inner) => Some(inner),
+            TeamFolderActivateError::StatusError(inner) => Some(inner),
+            TeamFolderActivateError::TeamSharedDropboxError(inner) => Some(inner),
+            _ => None,
+        }
     }
 }
 
@@ -22342,8 +22187,13 @@ impl ::serde::ser::Serialize for TeamFolderArchiveError {
 }
 
 impl ::std::error::Error for TeamFolderArchiveError {
-    fn description(&self) -> &str {
-        "TeamFolderArchiveError"
+    fn source(&self) -> Option<&(dyn ::std::error::Error + 'static)> {
+        match self {
+            TeamFolderArchiveError::AccessError(inner) => Some(inner),
+            TeamFolderArchiveError::StatusError(inner) => Some(inner),
+            TeamFolderArchiveError::TeamSharedDropboxError(inner) => Some(inner),
+            _ => None,
+        }
     }
 }
 
@@ -22709,8 +22559,11 @@ impl ::serde::ser::Serialize for TeamFolderCreateError {
 }
 
 impl ::std::error::Error for TeamFolderCreateError {
-    fn description(&self) -> &str {
-        "TeamFolderCreateError"
+    fn source(&self) -> Option<&(dyn ::std::error::Error + 'static)> {
+        match self {
+            TeamFolderCreateError::SyncSettingsError(inner) => Some(inner),
+            _ => None,
+        }
     }
 }
 
@@ -23052,9 +22905,6 @@ impl ::serde::ser::Serialize for TeamFolderInvalidStatusError {
 }
 
 impl ::std::error::Error for TeamFolderInvalidStatusError {
-    fn description(&self) -> &str {
-        "TeamFolderInvalidStatusError"
-    }
 }
 
 impl ::std::fmt::Display for TeamFolderInvalidStatusError {
@@ -23299,9 +23149,6 @@ impl ::serde::ser::Serialize for TeamFolderListContinueError {
 }
 
 impl ::std::error::Error for TeamFolderListContinueError {
-    fn description(&self) -> &str {
-        "TeamFolderListContinueError"
-    }
 }
 
 impl ::std::fmt::Display for TeamFolderListContinueError {
@@ -23778,8 +23625,13 @@ impl ::serde::ser::Serialize for TeamFolderPermanentlyDeleteError {
 }
 
 impl ::std::error::Error for TeamFolderPermanentlyDeleteError {
-    fn description(&self) -> &str {
-        "TeamFolderPermanentlyDeleteError"
+    fn source(&self) -> Option<&(dyn ::std::error::Error + 'static)> {
+        match self {
+            TeamFolderPermanentlyDeleteError::AccessError(inner) => Some(inner),
+            TeamFolderPermanentlyDeleteError::StatusError(inner) => Some(inner),
+            TeamFolderPermanentlyDeleteError::TeamSharedDropboxError(inner) => Some(inner),
+            _ => None,
+        }
     }
 }
 
@@ -24026,8 +23878,13 @@ impl ::serde::ser::Serialize for TeamFolderRenameError {
 }
 
 impl ::std::error::Error for TeamFolderRenameError {
-    fn description(&self) -> &str {
-        "TeamFolderRenameError"
+    fn source(&self) -> Option<&(dyn ::std::error::Error + 'static)> {
+        match self {
+            TeamFolderRenameError::AccessError(inner) => Some(inner),
+            TeamFolderRenameError::StatusError(inner) => Some(inner),
+            TeamFolderRenameError::TeamSharedDropboxError(inner) => Some(inner),
+            _ => None,
+        }
     }
 }
 
@@ -24182,9 +24039,6 @@ impl ::serde::ser::Serialize for TeamFolderTeamSharedDropboxError {
 }
 
 impl ::std::error::Error for TeamFolderTeamSharedDropboxError {
-    fn description(&self) -> &str {
-        "TeamFolderTeamSharedDropboxError"
-    }
 }
 
 impl ::std::fmt::Display for TeamFolderTeamSharedDropboxError {
@@ -24435,8 +24289,14 @@ impl ::serde::ser::Serialize for TeamFolderUpdateSyncSettingsError {
 }
 
 impl ::std::error::Error for TeamFolderUpdateSyncSettingsError {
-    fn description(&self) -> &str {
-        "TeamFolderUpdateSyncSettingsError"
+    fn source(&self) -> Option<&(dyn ::std::error::Error + 'static)> {
+        match self {
+            TeamFolderUpdateSyncSettingsError::AccessError(inner) => Some(inner),
+            TeamFolderUpdateSyncSettingsError::StatusError(inner) => Some(inner),
+            TeamFolderUpdateSyncSettingsError::TeamSharedDropboxError(inner) => Some(inner),
+            TeamFolderUpdateSyncSettingsError::SyncSettingsError(inner) => Some(inner),
+            _ => None,
+        }
     }
 }
 
@@ -25461,9 +25321,6 @@ impl ::serde::ser::Serialize for TeamNamespacesListContinueError {
 }
 
 impl ::std::error::Error for TeamNamespacesListContinueError {
-    fn description(&self) -> &str {
-        "TeamNamespacesListContinueError"
-    }
 }
 
 impl ::std::fmt::Display for TeamNamespacesListContinueError {
@@ -25532,9 +25389,6 @@ impl ::serde::ser::Serialize for TeamNamespacesListError {
 }
 
 impl ::std::error::Error for TeamNamespacesListError {
-    fn description(&self) -> &str {
-        "TeamNamespacesListError"
-    }
 }
 
 impl ::std::fmt::Display for TeamNamespacesListError {
@@ -25825,9 +25679,6 @@ impl ::serde::ser::Serialize for TokenGetAuthenticatedAdminError {
 }
 
 impl ::std::error::Error for TokenGetAuthenticatedAdminError {
-    fn description(&self) -> &str {
-        "TokenGetAuthenticatedAdminError"
-    }
 }
 
 impl ::std::fmt::Display for TokenGetAuthenticatedAdminError {
@@ -27025,9 +26876,6 @@ impl ::serde::ser::Serialize for UserSelectorError {
 }
 
 impl ::std::error::Error for UserSelectorError {
-    fn description(&self) -> &str {
-        "UserSelectorError"
-    }
 }
 
 impl ::std::fmt::Display for UserSelectorError {

--- a/src/generated/team.rs
+++ b/src/generated/team.rs
@@ -23554,6 +23554,15 @@ impl ::serde::ser::Serialize for TeamFolderListError {
     }
 }
 
+impl ::std::error::Error for TeamFolderListError {
+}
+
+impl ::std::fmt::Display for TeamFolderListError {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
+        write!(f, "{:?}", *self)
+    }
+}
+
 /// Result for [`team_folder_list()`](team_folder_list) and
 /// [`team_folder_list_continue()`](team_folder_list_continue).
 #[derive(Debug, Clone, PartialEq)]

--- a/src/generated/team.rs
+++ b/src/generated/team.rs
@@ -7111,7 +7111,7 @@ impl ::std::fmt::Display for GroupMembersAddError {
             GroupMembersAddError::SystemManagedGroupDisallowed => f.write_str("This operation is not supported on system-managed groups."),
             GroupMembersAddError::DuplicateUser => f.write_str("You cannot add duplicate users. One or more of the members you are trying to add is already a member of the group."),
             GroupMembersAddError::GroupNotInTeam => f.write_str("Group is not in this team. You cannot add members to a group that is outside of your team."),
-            GroupMembersAddError::MembersNotInTeam(inner) => write!(f, "{:?}", inner),
+            GroupMembersAddError::MembersNotInTeam(inner) => write!(f, "members_not_in_team: {:?}", inner),
             GroupMembersAddError::UsersNotFound(inner) => write!(f, "These users were not found in Dropbox: {:?}", inner),
             GroupMembersAddError::UserCannotBeManagerOfCompanyManagedGroup(inner) => write!(f, "A company-managed group cannot be managed by a user: {:?}", inner),
             _ => write!(f, "{:?}", *self),

--- a/src/generated/team.rs
+++ b/src/generated/team.rs
@@ -2340,7 +2340,12 @@ impl ::std::error::Error for BaseTeamFolderError {
 
 impl ::std::fmt::Display for BaseTeamFolderError {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
-        write!(f, "{:?}", *self)
+        match self {
+            BaseTeamFolderError::AccessError(inner) => write!(f, "{}", inner),
+            BaseTeamFolderError::StatusError(inner) => write!(f, "{}", inner),
+            BaseTeamFolderError::TeamSharedDropboxError(inner) => write!(f, "{}", inner),
+            _ => write!(f, "{:?}", *self),
+        }
     }
 }
 
@@ -7106,6 +7111,7 @@ impl ::std::fmt::Display for GroupMembersAddError {
             GroupMembersAddError::SystemManagedGroupDisallowed => f.write_str("This operation is not supported on system-managed groups."),
             GroupMembersAddError::DuplicateUser => f.write_str("You cannot add duplicate users. One or more of the members you are trying to add is already a member of the group."),
             GroupMembersAddError::GroupNotInTeam => f.write_str("Group is not in this team. You cannot add members to a group that is outside of your team."),
+            GroupMembersAddError::MembersNotInTeam(inner) => write!(f, "{:?}", inner),
             GroupMembersAddError::UsersNotFound(inner) => write!(f, "These users were not found in Dropbox: {:?}", inner),
             GroupMembersAddError::UserCannotBeManagerOfCompanyManagedGroup(inner) => write!(f, "A company-managed group cannot be managed by a user: {:?}", inner),
             _ => write!(f, "{:?}", *self),
@@ -18727,6 +18733,7 @@ impl ::std::fmt::Display for MembersSetProfilePhotoError {
             MembersSetProfilePhotoError::UserNotFound => f.write_str("No matching user found. The provided team_member_id, email, or external_id does not exist on this team."),
             MembersSetProfilePhotoError::UserNotInTeam => f.write_str("The user is not a member of the team."),
             MembersSetProfilePhotoError::SetProfileDisallowed => f.write_str("Modifying deleted users is not allowed."),
+            MembersSetProfilePhotoError::PhotoError(inner) => write!(f, "{}", inner),
             _ => write!(f, "{:?}", *self),
         }
     }
@@ -22256,7 +22263,12 @@ impl ::std::error::Error for TeamFolderActivateError {
 
 impl ::std::fmt::Display for TeamFolderActivateError {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
-        write!(f, "{:?}", *self)
+        match self {
+            TeamFolderActivateError::AccessError(inner) => write!(f, "{}", inner),
+            TeamFolderActivateError::StatusError(inner) => write!(f, "{}", inner),
+            TeamFolderActivateError::TeamSharedDropboxError(inner) => write!(f, "{}", inner),
+            _ => write!(f, "{:?}", *self),
+        }
     }
 }
 
@@ -22476,7 +22488,12 @@ impl ::std::error::Error for TeamFolderArchiveError {
 
 impl ::std::fmt::Display for TeamFolderArchiveError {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
-        write!(f, "{:?}", *self)
+        match self {
+            TeamFolderArchiveError::AccessError(inner) => write!(f, "{}", inner),
+            TeamFolderArchiveError::StatusError(inner) => write!(f, "{}", inner),
+            TeamFolderArchiveError::TeamSharedDropboxError(inner) => write!(f, "{}", inner),
+            _ => write!(f, "{:?}", *self),
+        }
     }
 }
 
@@ -23928,7 +23945,12 @@ impl ::std::error::Error for TeamFolderPermanentlyDeleteError {
 
 impl ::std::fmt::Display for TeamFolderPermanentlyDeleteError {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
-        write!(f, "{:?}", *self)
+        match self {
+            TeamFolderPermanentlyDeleteError::AccessError(inner) => write!(f, "{}", inner),
+            TeamFolderPermanentlyDeleteError::StatusError(inner) => write!(f, "{}", inner),
+            TeamFolderPermanentlyDeleteError::TeamSharedDropboxError(inner) => write!(f, "{}", inner),
+            _ => write!(f, "{:?}", *self),
+        }
     }
 }
 
@@ -24182,6 +24204,9 @@ impl ::std::error::Error for TeamFolderRenameError {
 impl ::std::fmt::Display for TeamFolderRenameError {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match self {
+            TeamFolderRenameError::AccessError(inner) => write!(f, "{}", inner),
+            TeamFolderRenameError::StatusError(inner) => write!(f, "{}", inner),
+            TeamFolderRenameError::TeamSharedDropboxError(inner) => write!(f, "{}", inner),
             TeamFolderRenameError::InvalidFolderName => f.write_str("The provided folder name cannot be used."),
             TeamFolderRenameError::FolderNameAlreadyUsed => f.write_str("There is already a team folder with the same name."),
             TeamFolderRenameError::FolderNameReserved => f.write_str("The provided name cannot be used because it is reserved."),
@@ -24602,6 +24627,9 @@ impl ::std::error::Error for TeamFolderUpdateSyncSettingsError {
 impl ::std::fmt::Display for TeamFolderUpdateSyncSettingsError {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match self {
+            TeamFolderUpdateSyncSettingsError::AccessError(inner) => write!(f, "{}", inner),
+            TeamFolderUpdateSyncSettingsError::StatusError(inner) => write!(f, "{}", inner),
+            TeamFolderUpdateSyncSettingsError::TeamSharedDropboxError(inner) => write!(f, "{}", inner),
             TeamFolderUpdateSyncSettingsError::SyncSettingsError(inner) => write!(f, "An error occurred setting the sync settings: {}", inner),
             _ => write!(f, "{:?}", *self),
         }

--- a/src/generated/team.rs
+++ b/src/generated/team.rs
@@ -1782,7 +1782,11 @@ impl ::std::error::Error for AddSecondaryEmailsError {
 
 impl ::std::fmt::Display for AddSecondaryEmailsError {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
-        write!(f, "{:?}", *self)
+        match self {
+            AddSecondaryEmailsError::SecondaryEmailsDisabled => f.write_str("Secondary emails are disabled for the team."),
+            AddSecondaryEmailsError::TooManyEmails => f.write_str("A maximum of 20 secondary emails can be added in a single call."),
+            _ => write!(f, "{:?}", *self),
+        }
     }
 }
 
@@ -2405,7 +2409,10 @@ impl ::std::error::Error for CustomQuotaError {
 
 impl ::std::fmt::Display for CustomQuotaError {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
-        write!(f, "{:?}", *self)
+        match self {
+            CustomQuotaError::TooManyUsers => f.write_str("A maximum of 1000 users can be set for a single call."),
+            _ => write!(f, "{:?}", *self),
+        }
     }
 }
 
@@ -4018,7 +4025,10 @@ impl ::std::error::Error for ExcludedUsersListContinueError {
 
 impl ::std::fmt::Display for ExcludedUsersListContinueError {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
-        write!(f, "{:?}", *self)
+        match self {
+            ExcludedUsersListContinueError::InvalidCursor => f.write_str("The cursor is invalid."),
+            _ => write!(f, "{:?}", *self),
+        }
     }
 }
 
@@ -4087,7 +4097,10 @@ impl ::std::error::Error for ExcludedUsersListError {
 
 impl ::std::fmt::Display for ExcludedUsersListError {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
-        write!(f, "{:?}", *self)
+        match self {
+            ExcludedUsersListError::ListError => f.write_str("An error occurred."),
+            _ => write!(f, "{:?}", *self),
+        }
     }
 }
 
@@ -4383,7 +4396,11 @@ impl ::std::error::Error for ExcludedUsersUpdateError {
 
 impl ::std::fmt::Display for ExcludedUsersUpdateError {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
-        write!(f, "{:?}", *self)
+        match self {
+            ExcludedUsersUpdateError::UsersNotInTeam => f.write_str("At least one of the users is not part of your team."),
+            ExcludedUsersUpdateError::TooManyUsers => f.write_str("A maximum of 1000 users for each of addition/removal can be supplied."),
+            _ => write!(f, "{:?}", *self),
+        }
     }
 }
 
@@ -6072,7 +6089,13 @@ impl ::std::error::Error for GroupCreateError {
 
 impl ::std::fmt::Display for GroupCreateError {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
-        write!(f, "{:?}", *self)
+        match self {
+            GroupCreateError::GroupNameAlreadyUsed => f.write_str("The requested group name is already being used by another group."),
+            GroupCreateError::GroupNameInvalid => f.write_str("Group name is empty or has invalid characters."),
+            GroupCreateError::ExternalIdAlreadyInUse => f.write_str("The requested external ID is already being used by another group."),
+            GroupCreateError::SystemManagedGroupDisallowed => f.write_str("System-managed group cannot be manually created."),
+            _ => write!(f, "{:?}", *self),
+        }
     }
 }
 
@@ -6166,7 +6189,12 @@ impl ::std::error::Error for GroupDeleteError {
 
 impl ::std::fmt::Display for GroupDeleteError {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
-        write!(f, "{:?}", *self)
+        match self {
+            GroupDeleteError::GroupNotFound => f.write_str("No matching group found. No groups match the specified group ID."),
+            GroupDeleteError::SystemManagedGroupDisallowed => f.write_str("This operation is not supported on system-managed groups."),
+            GroupDeleteError::GroupAlreadyDeleted => f.write_str("This group has already been deleted."),
+            _ => write!(f, "{:?}", *self),
+        }
     }
 }
 
@@ -6657,7 +6685,12 @@ impl ::std::error::Error for GroupMemberSelectorError {
 
 impl ::std::fmt::Display for GroupMemberSelectorError {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
-        write!(f, "{:?}", *self)
+        match self {
+            GroupMemberSelectorError::GroupNotFound => f.write_str("No matching group found. No groups match the specified group ID."),
+            GroupMemberSelectorError::SystemManagedGroupDisallowed => f.write_str("This operation is not supported on system-managed groups."),
+            GroupMemberSelectorError::MemberNotInGroup => f.write_str("The specified user is not a member of this group."),
+            _ => write!(f, "{:?}", *self),
+        }
     }
 }
 
@@ -6764,7 +6797,13 @@ impl ::std::error::Error for GroupMemberSetAccessTypeError {
 
 impl ::std::fmt::Display for GroupMemberSetAccessTypeError {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
-        write!(f, "{:?}", *self)
+        match self {
+            GroupMemberSetAccessTypeError::GroupNotFound => f.write_str("No matching group found. No groups match the specified group ID."),
+            GroupMemberSetAccessTypeError::SystemManagedGroupDisallowed => f.write_str("This operation is not supported on system-managed groups."),
+            GroupMemberSetAccessTypeError::MemberNotInGroup => f.write_str("The specified user is not a member of this group."),
+            GroupMemberSetAccessTypeError::UserCannotBeManagerOfCompanyManagedGroup => f.write_str("A company managed group cannot be managed by a user."),
+            _ => write!(f, "{:?}", *self),
+        }
     }
 }
 
@@ -7062,7 +7101,15 @@ impl ::std::error::Error for GroupMembersAddError {
 
 impl ::std::fmt::Display for GroupMembersAddError {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
-        write!(f, "{:?}", *self)
+        match self {
+            GroupMembersAddError::GroupNotFound => f.write_str("No matching group found. No groups match the specified group ID."),
+            GroupMembersAddError::SystemManagedGroupDisallowed => f.write_str("This operation is not supported on system-managed groups."),
+            GroupMembersAddError::DuplicateUser => f.write_str("You cannot add duplicate users. One or more of the members you are trying to add is already a member of the group."),
+            GroupMembersAddError::GroupNotInTeam => f.write_str("Group is not in this team. You cannot add members to a group that is outside of your team."),
+            GroupMembersAddError::UsersNotFound(inner) => write!(f, "These users were not found in Dropbox: {:?}", inner),
+            GroupMembersAddError::UserCannotBeManagerOfCompanyManagedGroup(inner) => write!(f, "A company-managed group cannot be managed by a user: {:?}", inner),
+            _ => write!(f, "{:?}", *self),
+        }
     }
 }
 
@@ -7434,7 +7481,15 @@ impl ::std::error::Error for GroupMembersRemoveError {
 
 impl ::std::fmt::Display for GroupMembersRemoveError {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
-        write!(f, "{:?}", *self)
+        match self {
+            GroupMembersRemoveError::GroupNotFound => f.write_str("No matching group found. No groups match the specified group ID."),
+            GroupMembersRemoveError::SystemManagedGroupDisallowed => f.write_str("This operation is not supported on system-managed groups."),
+            GroupMembersRemoveError::MemberNotInGroup => f.write_str("At least one of the specified users is not a member of the group."),
+            GroupMembersRemoveError::GroupNotInTeam => f.write_str("Group is not in this team. You cannot remove members from a group that is outside of your team."),
+            GroupMembersRemoveError::MembersNotInTeam(inner) => write!(f, "These members are not part of your team: {:?}", inner),
+            GroupMembersRemoveError::UsersNotFound(inner) => write!(f, "These users were not found in Dropbox: {:?}", inner),
+            _ => write!(f, "{:?}", *self),
+        }
     }
 }
 
@@ -7634,7 +7689,12 @@ impl ::std::error::Error for GroupMembersSelectorError {
 
 impl ::std::fmt::Display for GroupMembersSelectorError {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
-        write!(f, "{:?}", *self)
+        match self {
+            GroupMembersSelectorError::GroupNotFound => f.write_str("No matching group found. No groups match the specified group ID."),
+            GroupMembersSelectorError::SystemManagedGroupDisallowed => f.write_str("This operation is not supported on system-managed groups."),
+            GroupMembersSelectorError::MemberNotInGroup => f.write_str("At least one of the specified users is not a member of the group."),
+            _ => write!(f, "{:?}", *self),
+        }
     }
 }
 
@@ -7911,7 +7971,10 @@ impl ::std::error::Error for GroupSelectorError {
 
 impl ::std::fmt::Display for GroupSelectorError {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
-        write!(f, "{:?}", *self)
+        match self {
+            GroupSelectorError::GroupNotFound => f.write_str("No matching group found. No groups match the specified group ID."),
+            _ => write!(f, "{:?}", *self),
+        }
     }
 }
 
@@ -7994,7 +8057,11 @@ impl ::std::error::Error for GroupSelectorWithTeamGroupError {
 
 impl ::std::fmt::Display for GroupSelectorWithTeamGroupError {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
-        write!(f, "{:?}", *self)
+        match self {
+            GroupSelectorWithTeamGroupError::GroupNotFound => f.write_str("No matching group found. No groups match the specified group ID."),
+            GroupSelectorWithTeamGroupError::SystemManagedGroupDisallowed => f.write_str("This operation is not supported on system-managed groups."),
+            _ => write!(f, "{:?}", *self),
+        }
     }
 }
 
@@ -8285,7 +8352,14 @@ impl ::std::error::Error for GroupUpdateError {
 
 impl ::std::fmt::Display for GroupUpdateError {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
-        write!(f, "{:?}", *self)
+        match self {
+            GroupUpdateError::GroupNotFound => f.write_str("No matching group found. No groups match the specified group ID."),
+            GroupUpdateError::SystemManagedGroupDisallowed => f.write_str("This operation is not supported on system-managed groups."),
+            GroupUpdateError::GroupNameAlreadyUsed => f.write_str("The requested group name is already being used by another group."),
+            GroupUpdateError::GroupNameInvalid => f.write_str("Group name is empty or has invalid characters."),
+            GroupUpdateError::ExternalIdAlreadyInUse => f.write_str("The requested external ID is already being used by another group."),
+            _ => write!(f, "{:?}", *self),
+        }
     }
 }
 
@@ -8353,7 +8427,10 @@ impl ::std::error::Error for GroupsGetInfoError {
 
 impl ::std::fmt::Display for GroupsGetInfoError {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
-        write!(f, "{:?}", *self)
+        match self {
+            GroupsGetInfoError::GroupNotOnTeam => f.write_str("The group is not on your team."),
+            _ => write!(f, "{:?}", *self),
+        }
     }
 }
 
@@ -8664,7 +8741,10 @@ impl ::std::error::Error for GroupsListContinueError {
 
 impl ::std::fmt::Display for GroupsListContinueError {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
-        write!(f, "{:?}", *self)
+        match self {
+            GroupsListContinueError::InvalidCursor => f.write_str("The cursor is invalid."),
+            _ => write!(f, "{:?}", *self),
+        }
     }
 }
 
@@ -9051,7 +9131,10 @@ impl ::std::error::Error for GroupsMembersListContinueError {
 
 impl ::std::fmt::Display for GroupsMembersListContinueError {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
-        write!(f, "{:?}", *self)
+        match self {
+            GroupsMembersListContinueError::InvalidCursor => f.write_str("The cursor is invalid."),
+            _ => write!(f, "{:?}", *self),
+        }
     }
 }
 
@@ -9263,7 +9346,12 @@ impl ::std::error::Error for GroupsPollError {
 
 impl ::std::fmt::Display for GroupsPollError {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
-        write!(f, "{:?}", *self)
+        match self {
+            GroupsPollError::InvalidAsyncJobId => f.write_str("The job ID is invalid."),
+            GroupsPollError::InternalError => f.write_str("Something went wrong with the job on Dropbox's end. You'll need to verify that the action you were taking succeeded, and if not, try again. This should happen very rarely."),
+            GroupsPollError::AccessDenied => f.write_str("You are not allowed to poll this job."),
+            _ => write!(f, "{:?}", *self),
+        }
     }
 }
 
@@ -10242,7 +10330,11 @@ impl ::std::error::Error for LegalHoldsError {
 
 impl ::std::fmt::Display for LegalHoldsError {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
-        write!(f, "{:?}", *self)
+        match self {
+            LegalHoldsError::UnknownLegalHoldError => f.write_str("There has been an unknown legal hold error."),
+            LegalHoldsError::InsufficientPermissions => f.write_str("You don't have permissions to perform this action."),
+            _ => write!(f, "{:?}", *self),
+        }
     }
 }
 
@@ -10426,7 +10518,11 @@ impl ::std::error::Error for LegalHoldsGetPolicyError {
 
 impl ::std::fmt::Display for LegalHoldsGetPolicyError {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
-        write!(f, "{:?}", *self)
+        match self {
+            LegalHoldsGetPolicyError::UnknownLegalHoldError => f.write_str("There has been an unknown legal hold error."),
+            LegalHoldsGetPolicyError::InsufficientPermissions => f.write_str("You don't have permissions to perform this action."),
+            _ => write!(f, "{:?}", *self),
+        }
     }
 }
 
@@ -10845,7 +10941,11 @@ impl ::std::error::Error for LegalHoldsListHeldRevisionsContinueError {
 
 impl ::std::fmt::Display for LegalHoldsListHeldRevisionsContinueError {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
-        write!(f, "{:?}", *self)
+        match self {
+            LegalHoldsListHeldRevisionsContinueError::UnknownLegalHoldError => f.write_str("There has been an unknown legal hold error."),
+            LegalHoldsListHeldRevisionsContinueError::TransientError => f.write_str("Temporary infrastructure failure, please retry."),
+            _ => write!(f, "{:?}", *self),
+        }
     }
 }
 
@@ -10965,7 +11065,14 @@ impl ::std::error::Error for LegalHoldsListHeldRevisionsError {
 
 impl ::std::fmt::Display for LegalHoldsListHeldRevisionsError {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
-        write!(f, "{:?}", *self)
+        match self {
+            LegalHoldsListHeldRevisionsError::UnknownLegalHoldError => f.write_str("There has been an unknown legal hold error."),
+            LegalHoldsListHeldRevisionsError::InsufficientPermissions => f.write_str("You don't have permissions to perform this action."),
+            LegalHoldsListHeldRevisionsError::TransientError => f.write_str("Temporary infrastructure failure, please retry."),
+            LegalHoldsListHeldRevisionsError::LegalHoldStillEmpty => f.write_str("The legal hold is not holding any revisions yet."),
+            LegalHoldsListHeldRevisionsError::InactiveLegalHold => f.write_str("Trying to list revisions for an inactive legal hold."),
+            _ => write!(f, "{:?}", *self),
+        }
     }
 }
 
@@ -11145,7 +11252,12 @@ impl ::std::error::Error for LegalHoldsListPoliciesError {
 
 impl ::std::fmt::Display for LegalHoldsListPoliciesError {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
-        write!(f, "{:?}", *self)
+        match self {
+            LegalHoldsListPoliciesError::UnknownLegalHoldError => f.write_str("There has been an unknown legal hold error."),
+            LegalHoldsListPoliciesError::InsufficientPermissions => f.write_str("You don't have permissions to perform this action."),
+            LegalHoldsListPoliciesError::TransientError => f.write_str("Temporary infrastructure failure, please retry."),
+            _ => write!(f, "{:?}", *self),
+        }
     }
 }
 
@@ -11576,7 +11688,19 @@ impl ::std::error::Error for LegalHoldsPolicyCreateError {
 
 impl ::std::fmt::Display for LegalHoldsPolicyCreateError {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
-        write!(f, "{:?}", *self)
+        match self {
+            LegalHoldsPolicyCreateError::UnknownLegalHoldError => f.write_str("There has been an unknown legal hold error."),
+            LegalHoldsPolicyCreateError::InsufficientPermissions => f.write_str("You don't have permissions to perform this action."),
+            LegalHoldsPolicyCreateError::StartDateIsLaterThanEndDate => f.write_str("Start date must be earlier than end date."),
+            LegalHoldsPolicyCreateError::EmptyMembersList => f.write_str("The users list must have at least one user."),
+            LegalHoldsPolicyCreateError::InvalidMembers => f.write_str("Some members in the members list are not valid to be placed under legal hold."),
+            LegalHoldsPolicyCreateError::NumberOfUsersOnHoldIsGreaterThanHoldLimitation => f.write_str("You cannot add more than 5 users in a legal hold."),
+            LegalHoldsPolicyCreateError::TransientError => f.write_str("Temporary infrastructure failure, please retry."),
+            LegalHoldsPolicyCreateError::NameMustBeUnique => f.write_str("The name provided is already in use by another legal hold."),
+            LegalHoldsPolicyCreateError::TeamExceededLegalHoldQuota => f.write_str("Team exceeded legal hold quota."),
+            LegalHoldsPolicyCreateError::InvalidDate => f.write_str("The provided date is invalid."),
+            _ => write!(f, "{:?}", *self),
+        }
     }
 }
 
@@ -11787,7 +11911,13 @@ impl ::std::error::Error for LegalHoldsPolicyReleaseError {
 
 impl ::std::fmt::Display for LegalHoldsPolicyReleaseError {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
-        write!(f, "{:?}", *self)
+        match self {
+            LegalHoldsPolicyReleaseError::UnknownLegalHoldError => f.write_str("There has been an unknown legal hold error."),
+            LegalHoldsPolicyReleaseError::InsufficientPermissions => f.write_str("You don't have permissions to perform this action."),
+            LegalHoldsPolicyReleaseError::LegalHoldPerformingAnotherOperation => f.write_str("Legal hold is currently performing another operation."),
+            LegalHoldsPolicyReleaseError::LegalHoldAlreadyReleasing => f.write_str("Legal hold is currently performing a release or is already released."),
+            _ => write!(f, "{:?}", *self),
+        }
     }
 }
 
@@ -12104,7 +12234,17 @@ impl ::std::error::Error for LegalHoldsPolicyUpdateError {
 
 impl ::std::fmt::Display for LegalHoldsPolicyUpdateError {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
-        write!(f, "{:?}", *self)
+        match self {
+            LegalHoldsPolicyUpdateError::UnknownLegalHoldError => f.write_str("There has been an unknown legal hold error."),
+            LegalHoldsPolicyUpdateError::InsufficientPermissions => f.write_str("You don't have permissions to perform this action."),
+            LegalHoldsPolicyUpdateError::InactiveLegalHold => f.write_str("Trying to release an inactive legal hold."),
+            LegalHoldsPolicyUpdateError::LegalHoldPerformingAnotherOperation => f.write_str("Legal hold is currently performing another operation."),
+            LegalHoldsPolicyUpdateError::InvalidMembers => f.write_str("Some members in the members list are not valid to be placed under legal hold."),
+            LegalHoldsPolicyUpdateError::NumberOfUsersOnHoldIsGreaterThanHoldLimitation => f.write_str("You cannot add more than 5 users in a legal hold."),
+            LegalHoldsPolicyUpdateError::EmptyMembersList => f.write_str("The users list must have at least one user."),
+            LegalHoldsPolicyUpdateError::NameMustBeUnique => f.write_str("The name provided is already in use by another legal hold."),
+            _ => write!(f, "{:?}", *self),
+        }
     }
 }
 
@@ -12264,7 +12404,10 @@ impl ::std::error::Error for ListMemberAppsError {
 
 impl ::std::fmt::Display for ListMemberAppsError {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
-        write!(f, "{:?}", *self)
+        match self {
+            ListMemberAppsError::MemberNotFound => f.write_str("Member not found."),
+            _ => write!(f, "{:?}", *self),
+        }
     }
 }
 
@@ -12566,7 +12709,10 @@ impl ::std::error::Error for ListMemberDevicesError {
 
 impl ::std::fmt::Display for ListMemberDevicesError {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
-        write!(f, "{:?}", *self)
+        match self {
+            ListMemberDevicesError::MemberNotFound => f.write_str("Member not found."),
+            _ => write!(f, "{:?}", *self),
+        }
     }
 }
 
@@ -15141,7 +15287,10 @@ impl ::std::error::Error for MemberSelectorError {
 
 impl ::std::fmt::Display for MemberSelectorError {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
-        write!(f, "{:?}", *self)
+        match self {
+            MemberSelectorError::UserNotFound => f.write_str("No matching user found. The provided team_member_id, email, or external_id does not exist on this team."),
+            MemberSelectorError::UserNotInTeam => f.write_str("The user is not a member of the team."),
+        }
     }
 }
 
@@ -15808,7 +15957,11 @@ impl ::std::error::Error for MembersDeactivateError {
 
 impl ::std::fmt::Display for MembersDeactivateError {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
-        write!(f, "{:?}", *self)
+        match self {
+            MembersDeactivateError::UserNotFound => f.write_str("No matching user found. The provided team_member_id, email, or external_id does not exist on this team."),
+            MembersDeactivateError::UserNotInTeam => f.write_str("The user is not a member of the team."),
+            _ => write!(f, "{:?}", *self),
+        }
     }
 }
 
@@ -15993,7 +16146,12 @@ impl ::std::error::Error for MembersDeleteProfilePhotoError {
 
 impl ::std::fmt::Display for MembersDeleteProfilePhotoError {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
-        write!(f, "{:?}", *self)
+        match self {
+            MembersDeleteProfilePhotoError::UserNotFound => f.write_str("No matching user found. The provided team_member_id, email, or external_id does not exist on this team."),
+            MembersDeleteProfilePhotoError::UserNotInTeam => f.write_str("The user is not a member of the team."),
+            MembersDeleteProfilePhotoError::SetProfileDisallowed => f.write_str("Modifying deleted users is not allowed."),
+            _ => write!(f, "{:?}", *self),
+        }
     }
 }
 
@@ -16572,7 +16730,10 @@ impl ::std::error::Error for MembersListContinueError {
 
 impl ::std::fmt::Display for MembersListContinueError {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
-        write!(f, "{:?}", *self)
+        match self {
+            MembersListContinueError::InvalidCursor => f.write_str("The cursor is invalid."),
+            _ => write!(f, "{:?}", *self),
+        }
     }
 }
 
@@ -16942,7 +17103,13 @@ impl ::std::error::Error for MembersRecoverError {
 
 impl ::std::fmt::Display for MembersRecoverError {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
-        write!(f, "{:?}", *self)
+        match self {
+            MembersRecoverError::UserNotFound => f.write_str("No matching user found. The provided team_member_id, email, or external_id does not exist on this team."),
+            MembersRecoverError::UserUnrecoverable => f.write_str("The user is not recoverable."),
+            MembersRecoverError::UserNotInTeam => f.write_str("The user is not a member of the team."),
+            MembersRecoverError::TeamLicenseLimit => f.write_str("Team is full. The organization has no available licenses."),
+            _ => write!(f, "{:?}", *self),
+        }
     }
 }
 
@@ -17477,7 +17644,28 @@ impl ::std::error::Error for MembersRemoveError {
 
 impl ::std::fmt::Display for MembersRemoveError {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
-        write!(f, "{:?}", *self)
+        match self {
+            MembersRemoveError::UserNotFound => f.write_str("No matching user found. The provided team_member_id, email, or external_id does not exist on this team."),
+            MembersRemoveError::UserNotInTeam => f.write_str("The user is not a member of the team."),
+            MembersRemoveError::RemovedAndTransferDestShouldDiffer => f.write_str("Expected removed user and transfer_dest user to be different."),
+            MembersRemoveError::RemovedAndTransferAdminShouldDiffer => f.write_str("Expected removed user and transfer_admin user to be different."),
+            MembersRemoveError::TransferDestUserNotFound => f.write_str("No matching user found for the argument transfer_dest_id."),
+            MembersRemoveError::TransferDestUserNotInTeam => f.write_str("The provided transfer_dest_id does not exist on this team."),
+            MembersRemoveError::TransferAdminUserNotInTeam => f.write_str("The provided transfer_admin_id does not exist on this team."),
+            MembersRemoveError::TransferAdminUserNotFound => f.write_str("No matching user found for the argument transfer_admin_id."),
+            MembersRemoveError::UnspecifiedTransferAdminId => f.write_str("The transfer_admin_id argument must be provided when file transfer is requested."),
+            MembersRemoveError::TransferAdminIsNotAdmin => f.write_str("Specified transfer_admin user is not a team admin."),
+            MembersRemoveError::RecipientNotVerified => f.write_str("The recipient user's email is not verified."),
+            MembersRemoveError::RemoveLastAdmin => f.write_str("The user is the last admin of the team, so it cannot be removed from it."),
+            MembersRemoveError::CannotKeepAccountAndTransfer => f.write_str("Cannot keep account and transfer the data to another user at the same time."),
+            MembersRemoveError::EmailAddressTooLongToBeDisabled => f.write_str("The email address of the user is too long to be disabled."),
+            MembersRemoveError::CannotKeepInvitedUserAccount => f.write_str("Cannot keep account of an invited user."),
+            MembersRemoveError::CannotRetainSharesWhenTeamExternalSharingOff => f.write_str("Externally sharing files, folders, and links must be enabled in team settings in order to retain team shares for the user."),
+            MembersRemoveError::CannotKeepAccount => f.write_str("Only a team admin, can convert this account to a Basic account."),
+            MembersRemoveError::CannotKeepAccountUnderLegalHold => f.write_str("This user content is currently being held. To convert this member's account to a Basic account, you'll first need to remove them from the hold."),
+            MembersRemoveError::CannotKeepAccountRequiredToSignTos => f.write_str("To convert this member to a Basic account, they'll first need to sign in to Dropbox and agree to the terms of service."),
+            _ => write!(f, "{:?}", *self),
+        }
     }
 }
 
@@ -17560,7 +17748,11 @@ impl ::std::error::Error for MembersSendWelcomeError {
 
 impl ::std::fmt::Display for MembersSendWelcomeError {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
-        write!(f, "{:?}", *self)
+        match self {
+            MembersSendWelcomeError::UserNotFound => f.write_str("No matching user found. The provided team_member_id, email, or external_id does not exist on this team."),
+            MembersSendWelcomeError::UserNotInTeam => f.write_str("The user is not a member of the team."),
+            _ => write!(f, "{:?}", *self),
+        }
     }
 }
 
@@ -17786,7 +17978,14 @@ impl ::std::error::Error for MembersSetPermissionsError {
 
 impl ::std::fmt::Display for MembersSetPermissionsError {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
-        write!(f, "{:?}", *self)
+        match self {
+            MembersSetPermissionsError::UserNotFound => f.write_str("No matching user found. The provided team_member_id, email, or external_id does not exist on this team."),
+            MembersSetPermissionsError::LastAdmin => f.write_str("Cannot remove the admin setting of the last admin."),
+            MembersSetPermissionsError::UserNotInTeam => f.write_str("The user is not a member of the team."),
+            MembersSetPermissionsError::CannotSetPermissions => f.write_str("Cannot remove/grant permissions."),
+            MembersSetPermissionsError::TeamLicenseLimit => f.write_str("Team is full. The organization has no available licenses."),
+            _ => write!(f, "{:?}", *self),
+        }
     }
 }
 
@@ -18291,7 +18490,20 @@ impl ::std::error::Error for MembersSetProfileError {
 
 impl ::std::fmt::Display for MembersSetProfileError {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
-        write!(f, "{:?}", *self)
+        match self {
+            MembersSetProfileError::UserNotFound => f.write_str("No matching user found. The provided team_member_id, email, or external_id does not exist on this team."),
+            MembersSetProfileError::UserNotInTeam => f.write_str("The user is not a member of the team."),
+            MembersSetProfileError::ExternalIdAndNewExternalIdUnsafe => f.write_str("It is unsafe to use both external_id and new_external_id."),
+            MembersSetProfileError::NoNewDataSpecified => f.write_str("None of new_email, new_given_name, new_surname, or new_external_id are specified."),
+            MembersSetProfileError::EmailReservedForOtherUser => f.write_str("Email is already reserved for another user."),
+            MembersSetProfileError::ExternalIdUsedByOtherUser => f.write_str("The external ID is already in use by another team member."),
+            MembersSetProfileError::SetProfileDisallowed => f.write_str("Modifying deleted users is not allowed."),
+            MembersSetProfileError::ParamCannotBeEmpty => f.write_str("Parameter new_email cannot be empty."),
+            MembersSetProfileError::PersistentIdDisabled => f.write_str("Persistent ID is only available to teams with persistent ID SAML configuration. Please contact Dropbox for more information."),
+            MembersSetProfileError::PersistentIdUsedByOtherUser => f.write_str("The persistent ID is already in use by another team member."),
+            MembersSetProfileError::DirectoryRestrictedOff => f.write_str("Directory Restrictions option is not available."),
+            _ => write!(f, "{:?}", *self),
+        }
     }
 }
 
@@ -18511,7 +18723,12 @@ impl ::std::error::Error for MembersSetProfilePhotoError {
 
 impl ::std::fmt::Display for MembersSetProfilePhotoError {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
-        write!(f, "{:?}", *self)
+        match self {
+            MembersSetProfilePhotoError::UserNotFound => f.write_str("No matching user found. The provided team_member_id, email, or external_id does not exist on this team."),
+            MembersSetProfilePhotoError::UserNotInTeam => f.write_str("The user is not a member of the team."),
+            MembersSetProfilePhotoError::SetProfileDisallowed => f.write_str("Modifying deleted users is not allowed."),
+            _ => write!(f, "{:?}", *self),
+        }
     }
 }
 
@@ -18632,7 +18849,14 @@ impl ::std::error::Error for MembersSuspendError {
 
 impl ::std::fmt::Display for MembersSuspendError {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
-        write!(f, "{:?}", *self)
+        match self {
+            MembersSuspendError::UserNotFound => f.write_str("No matching user found. The provided team_member_id, email, or external_id does not exist on this team."),
+            MembersSuspendError::UserNotInTeam => f.write_str("The user is not a member of the team."),
+            MembersSuspendError::SuspendInactiveUser => f.write_str("The user is not active, so it cannot be suspended."),
+            MembersSuspendError::SuspendLastAdmin => f.write_str("The user is the last admin of the team, so it cannot be suspended."),
+            MembersSuspendError::TeamLicenseLimit => f.write_str("Team is full. The organization has no available licenses."),
+            _ => write!(f, "{:?}", *self),
+        }
     }
 }
 
@@ -18831,7 +19055,20 @@ impl ::std::error::Error for MembersTransferFilesError {
 
 impl ::std::fmt::Display for MembersTransferFilesError {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
-        write!(f, "{:?}", *self)
+        match self {
+            MembersTransferFilesError::UserNotFound => f.write_str("No matching user found. The provided team_member_id, email, or external_id does not exist on this team."),
+            MembersTransferFilesError::UserNotInTeam => f.write_str("The user is not a member of the team."),
+            MembersTransferFilesError::RemovedAndTransferDestShouldDiffer => f.write_str("Expected removed user and transfer_dest user to be different."),
+            MembersTransferFilesError::RemovedAndTransferAdminShouldDiffer => f.write_str("Expected removed user and transfer_admin user to be different."),
+            MembersTransferFilesError::TransferDestUserNotFound => f.write_str("No matching user found for the argument transfer_dest_id."),
+            MembersTransferFilesError::TransferDestUserNotInTeam => f.write_str("The provided transfer_dest_id does not exist on this team."),
+            MembersTransferFilesError::TransferAdminUserNotInTeam => f.write_str("The provided transfer_admin_id does not exist on this team."),
+            MembersTransferFilesError::TransferAdminUserNotFound => f.write_str("No matching user found for the argument transfer_admin_id."),
+            MembersTransferFilesError::UnspecifiedTransferAdminId => f.write_str("The transfer_admin_id argument must be provided when file transfer is requested."),
+            MembersTransferFilesError::TransferAdminIsNotAdmin => f.write_str("Specified transfer_admin user is not a team admin."),
+            MembersTransferFilesError::RecipientNotVerified => f.write_str("The recipient user's email is not verified."),
+            _ => write!(f, "{:?}", *self),
+        }
     }
 }
 
@@ -19082,7 +19319,24 @@ impl ::std::error::Error for MembersTransferFormerMembersFilesError {
 
 impl ::std::fmt::Display for MembersTransferFormerMembersFilesError {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
-        write!(f, "{:?}", *self)
+        match self {
+            MembersTransferFormerMembersFilesError::UserNotFound => f.write_str("No matching user found. The provided team_member_id, email, or external_id does not exist on this team."),
+            MembersTransferFormerMembersFilesError::UserNotInTeam => f.write_str("The user is not a member of the team."),
+            MembersTransferFormerMembersFilesError::RemovedAndTransferDestShouldDiffer => f.write_str("Expected removed user and transfer_dest user to be different."),
+            MembersTransferFormerMembersFilesError::RemovedAndTransferAdminShouldDiffer => f.write_str("Expected removed user and transfer_admin user to be different."),
+            MembersTransferFormerMembersFilesError::TransferDestUserNotFound => f.write_str("No matching user found for the argument transfer_dest_id."),
+            MembersTransferFormerMembersFilesError::TransferDestUserNotInTeam => f.write_str("The provided transfer_dest_id does not exist on this team."),
+            MembersTransferFormerMembersFilesError::TransferAdminUserNotInTeam => f.write_str("The provided transfer_admin_id does not exist on this team."),
+            MembersTransferFormerMembersFilesError::TransferAdminUserNotFound => f.write_str("No matching user found for the argument transfer_admin_id."),
+            MembersTransferFormerMembersFilesError::UnspecifiedTransferAdminId => f.write_str("The transfer_admin_id argument must be provided when file transfer is requested."),
+            MembersTransferFormerMembersFilesError::TransferAdminIsNotAdmin => f.write_str("Specified transfer_admin user is not a team admin."),
+            MembersTransferFormerMembersFilesError::RecipientNotVerified => f.write_str("The recipient user's email is not verified."),
+            MembersTransferFormerMembersFilesError::UserDataIsBeingTransferred => f.write_str("The user's data is being transferred. Please wait some time before retrying."),
+            MembersTransferFormerMembersFilesError::UserNotRemoved => f.write_str("No matching removed user found for the argument user."),
+            MembersTransferFormerMembersFilesError::UserDataCannotBeTransferred => f.write_str("User files aren't transferable anymore."),
+            MembersTransferFormerMembersFilesError::UserDataAlreadyTransferred => f.write_str("User's data has already been transferred to another user."),
+            _ => write!(f, "{:?}", *self),
+        }
     }
 }
 
@@ -19282,7 +19536,13 @@ impl ::std::error::Error for MembersUnsuspendError {
 
 impl ::std::fmt::Display for MembersUnsuspendError {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
-        write!(f, "{:?}", *self)
+        match self {
+            MembersUnsuspendError::UserNotFound => f.write_str("No matching user found. The provided team_member_id, email, or external_id does not exist on this team."),
+            MembersUnsuspendError::UserNotInTeam => f.write_str("The user is not a member of the team."),
+            MembersUnsuspendError::UnsuspendNonSuspendedMember => f.write_str("The user is unsuspended, so it cannot be unsuspended again."),
+            MembersUnsuspendError::TeamLicenseLimit => f.write_str("Team is full. The organization has no available licenses."),
+            _ => write!(f, "{:?}", *self),
+        }
     }
 }
 
@@ -20845,7 +21105,11 @@ impl ::std::error::Error for RevokeDeviceSessionError {
 
 impl ::std::fmt::Display for RevokeDeviceSessionError {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
-        write!(f, "{:?}", *self)
+        match self {
+            RevokeDeviceSessionError::DeviceSessionNotFound => f.write_str("Device session not found."),
+            RevokeDeviceSessionError::MemberNotFound => f.write_str("Member not found."),
+            _ => write!(f, "{:?}", *self),
+        }
     }
 }
 
@@ -21401,7 +21665,12 @@ impl ::std::error::Error for RevokeLinkedAppError {
 
 impl ::std::fmt::Display for RevokeLinkedAppError {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
-        write!(f, "{:?}", *self)
+        match self {
+            RevokeLinkedAppError::AppNotFound => f.write_str("Application not found."),
+            RevokeLinkedAppError::MemberNotFound => f.write_str("Member not found."),
+            RevokeLinkedAppError::AppFolderRemovalNotSupported => f.write_str("App folder removal is not supported."),
+            _ => write!(f, "{:?}", *self),
+        }
     }
 }
 
@@ -21681,7 +21950,11 @@ impl ::std::error::Error for SetCustomQuotaError {
 
 impl ::std::fmt::Display for SetCustomQuotaError {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
-        write!(f, "{:?}", *self)
+        match self {
+            SetCustomQuotaError::TooManyUsers => f.write_str("A maximum of 1000 users can be set for a single call."),
+            SetCustomQuotaError::SomeUsersAreExcluded => f.write_str("Some of the users are on the excluded users list and can't have custom quota set."),
+            _ => write!(f, "{:?}", *self),
+        }
     }
 }
 
@@ -21867,7 +22140,11 @@ impl ::std::error::Error for TeamFolderAccessError {
 
 impl ::std::fmt::Display for TeamFolderAccessError {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
-        write!(f, "{:?}", *self)
+        match self {
+            TeamFolderAccessError::InvalidTeamFolderId => f.write_str("The team folder ID is invalid."),
+            TeamFolderAccessError::NoAccess => f.write_str("The authenticated app does not have permission to manage that team folder."),
+            _ => write!(f, "{:?}", *self),
+        }
     }
 }
 
@@ -22569,7 +22846,13 @@ impl ::std::error::Error for TeamFolderCreateError {
 
 impl ::std::fmt::Display for TeamFolderCreateError {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
-        write!(f, "{:?}", *self)
+        match self {
+            TeamFolderCreateError::InvalidFolderName => f.write_str("The provided name cannot be used."),
+            TeamFolderCreateError::FolderNameAlreadyUsed => f.write_str("There is already a team folder with the provided name."),
+            TeamFolderCreateError::FolderNameReserved => f.write_str("The provided name cannot be used because it is reserved."),
+            TeamFolderCreateError::SyncSettingsError(inner) => write!(f, "An error occurred setting the sync settings: {}", inner),
+            _ => write!(f, "{:?}", *self),
+        }
     }
 }
 
@@ -22909,7 +23192,12 @@ impl ::std::error::Error for TeamFolderInvalidStatusError {
 
 impl ::std::fmt::Display for TeamFolderInvalidStatusError {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
-        write!(f, "{:?}", *self)
+        match self {
+            TeamFolderInvalidStatusError::Active => f.write_str("The folder is active and the operation did not succeed."),
+            TeamFolderInvalidStatusError::Archived => f.write_str("The folder is archived and the operation did not succeed."),
+            TeamFolderInvalidStatusError::ArchiveInProgress => f.write_str("The folder is being archived and the operation did not succeed."),
+            _ => write!(f, "{:?}", *self),
+        }
     }
 }
 
@@ -23153,7 +23441,10 @@ impl ::std::error::Error for TeamFolderListContinueError {
 
 impl ::std::fmt::Display for TeamFolderListContinueError {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
-        write!(f, "{:?}", *self)
+        match self {
+            TeamFolderListContinueError::InvalidCursor => f.write_str("The cursor is invalid."),
+            _ => write!(f, "{:?}", *self),
+        }
     }
 }
 
@@ -23890,7 +24181,12 @@ impl ::std::error::Error for TeamFolderRenameError {
 
 impl ::std::fmt::Display for TeamFolderRenameError {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
-        write!(f, "{:?}", *self)
+        match self {
+            TeamFolderRenameError::InvalidFolderName => f.write_str("The provided folder name cannot be used."),
+            TeamFolderRenameError::FolderNameAlreadyUsed => f.write_str("There is already a team folder with the same name."),
+            TeamFolderRenameError::FolderNameReserved => f.write_str("The provided name cannot be used because it is reserved."),
+            _ => write!(f, "{:?}", *self),
+        }
     }
 }
 
@@ -24043,7 +24339,10 @@ impl ::std::error::Error for TeamFolderTeamSharedDropboxError {
 
 impl ::std::fmt::Display for TeamFolderTeamSharedDropboxError {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
-        write!(f, "{:?}", *self)
+        match self {
+            TeamFolderTeamSharedDropboxError::Disallowed => f.write_str("This action is not allowed for a shared team root."),
+            _ => write!(f, "{:?}", *self),
+        }
     }
 }
 
@@ -24302,7 +24601,10 @@ impl ::std::error::Error for TeamFolderUpdateSyncSettingsError {
 
 impl ::std::fmt::Display for TeamFolderUpdateSyncSettingsError {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
-        write!(f, "{:?}", *self)
+        match self {
+            TeamFolderUpdateSyncSettingsError::SyncSettingsError(inner) => write!(f, "An error occurred setting the sync settings: {}", inner),
+            _ => write!(f, "{:?}", *self),
+        }
     }
 }
 
@@ -25325,7 +25627,11 @@ impl ::std::error::Error for TeamNamespacesListContinueError {
 
 impl ::std::fmt::Display for TeamNamespacesListContinueError {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
-        write!(f, "{:?}", *self)
+        match self {
+            TeamNamespacesListContinueError::InvalidArg => f.write_str("Argument passed in is invalid."),
+            TeamNamespacesListContinueError::InvalidCursor => f.write_str("The cursor is invalid."),
+            _ => write!(f, "{:?}", *self),
+        }
     }
 }
 
@@ -25393,7 +25699,10 @@ impl ::std::error::Error for TeamNamespacesListError {
 
 impl ::std::fmt::Display for TeamNamespacesListError {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
-        write!(f, "{:?}", *self)
+        match self {
+            TeamNamespacesListError::InvalidArg => f.write_str("Argument passed in is invalid."),
+            _ => write!(f, "{:?}", *self),
+        }
     }
 }
 
@@ -25683,7 +25992,11 @@ impl ::std::error::Error for TokenGetAuthenticatedAdminError {
 
 impl ::std::fmt::Display for TokenGetAuthenticatedAdminError {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
-        write!(f, "{:?}", *self)
+        match self {
+            TokenGetAuthenticatedAdminError::MappingNotFound => f.write_str("The current token is not associated with a team admin, because mappings were not recorded when the token was created. Consider re-authorizing a new access token to record its authenticating admin."),
+            TokenGetAuthenticatedAdminError::AdminNotActive => f.write_str("Either the team admin that authorized this token is no longer an active member of the team or no longer a team admin."),
+            _ => write!(f, "{:?}", *self),
+        }
     }
 }
 
@@ -26880,7 +27193,9 @@ impl ::std::error::Error for UserSelectorError {
 
 impl ::std::fmt::Display for UserSelectorError {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
-        write!(f, "{:?}", *self)
+        match self {
+            UserSelectorError::UserNotFound => f.write_str("No matching user found. The provided team_member_id, email, or external_id does not exist on this team."),
+        }
     }
 }
 

--- a/src/generated/team.rs
+++ b/src/generated/team.rs
@@ -110,7 +110,7 @@ pub fn features_get_values(
 /// Retrieves information about a team.
 pub fn get_info(
     client: &impl crate::client_trait::TeamAuthClient,
-) -> crate::Result<Result<TeamGetInfoResult, ()>> {
+) -> crate::Result<Result<TeamGetInfoResult, crate::NoError>> {
     crate::client_helpers::request(
         client,
         crate::client_trait::Endpoint::Api,
@@ -188,7 +188,7 @@ pub fn groups_job_status_get(
 pub fn groups_list(
     client: &impl crate::client_trait::TeamAuthClient,
     arg: &GroupsListArg,
-) -> crate::Result<Result<GroupsListResult, ()>> {
+) -> crate::Result<Result<GroupsListResult, crate::NoError>> {
     crate::client_helpers::request(
         client,
         crate::client_trait::Endpoint::Api,
@@ -594,7 +594,7 @@ pub fn member_space_limits_set_custom_quota(
 pub fn members_add(
     client: &impl crate::client_trait::TeamAuthClient,
     arg: &MembersAddArg,
-) -> crate::Result<Result<MembersAddLaunch, ()>> {
+) -> crate::Result<Result<MembersAddLaunch, crate::NoError>> {
     crate::client_helpers::request(
         client,
         crate::client_trait::Endpoint::Api,
@@ -785,7 +785,7 @@ pub fn members_secondary_emails_add(
 pub fn members_secondary_emails_delete(
     client: &impl crate::client_trait::TeamAuthClient,
     arg: &DeleteSecondaryEmailsArg,
-) -> crate::Result<Result<DeleteSecondaryEmailsResult, ()>> {
+) -> crate::Result<Result<DeleteSecondaryEmailsResult, crate::NoError>> {
     crate::client_helpers::request(
         client,
         crate::client_trait::Endpoint::Api,
@@ -799,7 +799,7 @@ pub fn members_secondary_emails_delete(
 pub fn members_secondary_emails_resend_verification_emails(
     client: &impl crate::client_trait::TeamAuthClient,
     arg: &ResendVerificationEmailArg,
-) -> crate::Result<Result<ResendVerificationEmailResult, ()>> {
+) -> crate::Result<Result<ResendVerificationEmailResult, crate::NoError>> {
     crate::client_helpers::request(
         client,
         crate::client_trait::Endpoint::Api,
@@ -1102,7 +1102,7 @@ pub fn team_folder_create(
 pub fn team_folder_get_info(
     client: &impl crate::client_trait::TeamAuthClient,
     arg: &TeamFolderIdListArg,
-) -> crate::Result<Result<Vec<TeamFolderGetInfoItem>, ()>> {
+) -> crate::Result<Result<Vec<TeamFolderGetInfoItem>, crate::NoError>> {
     crate::client_helpers::request(
         client,
         crate::client_trait::Endpoint::Api,

--- a/src/generated/users.rs
+++ b/src/generated/users.rs
@@ -56,7 +56,7 @@ pub fn get_account_batch(
 /// Get information about the current user's account.
 pub fn get_current_account(
     client: &impl crate::client_trait::UserAuthClient,
-) -> crate::Result<Result<FullAccount, ()>> {
+) -> crate::Result<Result<FullAccount, crate::NoError>> {
     crate::client_helpers::request(
         client,
         crate::client_trait::Endpoint::Api,
@@ -69,7 +69,7 @@ pub fn get_current_account(
 /// Get the space usage information for the current user's account.
 pub fn get_space_usage(
     client: &impl crate::client_trait::UserAuthClient,
-) -> crate::Result<Result<SpaceUsage, ()>> {
+) -> crate::Result<Result<SpaceUsage, crate::NoError>> {
     crate::client_helpers::request(
         client,
         crate::client_trait::Endpoint::Api,

--- a/src/generated/users.rs
+++ b/src/generated/users.rs
@@ -1191,9 +1191,6 @@ impl ::serde::ser::Serialize for GetAccountBatchError {
 }
 
 impl ::std::error::Error for GetAccountBatchError {
-    fn description(&self) -> &str {
-        "GetAccountBatchError"
-    }
 }
 
 impl ::std::fmt::Display for GetAccountBatchError {
@@ -1262,9 +1259,6 @@ impl ::serde::ser::Serialize for GetAccountError {
 }
 
 impl ::std::error::Error for GetAccountError {
-    fn description(&self) -> &str {
-        "GetAccountError"
-    }
 }
 
 impl ::std::fmt::Display for GetAccountError {
@@ -2310,9 +2304,6 @@ impl ::serde::ser::Serialize for UserFeaturesGetValuesBatchError {
 }
 
 impl ::std::error::Error for UserFeaturesGetValuesBatchError {
-    fn description(&self) -> &str {
-        "UserFeaturesGetValuesBatchError"
-    }
 }
 
 impl ::std::fmt::Display for UserFeaturesGetValuesBatchError {

--- a/src/generated/users.rs
+++ b/src/generated/users.rs
@@ -1196,7 +1196,7 @@ impl ::std::error::Error for GetAccountBatchError {
 impl ::std::fmt::Display for GetAccountBatchError {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match self {
-            GetAccountBatchError::NoAccount(inner) => write!(f, "{:?}", inner),
+            GetAccountBatchError::NoAccount(inner) => write!(f, "no_account: {:?}", inner),
             _ => write!(f, "{:?}", *self),
         }
     }

--- a/src/generated/users.rs
+++ b/src/generated/users.rs
@@ -1195,7 +1195,10 @@ impl ::std::error::Error for GetAccountBatchError {
 
 impl ::std::fmt::Display for GetAccountBatchError {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
-        write!(f, "{:?}", *self)
+        match self {
+            GetAccountBatchError::NoAccount(inner) => write!(f, "{:?}", inner),
+            _ => write!(f, "{:?}", *self),
+        }
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -97,3 +97,28 @@ pub mod oauth2;
 
 mod generated; // You need to run the Stone generator to create this module.
 pub use generated::*;
+
+/// A special error type for a method that doesn't have any defined error return. You shouldn't
+/// actually encounter this value in real life; it's here to satisfy type requirements.
+///
+/// Maybe some day this could maybe be replaced by `!`, the never-type.
+#[derive(Debug, Copy, Clone, PartialEq)]
+pub struct NoError;
+
+impl std::error::Error for NoError {}
+
+impl std::fmt::Display for NoError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str("(void error: you shouldn't be seeing this!)")
+    }
+}
+
+impl<'de> serde::de::Deserialize<'de> for NoError {
+    fn deserialize<D: serde::de::Deserializer<'de>>(deserializer: D)
+        -> std::result::Result<Self, D::Error>
+    {
+        // Pretend we're the unit type.
+        <()>::deserialize(deserializer)?;
+        Ok(NoError {})
+    }
+}


### PR DESCRIPTION
In general, this change makes many types that are used as errors, look more like proper error types in Rust.

The impl of `std::error::Error` has been improved to no longer include the deprecated `description()` method, and to include a `source()` method that returns any inner value if that value is also an error type.

The `Display` impl of these has been improved to make use of the types' documentation as much as possible, falling back to `Debug` representation when none is available. This replaces the current behavior, where the `Debug` representation is always re-used for `Display`.

The quality of these error messages varies a bit, as they were not always written with the intent to be used as display messages, but the vast majority are quite good.

As a breaking change, the error type for routes which have no defined error has been changed from `()` to a new type, `NoError`, which implements `std::error::Error` and `Display` (which cannot be implemented for `()`). This finally allows setting a constraint on all routes that they *must* return an `Error` type, which means callers can all use the friendlier `Display` message when logging error messages.

## **Checklist**

**General Contributing**
<!-- Change [ ] to [x] if you have: -->
- [x] I have read the Code of Conduct and signed the [CLA](https://opensource.dropbox.com/cla/).
- [x] I have added an entry to the `RELEASE_NOTES.md` file, or believe it's not necessary for this change.

**Validation**
<!-- Describe which tests cover the changes you've made, and any additional manual validation you
     did to ensure the correctness of this change. Does this change warrant addition of new tests?
     Does this change have performance implications? Etc. -->
These fall under the "if it compiles, it's good" category. Changing some type bounds in `client_helpers` ensures that all types returned as errors by routes have a valid `Display` and `Error` impl.

Further verification was done by hand, as the quality of error messages is largely subjective.