### PR TITLE
update to ureq 2.0.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,8 +15,13 @@ log = "0.4"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 thiserror = "1.0"
-ureq = { version = "1.4", optional = true, default-features = false, features = ["native-tls"] }
 url = "2.1"
+
+[dependencies.ureq]
+version = "2.0.0"
+optional = true
+default-features = false
+features = ["tls"]
 
 [dev-dependencies]
 env_logger = "0.8"

--- a/README.md
+++ b/README.md
@@ -44,13 +44,13 @@ located at `dropbox_sdk::client_trait::HttpClient`. Implement this trait and
 pass it as the client argument.
 
 If you don't want to implement your own, this SDK comes with an optional
-default client that uses `ureq` and your system's native TLS library.  To use
-it, build with the `default_client` feature flag, and then there will be a
-set of clents in the `dropbox_sdk::default_client` module that you can use,
-corresponding to each of the authentication types Dropbox uses (see below). The
-default client needs a Dropbox API token; how you get one is up to you and your
-program. See the programs under [examples/](examples/) for examples, and see
-the helper code in the [oauth2](src/oauth2.rs) module.
+default client that uses `ureq` and `rustls`.  To use it, build with the
+`default_client` feature flag, and then there will be a set of clents in the
+`dropbox_sdk::default_client` module that you can use, corresponding to each of
+the authentication types Dropbox uses (see below). The default client needs a
+Dropbox API token; how you get one is up to you and your program. See the
+programs under [examples/](examples/) for examples, and see the helper code in
+the [oauth2](src/oauth2.rs) module.
 
 ## Authentication Types
 

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -4,6 +4,8 @@ xxxx-yy-zz
   method which adds the `Dropbox-API-Path-Root` header, which sets what namespace paths are
   evaluated relative to. This requires that the `dbx_common` feature is enabled, as it uses the
   `PathRoot` type defined in that namespace.
+* Updated to `ureq` 2.0.0. The only changes relevant to users of this crate is that it now uses
+  `rustls` instead of system-native TLS, and that transport errors raised may be of higher quality.
 
 # v0.10.0
 2020-12-11


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description below.
-->
While this is a major-version change to an important dependency, this is all hidden behind the `HttpClient` facade and none of it leaks out to users.

Therefore there should be no user-visible changes unless you really care about the TLS implementation, which has changed from platform-native TLS to `rustls`.

And of course, if you're not using `default_client` this has no effect whatsoever. :)

## **Checklist**

**General Contributing**
<!-- Change [ ] to [x] if you have: -->
- [x] I have read the Code of Conduct and signed the [CLA](https://opensource.dropbox.com/cla/).
- [x] I have added an entry to the `RELEASE_NOTES.md` file, or believe it's not necessary for this change.

**Validation**
<!-- Describe which tests cover the changes you've made, and any additional manual validation you
     did to ensure the correctness of this change. Does this change warrant addition of new tests?
     Does this change have performance implications? Etc. -->
Covered by existing integration tests.