### PR TITLE
Path root

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,3 +1,10 @@
+# v0.10.1
+xxxx-yy-zz
+* Implemented path root selection for default_client. Clients now have a `.set_path_root()` 
+  method which adds the `Dropbox-API-Path-Root` header, which sets what namespace paths are
+  evaluated relative to. This requires that the `dbx_common` feature is enabled, as it uses the
+  `PathRoot` type defined in that namespace.
+
 # v0.10.0
 2020-12-11
 * Several improvements to error types:

--- a/tests/path_root.rs
+++ b/tests/path_root.rs
@@ -1,0 +1,39 @@
+use dropbox_sdk::common::PathRoot;
+use dropbox_sdk::default_client::UserAuthDefaultClient;
+use dropbox_sdk::files::{self, ListFolderArg};
+
+#[test]
+#[ignore] // requires a pre-configured app token; should be run separately
+fn invalid_path_root() {
+    let token = std::env::var("DBX_OAUTH_TOKEN").expect("DBX_OAUTH_TOKEN must be set");
+    let mut client = UserAuthDefaultClient::new(token);
+    client.set_path_root(&PathRoot::NamespaceId("1".to_owned()));
+    match files::list_folder(&client, &ListFolderArg::new("/".to_owned())) {
+        // If the oauth token is for an app which only has access to its app folder, then the path
+        // root cannot be specified.
+        Err(dropbox_sdk::Error::BadRequest(msg)) if msg.contains("Path root is not supported for sandbox app") => (),
+
+        // If the oauth token is for a "whole dropbox" app, then we should get this error, which
+        // inside will have a "no_permission" error.
+        // If the error is due to a change in the user's home nsid, then we get an "invalid_root"
+        // error which includes the new nsid, but that's not what we expect here, where we're just
+        // giving a bogus nsid.
+        Err(dropbox_sdk::Error::UnexpectedHttpError { code: 422, json, .. }) => {
+            let error = serde_json::from_str::<serde_json::Value>(&json)
+                .unwrap_or_else(|e| panic!("invalid json {:?}: {}", json, e));
+            let tag = error.as_object()
+                .and_then(|map| map.get("error"))
+                .and_then(|v| v.as_object())
+                .and_then(|map| map.get(".tag"))
+                .and_then(|v| v.as_str())
+                .unwrap_or_else(|| panic!("got a weird error {}", json));
+
+            if tag != "no_permission" {
+                panic!("unexpected error kind in {:?}", json);
+            }
+        }
+
+        // Any other result is a bug.
+        otherwise => panic!("wrong result: {:?}", otherwise),
+    }
+}


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description below.
-->

This adds a `.set_root_path()` method to the client types in `default_client` which allow setting the `Dropbox-API-Path-Root` header, for specifying what namespace should be the root from which paths get resolved. This is mostly used in Team contexts to ensure that operations done against team folders are done as expected.

These methods require the `dbx_common` feature is enabled, because it uses the `PathRoot` type defined in that stone namespace. This feature is almost always going to be enabled automatically, because it's a dependency of most other namespaces.

## **Checklist**

**General Contributing**
<!-- Change [ ] to [x] if you have: -->
- [x] I have read the Code of Conduct and signed the [CLA](https://opensource.dropbox.com/cla/).
- [x] I have added an entry to the `RELEASE_NOTES.md` file, or believe it's not necessary for this change.

**Validation**
<!-- Describe which tests cover the changes you've made, and any additional manual validation you
     did to ensure the correctness of this change. Does this change warrant addition of new tests?
     Does this change have performance implications? Etc. -->
Added an integration test which verifies that setting an incorrect root results in the errors we expect. This validates that the header is being set appropriately.