### PR TITLE
make deserializer for unions more concise

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,5 +1,6 @@
 # v0.11.2
 xxxx-yy-zz
+* minor codegen change to make enum deserializers more concise
 * API spec update 2021-03-03
   * documentation, team_log updates
 

--- a/src/generated/account.rs
+++ b/src/generated/account.rs
@@ -46,19 +46,18 @@ impl<'de> ::serde::de::Deserialize<'de> for PhotoSourceArg {
                     Some(".tag") => map.next_value()?,
                     _ => return Err(de::Error::missing_field(".tag"))
                 };
-                match tag {
+                let value = match tag {
                     "base64_data" => {
                         match map.next_key()? {
-                            Some("base64_data") => Ok(PhotoSourceArg::Base64Data(map.next_value()?)),
-                            None => Err(de::Error::missing_field("base64_data")),
-                            _ => Err(de::Error::unknown_field(tag, VARIANTS))
+                            Some("base64_data") => PhotoSourceArg::Base64Data(map.next_value()?),
+                            None => return Err(de::Error::missing_field("base64_data")),
+                            _ => return Err(de::Error::unknown_field(tag, VARIANTS))
                         }
                     }
-                    _ => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(PhotoSourceArg::Other)
-                    }
-                }
+                    _ => PhotoSourceArg::Other,
+                };
+                crate::eat_json_fields(&mut map)?;
+                Ok(value)
             }
         }
         const VARIANTS: &[&str] = &["base64_data",
@@ -207,32 +206,16 @@ impl<'de> ::serde::de::Deserialize<'de> for SetProfilePhotoError {
                     Some(".tag") => map.next_value()?,
                     _ => return Err(de::Error::missing_field(".tag"))
                 };
-                match tag {
-                    "file_type_error" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(SetProfilePhotoError::FileTypeError)
-                    }
-                    "file_size_error" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(SetProfilePhotoError::FileSizeError)
-                    }
-                    "dimension_error" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(SetProfilePhotoError::DimensionError)
-                    }
-                    "thumbnail_error" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(SetProfilePhotoError::ThumbnailError)
-                    }
-                    "transient_error" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(SetProfilePhotoError::TransientError)
-                    }
-                    _ => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(SetProfilePhotoError::Other)
-                    }
-                }
+                let value = match tag {
+                    "file_type_error" => SetProfilePhotoError::FileTypeError,
+                    "file_size_error" => SetProfilePhotoError::FileSizeError,
+                    "dimension_error" => SetProfilePhotoError::DimensionError,
+                    "thumbnail_error" => SetProfilePhotoError::ThumbnailError,
+                    "transient_error" => SetProfilePhotoError::TransientError,
+                    _ => SetProfilePhotoError::Other,
+                };
+                crate::eat_json_fields(&mut map)?;
+                Ok(value)
             }
         }
         const VARIANTS: &[&str] = &["file_type_error",

--- a/src/generated/auth.rs
+++ b/src/generated/auth.rs
@@ -64,26 +64,25 @@ impl<'de> ::serde::de::Deserialize<'de> for AccessError {
                     Some(".tag") => map.next_value()?,
                     _ => return Err(de::Error::missing_field(".tag"))
                 };
-                match tag {
+                let value = match tag {
                     "invalid_account_type" => {
                         match map.next_key()? {
-                            Some("invalid_account_type") => Ok(AccessError::InvalidAccountType(map.next_value()?)),
-                            None => Err(de::Error::missing_field("invalid_account_type")),
-                            _ => Err(de::Error::unknown_field(tag, VARIANTS))
+                            Some("invalid_account_type") => AccessError::InvalidAccountType(map.next_value()?),
+                            None => return Err(de::Error::missing_field("invalid_account_type")),
+                            _ => return Err(de::Error::unknown_field(tag, VARIANTS))
                         }
                     }
                     "paper_access_denied" => {
                         match map.next_key()? {
-                            Some("paper_access_denied") => Ok(AccessError::PaperAccessDenied(map.next_value()?)),
-                            None => Err(de::Error::missing_field("paper_access_denied")),
-                            _ => Err(de::Error::unknown_field(tag, VARIANTS))
+                            Some("paper_access_denied") => AccessError::PaperAccessDenied(map.next_value()?),
+                            None => return Err(de::Error::missing_field("paper_access_denied")),
+                            _ => return Err(de::Error::unknown_field(tag, VARIANTS))
                         }
                     }
-                    _ => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(AccessError::Other)
-                    }
-                }
+                    _ => AccessError::Other,
+                };
+                crate::eat_json_fields(&mut map)?;
+                Ok(value)
             }
         }
         const VARIANTS: &[&str] = &["invalid_account_type",
@@ -175,37 +174,18 @@ impl<'de> ::serde::de::Deserialize<'de> for AuthError {
                     Some(".tag") => map.next_value()?,
                     _ => return Err(de::Error::missing_field(".tag"))
                 };
-                match tag {
-                    "invalid_access_token" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(AuthError::InvalidAccessToken)
-                    }
-                    "invalid_select_user" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(AuthError::InvalidSelectUser)
-                    }
-                    "invalid_select_admin" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(AuthError::InvalidSelectAdmin)
-                    }
-                    "user_suspended" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(AuthError::UserSuspended)
-                    }
-                    "expired_access_token" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(AuthError::ExpiredAccessToken)
-                    }
-                    "missing_scope" => Ok(AuthError::MissingScope(TokenScopeError::internal_deserialize(map)?)),
-                    "route_access_denied" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(AuthError::RouteAccessDenied)
-                    }
-                    _ => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(AuthError::Other)
-                    }
-                }
+                let value = match tag {
+                    "invalid_access_token" => AuthError::InvalidAccessToken,
+                    "invalid_select_user" => AuthError::InvalidSelectUser,
+                    "invalid_select_admin" => AuthError::InvalidSelectAdmin,
+                    "user_suspended" => AuthError::UserSuspended,
+                    "expired_access_token" => AuthError::ExpiredAccessToken,
+                    "missing_scope" => AuthError::MissingScope(TokenScopeError::internal_deserialize(&mut map)?),
+                    "route_access_denied" => AuthError::RouteAccessDenied,
+                    _ => AuthError::Other,
+                };
+                crate::eat_json_fields(&mut map)?;
+                Ok(value)
             }
         }
         const VARIANTS: &[&str] = &["invalid_access_token",
@@ -318,20 +298,13 @@ impl<'de> ::serde::de::Deserialize<'de> for InvalidAccountTypeError {
                     Some(".tag") => map.next_value()?,
                     _ => return Err(de::Error::missing_field(".tag"))
                 };
-                match tag {
-                    "endpoint" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(InvalidAccountTypeError::Endpoint)
-                    }
-                    "feature" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(InvalidAccountTypeError::Feature)
-                    }
-                    _ => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(InvalidAccountTypeError::Other)
-                    }
-                }
+                let value = match tag {
+                    "endpoint" => InvalidAccountTypeError::Endpoint,
+                    "feature" => InvalidAccountTypeError::Feature,
+                    _ => InvalidAccountTypeError::Other,
+                };
+                crate::eat_json_fields(&mut map)?;
+                Ok(value)
             }
         }
         const VARIANTS: &[&str] = &["endpoint",
@@ -403,20 +376,13 @@ impl<'de> ::serde::de::Deserialize<'de> for PaperAccessError {
                     Some(".tag") => map.next_value()?,
                     _ => return Err(de::Error::missing_field(".tag"))
                 };
-                match tag {
-                    "paper_disabled" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(PaperAccessError::PaperDisabled)
-                    }
-                    "not_paper_user" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(PaperAccessError::NotPaperUser)
-                    }
-                    _ => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(PaperAccessError::Other)
-                    }
-                }
+                let value = match tag {
+                    "paper_disabled" => PaperAccessError::PaperDisabled,
+                    "not_paper_user" => PaperAccessError::NotPaperUser,
+                    _ => PaperAccessError::Other,
+                };
+                crate::eat_json_fields(&mut map)?;
+                Ok(value)
             }
         }
         const VARIANTS: &[&str] = &["paper_disabled",
@@ -597,20 +563,13 @@ impl<'de> ::serde::de::Deserialize<'de> for RateLimitReason {
                     Some(".tag") => map.next_value()?,
                     _ => return Err(de::Error::missing_field(".tag"))
                 };
-                match tag {
-                    "too_many_requests" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(RateLimitReason::TooManyRequests)
-                    }
-                    "too_many_write_operations" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(RateLimitReason::TooManyWriteOperations)
-                    }
-                    _ => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(RateLimitReason::Other)
-                    }
-                }
+                let value = match tag {
+                    "too_many_requests" => RateLimitReason::TooManyRequests,
+                    "too_many_write_operations" => RateLimitReason::TooManyWriteOperations,
+                    _ => RateLimitReason::Other,
+                };
+                crate::eat_json_fields(&mut map)?;
+                Ok(value)
             }
         }
         const VARIANTS: &[&str] = &["too_many_requests",
@@ -772,20 +731,13 @@ impl<'de> ::serde::de::Deserialize<'de> for TokenFromOAuth1Error {
                     Some(".tag") => map.next_value()?,
                     _ => return Err(de::Error::missing_field(".tag"))
                 };
-                match tag {
-                    "invalid_oauth1_token_info" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(TokenFromOAuth1Error::InvalidOauth1TokenInfo)
-                    }
-                    "app_id_mismatch" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(TokenFromOAuth1Error::AppIdMismatch)
-                    }
-                    _ => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(TokenFromOAuth1Error::Other)
-                    }
-                }
+                let value = match tag {
+                    "invalid_oauth1_token_info" => TokenFromOAuth1Error::InvalidOauth1TokenInfo,
+                    "app_id_mismatch" => TokenFromOAuth1Error::AppIdMismatch,
+                    _ => TokenFromOAuth1Error::Other,
+                };
+                crate::eat_json_fields(&mut map)?;
+                Ok(value)
             }
         }
         const VARIANTS: &[&str] = &["invalid_oauth1_token_info",

--- a/src/generated/common.rs
+++ b/src/generated/common.rs
@@ -53,30 +53,26 @@ impl<'de> ::serde::de::Deserialize<'de> for PathRoot {
                     Some(".tag") => map.next_value()?,
                     _ => return Err(de::Error::missing_field(".tag"))
                 };
-                match tag {
-                    "home" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(PathRoot::Home)
-                    }
+                let value = match tag {
+                    "home" => PathRoot::Home,
                     "root" => {
                         match map.next_key()? {
-                            Some("root") => Ok(PathRoot::Root(map.next_value()?)),
-                            None => Err(de::Error::missing_field("root")),
-                            _ => Err(de::Error::unknown_field(tag, VARIANTS))
+                            Some("root") => PathRoot::Root(map.next_value()?),
+                            None => return Err(de::Error::missing_field("root")),
+                            _ => return Err(de::Error::unknown_field(tag, VARIANTS))
                         }
                     }
                     "namespace_id" => {
                         match map.next_key()? {
-                            Some("namespace_id") => Ok(PathRoot::NamespaceId(map.next_value()?)),
-                            None => Err(de::Error::missing_field("namespace_id")),
-                            _ => Err(de::Error::unknown_field(tag, VARIANTS))
+                            Some("namespace_id") => PathRoot::NamespaceId(map.next_value()?),
+                            None => return Err(de::Error::missing_field("namespace_id")),
+                            _ => return Err(de::Error::unknown_field(tag, VARIANTS))
                         }
                     }
-                    _ => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(PathRoot::Other)
-                    }
-                }
+                    _ => PathRoot::Other,
+                };
+                crate::eat_json_fields(&mut map)?;
+                Ok(value)
             }
         }
         const VARIANTS: &[&str] = &["home",
@@ -145,23 +141,19 @@ impl<'de> ::serde::de::Deserialize<'de> for PathRootError {
                     Some(".tag") => map.next_value()?,
                     _ => return Err(de::Error::missing_field(".tag"))
                 };
-                match tag {
+                let value = match tag {
                     "invalid_root" => {
                         match map.next_key()? {
-                            Some("invalid_root") => Ok(PathRootError::InvalidRoot(map.next_value()?)),
-                            None => Err(de::Error::missing_field("invalid_root")),
-                            _ => Err(de::Error::unknown_field(tag, VARIANTS))
+                            Some("invalid_root") => PathRootError::InvalidRoot(map.next_value()?),
+                            None => return Err(de::Error::missing_field("invalid_root")),
+                            _ => return Err(de::Error::unknown_field(tag, VARIANTS))
                         }
                     }
-                    "no_permission" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(PathRootError::NoPermission)
-                    }
-                    _ => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(PathRootError::Other)
-                    }
-                }
+                    "no_permission" => PathRootError::NoPermission,
+                    _ => PathRootError::Other,
+                };
+                crate::eat_json_fields(&mut map)?;
+                Ok(value)
             }
         }
         const VARIANTS: &[&str] = &["invalid_root",

--- a/src/generated/contacts.rs
+++ b/src/generated/contacts.rs
@@ -151,19 +151,18 @@ impl<'de> ::serde::de::Deserialize<'de> for DeleteManualContactsError {
                     Some(".tag") => map.next_value()?,
                     _ => return Err(de::Error::missing_field(".tag"))
                 };
-                match tag {
+                let value = match tag {
                     "contacts_not_found" => {
                         match map.next_key()? {
-                            Some("contacts_not_found") => Ok(DeleteManualContactsError::ContactsNotFound(map.next_value()?)),
-                            None => Err(de::Error::missing_field("contacts_not_found")),
-                            _ => Err(de::Error::unknown_field(tag, VARIANTS))
+                            Some("contacts_not_found") => DeleteManualContactsError::ContactsNotFound(map.next_value()?),
+                            None => return Err(de::Error::missing_field("contacts_not_found")),
+                            _ => return Err(de::Error::unknown_field(tag, VARIANTS))
                         }
                     }
-                    _ => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(DeleteManualContactsError::Other)
-                    }
-                }
+                    _ => DeleteManualContactsError::Other,
+                };
+                crate::eat_json_fields(&mut map)?;
+                Ok(value)
             }
         }
         const VARIANTS: &[&str] = &["contacts_not_found",

--- a/src/generated/dbx_async.rs
+++ b/src/generated/dbx_async.rs
@@ -35,20 +35,19 @@ impl<'de> ::serde::de::Deserialize<'de> for LaunchEmptyResult {
                     Some(".tag") => map.next_value()?,
                     _ => return Err(de::Error::missing_field(".tag"))
                 };
-                match tag {
+                let value = match tag {
                     "async_job_id" => {
                         match map.next_key()? {
-                            Some("async_job_id") => Ok(LaunchEmptyResult::AsyncJobId(map.next_value()?)),
-                            None => Err(de::Error::missing_field("async_job_id")),
-                            _ => Err(de::Error::unknown_field(tag, VARIANTS))
+                            Some("async_job_id") => LaunchEmptyResult::AsyncJobId(map.next_value()?),
+                            None => return Err(de::Error::missing_field("async_job_id")),
+                            _ => return Err(de::Error::unknown_field(tag, VARIANTS))
                         }
                     }
-                    "complete" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(LaunchEmptyResult::Complete)
-                    }
-                    _ => Err(de::Error::unknown_variant(tag, VARIANTS))
-                }
+                    "complete" => LaunchEmptyResult::Complete,
+                    _ => return Err(de::Error::unknown_variant(tag, VARIANTS))
+                };
+                crate::eat_json_fields(&mut map)?;
+                Ok(value)
             }
         }
         const VARIANTS: &[&str] = &["async_job_id",
@@ -105,16 +104,18 @@ impl<'de> ::serde::de::Deserialize<'de> for LaunchResultBase {
                     Some(".tag") => map.next_value()?,
                     _ => return Err(de::Error::missing_field(".tag"))
                 };
-                match tag {
+                let value = match tag {
                     "async_job_id" => {
                         match map.next_key()? {
-                            Some("async_job_id") => Ok(LaunchResultBase::AsyncJobId(map.next_value()?)),
-                            None => Err(de::Error::missing_field("async_job_id")),
-                            _ => Err(de::Error::unknown_field(tag, VARIANTS))
+                            Some("async_job_id") => LaunchResultBase::AsyncJobId(map.next_value()?),
+                            None => return Err(de::Error::missing_field("async_job_id")),
+                            _ => return Err(de::Error::unknown_field(tag, VARIANTS))
                         }
                     }
-                    _ => Err(de::Error::unknown_variant(tag, VARIANTS))
-                }
+                    _ => return Err(de::Error::unknown_variant(tag, VARIANTS))
+                };
+                crate::eat_json_fields(&mut map)?;
+                Ok(value)
             }
         }
         const VARIANTS: &[&str] = &["async_job_id"];
@@ -255,17 +256,13 @@ impl<'de> ::serde::de::Deserialize<'de> for PollEmptyResult {
                     Some(".tag") => map.next_value()?,
                     _ => return Err(de::Error::missing_field(".tag"))
                 };
-                match tag {
-                    "in_progress" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(PollEmptyResult::InProgress)
-                    }
-                    "complete" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(PollEmptyResult::Complete)
-                    }
-                    _ => Err(de::Error::unknown_variant(tag, VARIANTS))
-                }
+                let value = match tag {
+                    "in_progress" => PollEmptyResult::InProgress,
+                    "complete" => PollEmptyResult::Complete,
+                    _ => return Err(de::Error::unknown_variant(tag, VARIANTS))
+                };
+                crate::eat_json_fields(&mut map)?;
+                Ok(value)
             }
         }
         const VARIANTS: &[&str] = &["in_progress",
@@ -324,20 +321,13 @@ impl<'de> ::serde::de::Deserialize<'de> for PollError {
                     Some(".tag") => map.next_value()?,
                     _ => return Err(de::Error::missing_field(".tag"))
                 };
-                match tag {
-                    "invalid_async_job_id" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(PollError::InvalidAsyncJobId)
-                    }
-                    "internal_error" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(PollError::InternalError)
-                    }
-                    _ => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(PollError::Other)
-                    }
-                }
+                let value = match tag {
+                    "invalid_async_job_id" => PollError::InvalidAsyncJobId,
+                    "internal_error" => PollError::InternalError,
+                    _ => PollError::Other,
+                };
+                crate::eat_json_fields(&mut map)?;
+                Ok(value)
             }
         }
         const VARIANTS: &[&str] = &["invalid_async_job_id",
@@ -406,13 +396,12 @@ impl<'de> ::serde::de::Deserialize<'de> for PollResultBase {
                     Some(".tag") => map.next_value()?,
                     _ => return Err(de::Error::missing_field(".tag"))
                 };
-                match tag {
-                    "in_progress" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(PollResultBase::InProgress)
-                    }
-                    _ => Err(de::Error::unknown_variant(tag, VARIANTS))
-                }
+                let value = match tag {
+                    "in_progress" => PollResultBase::InProgress,
+                    _ => return Err(de::Error::unknown_variant(tag, VARIANTS))
+                };
+                crate::eat_json_fields(&mut map)?;
+                Ok(value)
             }
         }
         const VARIANTS: &[&str] = &["in_progress"];

--- a/src/generated/file_properties.rs
+++ b/src/generated/file_properties.rs
@@ -437,50 +437,31 @@ impl<'de> ::serde::de::Deserialize<'de> for AddPropertiesError {
                     Some(".tag") => map.next_value()?,
                     _ => return Err(de::Error::missing_field(".tag"))
                 };
-                match tag {
+                let value = match tag {
                     "template_not_found" => {
                         match map.next_key()? {
-                            Some("template_not_found") => Ok(AddPropertiesError::TemplateNotFound(map.next_value()?)),
-                            None => Err(de::Error::missing_field("template_not_found")),
-                            _ => Err(de::Error::unknown_field(tag, VARIANTS))
+                            Some("template_not_found") => AddPropertiesError::TemplateNotFound(map.next_value()?),
+                            None => return Err(de::Error::missing_field("template_not_found")),
+                            _ => return Err(de::Error::unknown_field(tag, VARIANTS))
                         }
                     }
-                    "restricted_content" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(AddPropertiesError::RestrictedContent)
-                    }
+                    "restricted_content" => AddPropertiesError::RestrictedContent,
                     "path" => {
                         match map.next_key()? {
-                            Some("path") => Ok(AddPropertiesError::Path(map.next_value()?)),
-                            None => Err(de::Error::missing_field("path")),
-                            _ => Err(de::Error::unknown_field(tag, VARIANTS))
+                            Some("path") => AddPropertiesError::Path(map.next_value()?),
+                            None => return Err(de::Error::missing_field("path")),
+                            _ => return Err(de::Error::unknown_field(tag, VARIANTS))
                         }
                     }
-                    "unsupported_folder" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(AddPropertiesError::UnsupportedFolder)
-                    }
-                    "property_field_too_large" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(AddPropertiesError::PropertyFieldTooLarge)
-                    }
-                    "does_not_fit_template" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(AddPropertiesError::DoesNotFitTemplate)
-                    }
-                    "duplicate_property_groups" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(AddPropertiesError::DuplicatePropertyGroups)
-                    }
-                    "property_group_already_exists" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(AddPropertiesError::PropertyGroupAlreadyExists)
-                    }
-                    _ => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(AddPropertiesError::Other)
-                    }
-                }
+                    "unsupported_folder" => AddPropertiesError::UnsupportedFolder,
+                    "property_field_too_large" => AddPropertiesError::PropertyFieldTooLarge,
+                    "does_not_fit_template" => AddPropertiesError::DoesNotFitTemplate,
+                    "duplicate_property_groups" => AddPropertiesError::DuplicatePropertyGroups,
+                    "property_group_already_exists" => AddPropertiesError::PropertyGroupAlreadyExists,
+                    _ => AddPropertiesError::Other,
+                };
+                crate::eat_json_fields(&mut map)?;
+                Ok(value)
             }
         }
         const VARIANTS: &[&str] = &["template_not_found",
@@ -1035,46 +1016,30 @@ impl<'de> ::serde::de::Deserialize<'de> for InvalidPropertyGroupError {
                     Some(".tag") => map.next_value()?,
                     _ => return Err(de::Error::missing_field(".tag"))
                 };
-                match tag {
+                let value = match tag {
                     "template_not_found" => {
                         match map.next_key()? {
-                            Some("template_not_found") => Ok(InvalidPropertyGroupError::TemplateNotFound(map.next_value()?)),
-                            None => Err(de::Error::missing_field("template_not_found")),
-                            _ => Err(de::Error::unknown_field(tag, VARIANTS))
+                            Some("template_not_found") => InvalidPropertyGroupError::TemplateNotFound(map.next_value()?),
+                            None => return Err(de::Error::missing_field("template_not_found")),
+                            _ => return Err(de::Error::unknown_field(tag, VARIANTS))
                         }
                     }
-                    "restricted_content" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(InvalidPropertyGroupError::RestrictedContent)
-                    }
+                    "restricted_content" => InvalidPropertyGroupError::RestrictedContent,
                     "path" => {
                         match map.next_key()? {
-                            Some("path") => Ok(InvalidPropertyGroupError::Path(map.next_value()?)),
-                            None => Err(de::Error::missing_field("path")),
-                            _ => Err(de::Error::unknown_field(tag, VARIANTS))
+                            Some("path") => InvalidPropertyGroupError::Path(map.next_value()?),
+                            None => return Err(de::Error::missing_field("path")),
+                            _ => return Err(de::Error::unknown_field(tag, VARIANTS))
                         }
                     }
-                    "unsupported_folder" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(InvalidPropertyGroupError::UnsupportedFolder)
-                    }
-                    "property_field_too_large" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(InvalidPropertyGroupError::PropertyFieldTooLarge)
-                    }
-                    "does_not_fit_template" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(InvalidPropertyGroupError::DoesNotFitTemplate)
-                    }
-                    "duplicate_property_groups" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(InvalidPropertyGroupError::DuplicatePropertyGroups)
-                    }
-                    _ => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(InvalidPropertyGroupError::Other)
-                    }
-                }
+                    "unsupported_folder" => InvalidPropertyGroupError::UnsupportedFolder,
+                    "property_field_too_large" => InvalidPropertyGroupError::PropertyFieldTooLarge,
+                    "does_not_fit_template" => InvalidPropertyGroupError::DoesNotFitTemplate,
+                    "duplicate_property_groups" => InvalidPropertyGroupError::DuplicatePropertyGroups,
+                    _ => InvalidPropertyGroupError::Other,
+                };
+                crate::eat_json_fields(&mut map)?;
+                Ok(value)
             }
         }
         const VARIANTS: &[&str] = &["template_not_found",
@@ -1285,16 +1250,12 @@ impl<'de> ::serde::de::Deserialize<'de> for LogicalOperator {
                     Some(".tag") => map.next_value()?,
                     _ => return Err(de::Error::missing_field(".tag"))
                 };
-                match tag {
-                    "or_operator" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(LogicalOperator::OrOperator)
-                    }
-                    _ => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(LogicalOperator::Other)
-                    }
-                }
+                let value = match tag {
+                    "or_operator" => LogicalOperator::OrOperator,
+                    _ => LogicalOperator::Other,
+                };
+                crate::eat_json_fields(&mut map)?;
+                Ok(value)
             }
         }
         const VARIANTS: &[&str] = &["or_operator",
@@ -1344,16 +1305,12 @@ impl<'de> ::serde::de::Deserialize<'de> for LookUpPropertiesError {
                     Some(".tag") => map.next_value()?,
                     _ => return Err(de::Error::missing_field(".tag"))
                 };
-                match tag {
-                    "property_group_not_found" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(LookUpPropertiesError::PropertyGroupNotFound)
-                    }
-                    _ => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(LookUpPropertiesError::Other)
-                    }
-                }
+                let value = match tag {
+                    "property_group_not_found" => LookUpPropertiesError::PropertyGroupNotFound,
+                    _ => LookUpPropertiesError::Other,
+                };
+                crate::eat_json_fields(&mut map)?;
+                Ok(value)
             }
         }
         const VARIANTS: &[&str] = &["property_group_not_found",
@@ -1423,35 +1380,22 @@ impl<'de> ::serde::de::Deserialize<'de> for LookupError {
                     Some(".tag") => map.next_value()?,
                     _ => return Err(de::Error::missing_field(".tag"))
                 };
-                match tag {
+                let value = match tag {
                     "malformed_path" => {
                         match map.next_key()? {
-                            Some("malformed_path") => Ok(LookupError::MalformedPath(map.next_value()?)),
-                            None => Err(de::Error::missing_field("malformed_path")),
-                            _ => Err(de::Error::unknown_field(tag, VARIANTS))
+                            Some("malformed_path") => LookupError::MalformedPath(map.next_value()?),
+                            None => return Err(de::Error::missing_field("malformed_path")),
+                            _ => return Err(de::Error::unknown_field(tag, VARIANTS))
                         }
                     }
-                    "not_found" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(LookupError::NotFound)
-                    }
-                    "not_file" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(LookupError::NotFile)
-                    }
-                    "not_folder" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(LookupError::NotFolder)
-                    }
-                    "restricted_content" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(LookupError::RestrictedContent)
-                    }
-                    _ => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(LookupError::Other)
-                    }
-                }
+                    "not_found" => LookupError::NotFound,
+                    "not_file" => LookupError::NotFile,
+                    "not_folder" => LookupError::NotFolder,
+                    "restricted_content" => LookupError::RestrictedContent,
+                    _ => LookupError::Other,
+                };
+                crate::eat_json_fields(&mut map)?;
+                Ok(value)
             }
         }
         const VARIANTS: &[&str] = &["malformed_path",
@@ -1557,39 +1501,23 @@ impl<'de> ::serde::de::Deserialize<'de> for ModifyTemplateError {
                     Some(".tag") => map.next_value()?,
                     _ => return Err(de::Error::missing_field(".tag"))
                 };
-                match tag {
+                let value = match tag {
                     "template_not_found" => {
                         match map.next_key()? {
-                            Some("template_not_found") => Ok(ModifyTemplateError::TemplateNotFound(map.next_value()?)),
-                            None => Err(de::Error::missing_field("template_not_found")),
-                            _ => Err(de::Error::unknown_field(tag, VARIANTS))
+                            Some("template_not_found") => ModifyTemplateError::TemplateNotFound(map.next_value()?),
+                            None => return Err(de::Error::missing_field("template_not_found")),
+                            _ => return Err(de::Error::unknown_field(tag, VARIANTS))
                         }
                     }
-                    "restricted_content" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(ModifyTemplateError::RestrictedContent)
-                    }
-                    "conflicting_property_names" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(ModifyTemplateError::ConflictingPropertyNames)
-                    }
-                    "too_many_properties" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(ModifyTemplateError::TooManyProperties)
-                    }
-                    "too_many_templates" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(ModifyTemplateError::TooManyTemplates)
-                    }
-                    "template_attribute_too_large" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(ModifyTemplateError::TemplateAttributeTooLarge)
-                    }
-                    _ => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(ModifyTemplateError::Other)
-                    }
-                }
+                    "restricted_content" => ModifyTemplateError::RestrictedContent,
+                    "conflicting_property_names" => ModifyTemplateError::ConflictingPropertyNames,
+                    "too_many_properties" => ModifyTemplateError::TooManyProperties,
+                    "too_many_templates" => ModifyTemplateError::TooManyTemplates,
+                    "template_attribute_too_large" => ModifyTemplateError::TemplateAttributeTooLarge,
+                    _ => ModifyTemplateError::Other,
+                };
+                crate::eat_json_fields(&mut map)?;
+                Ok(value)
             }
         }
         const VARIANTS: &[&str] = &["template_not_found",
@@ -1801,34 +1729,27 @@ impl<'de> ::serde::de::Deserialize<'de> for PropertiesError {
                     Some(".tag") => map.next_value()?,
                     _ => return Err(de::Error::missing_field(".tag"))
                 };
-                match tag {
+                let value = match tag {
                     "template_not_found" => {
                         match map.next_key()? {
-                            Some("template_not_found") => Ok(PropertiesError::TemplateNotFound(map.next_value()?)),
-                            None => Err(de::Error::missing_field("template_not_found")),
-                            _ => Err(de::Error::unknown_field(tag, VARIANTS))
+                            Some("template_not_found") => PropertiesError::TemplateNotFound(map.next_value()?),
+                            None => return Err(de::Error::missing_field("template_not_found")),
+                            _ => return Err(de::Error::unknown_field(tag, VARIANTS))
                         }
                     }
-                    "restricted_content" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(PropertiesError::RestrictedContent)
-                    }
+                    "restricted_content" => PropertiesError::RestrictedContent,
                     "path" => {
                         match map.next_key()? {
-                            Some("path") => Ok(PropertiesError::Path(map.next_value()?)),
-                            None => Err(de::Error::missing_field("path")),
-                            _ => Err(de::Error::unknown_field(tag, VARIANTS))
+                            Some("path") => PropertiesError::Path(map.next_value()?),
+                            None => return Err(de::Error::missing_field("path")),
+                            _ => return Err(de::Error::unknown_field(tag, VARIANTS))
                         }
                     }
-                    "unsupported_folder" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(PropertiesError::UnsupportedFolder)
-                    }
-                    _ => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(PropertiesError::Other)
-                    }
-                }
+                    "unsupported_folder" => PropertiesError::UnsupportedFolder,
+                    _ => PropertiesError::Other,
+                };
+                crate::eat_json_fields(&mut map)?;
+                Ok(value)
             }
         }
         const VARIANTS: &[&str] = &["template_not_found",
@@ -2122,16 +2043,12 @@ impl<'de> ::serde::de::Deserialize<'de> for PropertiesSearchContinueError {
                     Some(".tag") => map.next_value()?,
                     _ => return Err(de::Error::missing_field(".tag"))
                 };
-                match tag {
-                    "reset" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(PropertiesSearchContinueError::Reset)
-                    }
-                    _ => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(PropertiesSearchContinueError::Other)
-                    }
-                }
+                let value = match tag {
+                    "reset" => PropertiesSearchContinueError::Reset,
+                    _ => PropertiesSearchContinueError::Other,
+                };
+                crate::eat_json_fields(&mut map)?;
+                Ok(value)
             }
         }
         const VARIANTS: &[&str] = &["reset",
@@ -2189,19 +2106,18 @@ impl<'de> ::serde::de::Deserialize<'de> for PropertiesSearchError {
                     Some(".tag") => map.next_value()?,
                     _ => return Err(de::Error::missing_field(".tag"))
                 };
-                match tag {
+                let value = match tag {
                     "property_group_lookup" => {
                         match map.next_key()? {
-                            Some("property_group_lookup") => Ok(PropertiesSearchError::PropertyGroupLookup(map.next_value()?)),
-                            None => Err(de::Error::missing_field("property_group_lookup")),
-                            _ => Err(de::Error::unknown_field(tag, VARIANTS))
+                            Some("property_group_lookup") => PropertiesSearchError::PropertyGroupLookup(map.next_value()?),
+                            None => return Err(de::Error::missing_field("property_group_lookup")),
+                            _ => return Err(de::Error::unknown_field(tag, VARIANTS))
                         }
                     }
-                    _ => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(PropertiesSearchError::Other)
-                    }
-                }
+                    _ => PropertiesSearchError::Other,
+                };
+                crate::eat_json_fields(&mut map)?;
+                Ok(value)
             }
         }
         const VARIANTS: &[&str] = &["property_group_lookup",
@@ -2404,19 +2320,18 @@ impl<'de> ::serde::de::Deserialize<'de> for PropertiesSearchMode {
                     Some(".tag") => map.next_value()?,
                     _ => return Err(de::Error::missing_field(".tag"))
                 };
-                match tag {
+                let value = match tag {
                     "field_name" => {
                         match map.next_key()? {
-                            Some("field_name") => Ok(PropertiesSearchMode::FieldName(map.next_value()?)),
-                            None => Err(de::Error::missing_field("field_name")),
-                            _ => Err(de::Error::unknown_field(tag, VARIANTS))
+                            Some("field_name") => PropertiesSearchMode::FieldName(map.next_value()?),
+                            None => return Err(de::Error::missing_field("field_name")),
+                            _ => return Err(de::Error::unknown_field(tag, VARIANTS))
                         }
                     }
-                    _ => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(PropertiesSearchMode::Other)
-                    }
-                }
+                    _ => PropertiesSearchMode::Other,
+                };
+                crate::eat_json_fields(&mut map)?;
+                Ok(value)
             }
         }
         const VARIANTS: &[&str] = &["field_name",
@@ -3276,16 +3191,12 @@ impl<'de> ::serde::de::Deserialize<'de> for PropertyType {
                     Some(".tag") => map.next_value()?,
                     _ => return Err(de::Error::missing_field(".tag"))
                 };
-                match tag {
-                    "string" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(PropertyType::String)
-                    }
-                    _ => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(PropertyType::Other)
-                    }
-                }
+                let value = match tag {
+                    "string" => PropertyType::String,
+                    _ => PropertyType::Other,
+                };
+                crate::eat_json_fields(&mut map)?;
+                Ok(value)
             }
         }
         const VARIANTS: &[&str] = &["string",
@@ -3446,41 +3357,34 @@ impl<'de> ::serde::de::Deserialize<'de> for RemovePropertiesError {
                     Some(".tag") => map.next_value()?,
                     _ => return Err(de::Error::missing_field(".tag"))
                 };
-                match tag {
+                let value = match tag {
                     "template_not_found" => {
                         match map.next_key()? {
-                            Some("template_not_found") => Ok(RemovePropertiesError::TemplateNotFound(map.next_value()?)),
-                            None => Err(de::Error::missing_field("template_not_found")),
-                            _ => Err(de::Error::unknown_field(tag, VARIANTS))
+                            Some("template_not_found") => RemovePropertiesError::TemplateNotFound(map.next_value()?),
+                            None => return Err(de::Error::missing_field("template_not_found")),
+                            _ => return Err(de::Error::unknown_field(tag, VARIANTS))
                         }
                     }
-                    "restricted_content" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(RemovePropertiesError::RestrictedContent)
-                    }
+                    "restricted_content" => RemovePropertiesError::RestrictedContent,
                     "path" => {
                         match map.next_key()? {
-                            Some("path") => Ok(RemovePropertiesError::Path(map.next_value()?)),
-                            None => Err(de::Error::missing_field("path")),
-                            _ => Err(de::Error::unknown_field(tag, VARIANTS))
+                            Some("path") => RemovePropertiesError::Path(map.next_value()?),
+                            None => return Err(de::Error::missing_field("path")),
+                            _ => return Err(de::Error::unknown_field(tag, VARIANTS))
                         }
                     }
-                    "unsupported_folder" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(RemovePropertiesError::UnsupportedFolder)
-                    }
+                    "unsupported_folder" => RemovePropertiesError::UnsupportedFolder,
                     "property_group_lookup" => {
                         match map.next_key()? {
-                            Some("property_group_lookup") => Ok(RemovePropertiesError::PropertyGroupLookup(map.next_value()?)),
-                            None => Err(de::Error::missing_field("property_group_lookup")),
-                            _ => Err(de::Error::unknown_field(tag, VARIANTS))
+                            Some("property_group_lookup") => RemovePropertiesError::PropertyGroupLookup(map.next_value()?),
+                            None => return Err(de::Error::missing_field("property_group_lookup")),
+                            _ => return Err(de::Error::unknown_field(tag, VARIANTS))
                         }
                     }
-                    _ => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(RemovePropertiesError::Other)
-                    }
-                }
+                    _ => RemovePropertiesError::Other,
+                };
+                crate::eat_json_fields(&mut map)?;
+                Ok(value)
             }
         }
         const VARIANTS: &[&str] = &["template_not_found",
@@ -3677,23 +3581,19 @@ impl<'de> ::serde::de::Deserialize<'de> for TemplateError {
                     Some(".tag") => map.next_value()?,
                     _ => return Err(de::Error::missing_field(".tag"))
                 };
-                match tag {
+                let value = match tag {
                     "template_not_found" => {
                         match map.next_key()? {
-                            Some("template_not_found") => Ok(TemplateError::TemplateNotFound(map.next_value()?)),
-                            None => Err(de::Error::missing_field("template_not_found")),
-                            _ => Err(de::Error::unknown_field(tag, VARIANTS))
+                            Some("template_not_found") => TemplateError::TemplateNotFound(map.next_value()?),
+                            None => return Err(de::Error::missing_field("template_not_found")),
+                            _ => return Err(de::Error::unknown_field(tag, VARIANTS))
                         }
                     }
-                    "restricted_content" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(TemplateError::RestrictedContent)
-                    }
-                    _ => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(TemplateError::Other)
-                    }
-                }
+                    "restricted_content" => TemplateError::RestrictedContent,
+                    _ => TemplateError::Other,
+                };
+                crate::eat_json_fields(&mut map)?;
+                Ok(value)
             }
         }
         const VARIANTS: &[&str] = &["template_not_found",
@@ -3767,23 +3667,19 @@ impl<'de> ::serde::de::Deserialize<'de> for TemplateFilter {
                     Some(".tag") => map.next_value()?,
                     _ => return Err(de::Error::missing_field(".tag"))
                 };
-                match tag {
+                let value = match tag {
                     "filter_some" => {
                         match map.next_key()? {
-                            Some("filter_some") => Ok(TemplateFilter::FilterSome(map.next_value()?)),
-                            None => Err(de::Error::missing_field("filter_some")),
-                            _ => Err(de::Error::unknown_field(tag, VARIANTS))
+                            Some("filter_some") => TemplateFilter::FilterSome(map.next_value()?),
+                            None => return Err(de::Error::missing_field("filter_some")),
+                            _ => return Err(de::Error::unknown_field(tag, VARIANTS))
                         }
                     }
-                    "filter_none" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(TemplateFilter::FilterNone)
-                    }
-                    _ => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(TemplateFilter::Other)
-                    }
-                }
+                    "filter_none" => TemplateFilter::FilterNone,
+                    _ => TemplateFilter::Other,
+                };
+                crate::eat_json_fields(&mut map)?;
+                Ok(value)
             }
         }
         const VARIANTS: &[&str] = &["filter_some",
@@ -3842,19 +3738,18 @@ impl<'de> ::serde::de::Deserialize<'de> for TemplateFilterBase {
                     Some(".tag") => map.next_value()?,
                     _ => return Err(de::Error::missing_field(".tag"))
                 };
-                match tag {
+                let value = match tag {
                     "filter_some" => {
                         match map.next_key()? {
-                            Some("filter_some") => Ok(TemplateFilterBase::FilterSome(map.next_value()?)),
-                            None => Err(de::Error::missing_field("filter_some")),
-                            _ => Err(de::Error::unknown_field(tag, VARIANTS))
+                            Some("filter_some") => TemplateFilterBase::FilterSome(map.next_value()?),
+                            None => return Err(de::Error::missing_field("filter_some")),
+                            _ => return Err(de::Error::unknown_field(tag, VARIANTS))
                         }
                     }
-                    _ => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(TemplateFilterBase::Other)
-                    }
-                }
+                    _ => TemplateFilterBase::Other,
+                };
+                crate::eat_json_fields(&mut map)?;
+                Ok(value)
             }
         }
         const VARIANTS: &[&str] = &["filter_some",
@@ -3907,20 +3802,13 @@ impl<'de> ::serde::de::Deserialize<'de> for TemplateOwnerType {
                     Some(".tag") => map.next_value()?,
                     _ => return Err(de::Error::missing_field(".tag"))
                 };
-                match tag {
-                    "user" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(TemplateOwnerType::User)
-                    }
-                    "team" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(TemplateOwnerType::Team)
-                    }
-                    _ => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(TemplateOwnerType::Other)
-                    }
-                }
+                let value = match tag {
+                    "user" => TemplateOwnerType::User,
+                    "team" => TemplateOwnerType::Team,
+                    _ => TemplateOwnerType::Other,
+                };
+                crate::eat_json_fields(&mut map)?;
+                Ok(value)
             }
         }
         const VARIANTS: &[&str] = &["user",
@@ -4092,53 +3980,37 @@ impl<'de> ::serde::de::Deserialize<'de> for UpdatePropertiesError {
                     Some(".tag") => map.next_value()?,
                     _ => return Err(de::Error::missing_field(".tag"))
                 };
-                match tag {
+                let value = match tag {
                     "template_not_found" => {
                         match map.next_key()? {
-                            Some("template_not_found") => Ok(UpdatePropertiesError::TemplateNotFound(map.next_value()?)),
-                            None => Err(de::Error::missing_field("template_not_found")),
-                            _ => Err(de::Error::unknown_field(tag, VARIANTS))
+                            Some("template_not_found") => UpdatePropertiesError::TemplateNotFound(map.next_value()?),
+                            None => return Err(de::Error::missing_field("template_not_found")),
+                            _ => return Err(de::Error::unknown_field(tag, VARIANTS))
                         }
                     }
-                    "restricted_content" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(UpdatePropertiesError::RestrictedContent)
-                    }
+                    "restricted_content" => UpdatePropertiesError::RestrictedContent,
                     "path" => {
                         match map.next_key()? {
-                            Some("path") => Ok(UpdatePropertiesError::Path(map.next_value()?)),
-                            None => Err(de::Error::missing_field("path")),
-                            _ => Err(de::Error::unknown_field(tag, VARIANTS))
+                            Some("path") => UpdatePropertiesError::Path(map.next_value()?),
+                            None => return Err(de::Error::missing_field("path")),
+                            _ => return Err(de::Error::unknown_field(tag, VARIANTS))
                         }
                     }
-                    "unsupported_folder" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(UpdatePropertiesError::UnsupportedFolder)
-                    }
-                    "property_field_too_large" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(UpdatePropertiesError::PropertyFieldTooLarge)
-                    }
-                    "does_not_fit_template" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(UpdatePropertiesError::DoesNotFitTemplate)
-                    }
-                    "duplicate_property_groups" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(UpdatePropertiesError::DuplicatePropertyGroups)
-                    }
+                    "unsupported_folder" => UpdatePropertiesError::UnsupportedFolder,
+                    "property_field_too_large" => UpdatePropertiesError::PropertyFieldTooLarge,
+                    "does_not_fit_template" => UpdatePropertiesError::DoesNotFitTemplate,
+                    "duplicate_property_groups" => UpdatePropertiesError::DuplicatePropertyGroups,
                     "property_group_lookup" => {
                         match map.next_key()? {
-                            Some("property_group_lookup") => Ok(UpdatePropertiesError::PropertyGroupLookup(map.next_value()?)),
-                            None => Err(de::Error::missing_field("property_group_lookup")),
-                            _ => Err(de::Error::unknown_field(tag, VARIANTS))
+                            Some("property_group_lookup") => UpdatePropertiesError::PropertyGroupLookup(map.next_value()?),
+                            None => return Err(de::Error::missing_field("property_group_lookup")),
+                            _ => return Err(de::Error::unknown_field(tag, VARIANTS))
                         }
                     }
-                    _ => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(UpdatePropertiesError::Other)
-                    }
-                }
+                    _ => UpdatePropertiesError::Other,
+                };
+                crate::eat_json_fields(&mut map)?;
+                Ok(value)
             }
         }
         const VARIANTS: &[&str] = &["template_not_found",

--- a/src/generated/file_requests.rs
+++ b/src/generated/file_requests.rs
@@ -166,16 +166,12 @@ impl<'de> ::serde::de::Deserialize<'de> for CountFileRequestsError {
                     Some(".tag") => map.next_value()?,
                     _ => return Err(de::Error::missing_field(".tag"))
                 };
-                match tag {
-                    "disabled_for_team" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(CountFileRequestsError::DisabledForTeam)
-                    }
-                    _ => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(CountFileRequestsError::Other)
-                    }
-                }
+                let value = match tag {
+                    "disabled_for_team" => CountFileRequestsError::DisabledForTeam,
+                    _ => CountFileRequestsError::Other,
+                };
+                crate::eat_json_fields(&mut map)?;
+                Ok(value)
             }
         }
         const VARIANTS: &[&str] = &["disabled_for_team",
@@ -511,48 +507,20 @@ impl<'de> ::serde::de::Deserialize<'de> for CreateFileRequestError {
                     Some(".tag") => map.next_value()?,
                     _ => return Err(de::Error::missing_field(".tag"))
                 };
-                match tag {
-                    "disabled_for_team" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(CreateFileRequestError::DisabledForTeam)
-                    }
-                    "not_found" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(CreateFileRequestError::NotFound)
-                    }
-                    "not_a_folder" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(CreateFileRequestError::NotAFolder)
-                    }
-                    "app_lacks_access" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(CreateFileRequestError::AppLacksAccess)
-                    }
-                    "no_permission" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(CreateFileRequestError::NoPermission)
-                    }
-                    "email_unverified" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(CreateFileRequestError::EmailUnverified)
-                    }
-                    "validation_error" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(CreateFileRequestError::ValidationError)
-                    }
-                    "invalid_location" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(CreateFileRequestError::InvalidLocation)
-                    }
-                    "rate_limit" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(CreateFileRequestError::RateLimit)
-                    }
-                    _ => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(CreateFileRequestError::Other)
-                    }
-                }
+                let value = match tag {
+                    "disabled_for_team" => CreateFileRequestError::DisabledForTeam,
+                    "not_found" => CreateFileRequestError::NotFound,
+                    "not_a_folder" => CreateFileRequestError::NotAFolder,
+                    "app_lacks_access" => CreateFileRequestError::AppLacksAccess,
+                    "no_permission" => CreateFileRequestError::NoPermission,
+                    "email_unverified" => CreateFileRequestError::EmailUnverified,
+                    "validation_error" => CreateFileRequestError::ValidationError,
+                    "invalid_location" => CreateFileRequestError::InvalidLocation,
+                    "rate_limit" => CreateFileRequestError::RateLimit,
+                    _ => CreateFileRequestError::Other,
+                };
+                crate::eat_json_fields(&mut map)?;
+                Ok(value)
             }
         }
         const VARIANTS: &[&str] = &["disabled_for_team",
@@ -694,40 +662,18 @@ impl<'de> ::serde::de::Deserialize<'de> for DeleteAllClosedFileRequestsError {
                     Some(".tag") => map.next_value()?,
                     _ => return Err(de::Error::missing_field(".tag"))
                 };
-                match tag {
-                    "disabled_for_team" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(DeleteAllClosedFileRequestsError::DisabledForTeam)
-                    }
-                    "not_found" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(DeleteAllClosedFileRequestsError::NotFound)
-                    }
-                    "not_a_folder" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(DeleteAllClosedFileRequestsError::NotAFolder)
-                    }
-                    "app_lacks_access" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(DeleteAllClosedFileRequestsError::AppLacksAccess)
-                    }
-                    "no_permission" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(DeleteAllClosedFileRequestsError::NoPermission)
-                    }
-                    "email_unverified" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(DeleteAllClosedFileRequestsError::EmailUnverified)
-                    }
-                    "validation_error" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(DeleteAllClosedFileRequestsError::ValidationError)
-                    }
-                    _ => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(DeleteAllClosedFileRequestsError::Other)
-                    }
-                }
+                let value = match tag {
+                    "disabled_for_team" => DeleteAllClosedFileRequestsError::DisabledForTeam,
+                    "not_found" => DeleteAllClosedFileRequestsError::NotFound,
+                    "not_a_folder" => DeleteAllClosedFileRequestsError::NotAFolder,
+                    "app_lacks_access" => DeleteAllClosedFileRequestsError::AppLacksAccess,
+                    "no_permission" => DeleteAllClosedFileRequestsError::NoPermission,
+                    "email_unverified" => DeleteAllClosedFileRequestsError::EmailUnverified,
+                    "validation_error" => DeleteAllClosedFileRequestsError::ValidationError,
+                    _ => DeleteAllClosedFileRequestsError::Other,
+                };
+                crate::eat_json_fields(&mut map)?;
+                Ok(value)
             }
         }
         const VARIANTS: &[&str] = &["disabled_for_team",
@@ -1037,44 +983,19 @@ impl<'de> ::serde::de::Deserialize<'de> for DeleteFileRequestError {
                     Some(".tag") => map.next_value()?,
                     _ => return Err(de::Error::missing_field(".tag"))
                 };
-                match tag {
-                    "disabled_for_team" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(DeleteFileRequestError::DisabledForTeam)
-                    }
-                    "not_found" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(DeleteFileRequestError::NotFound)
-                    }
-                    "not_a_folder" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(DeleteFileRequestError::NotAFolder)
-                    }
-                    "app_lacks_access" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(DeleteFileRequestError::AppLacksAccess)
-                    }
-                    "no_permission" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(DeleteFileRequestError::NoPermission)
-                    }
-                    "email_unverified" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(DeleteFileRequestError::EmailUnverified)
-                    }
-                    "validation_error" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(DeleteFileRequestError::ValidationError)
-                    }
-                    "file_request_open" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(DeleteFileRequestError::FileRequestOpen)
-                    }
-                    _ => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(DeleteFileRequestError::Other)
-                    }
-                }
+                let value = match tag {
+                    "disabled_for_team" => DeleteFileRequestError::DisabledForTeam,
+                    "not_found" => DeleteFileRequestError::NotFound,
+                    "not_a_folder" => DeleteFileRequestError::NotAFolder,
+                    "app_lacks_access" => DeleteFileRequestError::AppLacksAccess,
+                    "no_permission" => DeleteFileRequestError::NoPermission,
+                    "email_unverified" => DeleteFileRequestError::EmailUnverified,
+                    "validation_error" => DeleteFileRequestError::ValidationError,
+                    "file_request_open" => DeleteFileRequestError::FileRequestOpen,
+                    _ => DeleteFileRequestError::Other,
+                };
+                crate::eat_json_fields(&mut map)?;
+                Ok(value)
             }
         }
         const VARIANTS: &[&str] = &["disabled_for_team",
@@ -1629,40 +1550,18 @@ impl<'de> ::serde::de::Deserialize<'de> for FileRequestError {
                     Some(".tag") => map.next_value()?,
                     _ => return Err(de::Error::missing_field(".tag"))
                 };
-                match tag {
-                    "disabled_for_team" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(FileRequestError::DisabledForTeam)
-                    }
-                    "not_found" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(FileRequestError::NotFound)
-                    }
-                    "not_a_folder" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(FileRequestError::NotAFolder)
-                    }
-                    "app_lacks_access" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(FileRequestError::AppLacksAccess)
-                    }
-                    "no_permission" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(FileRequestError::NoPermission)
-                    }
-                    "email_unverified" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(FileRequestError::EmailUnverified)
-                    }
-                    "validation_error" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(FileRequestError::ValidationError)
-                    }
-                    _ => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(FileRequestError::Other)
-                    }
-                }
+                let value = match tag {
+                    "disabled_for_team" => FileRequestError::DisabledForTeam,
+                    "not_found" => FileRequestError::NotFound,
+                    "not_a_folder" => FileRequestError::NotAFolder,
+                    "app_lacks_access" => FileRequestError::AppLacksAccess,
+                    "no_permission" => FileRequestError::NoPermission,
+                    "email_unverified" => FileRequestError::EmailUnverified,
+                    "validation_error" => FileRequestError::ValidationError,
+                    _ => FileRequestError::Other,
+                };
+                crate::eat_json_fields(&mut map)?;
+                Ok(value)
             }
         }
         const VARIANTS: &[&str] = &["disabled_for_team",
@@ -1772,16 +1671,12 @@ impl<'de> ::serde::de::Deserialize<'de> for GeneralFileRequestsError {
                     Some(".tag") => map.next_value()?,
                     _ => return Err(de::Error::missing_field(".tag"))
                 };
-                match tag {
-                    "disabled_for_team" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(GeneralFileRequestsError::DisabledForTeam)
-                    }
-                    _ => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(GeneralFileRequestsError::Other)
-                    }
-                }
+                let value = match tag {
+                    "disabled_for_team" => GeneralFileRequestsError::DisabledForTeam,
+                    _ => GeneralFileRequestsError::Other,
+                };
+                crate::eat_json_fields(&mut map)?;
+                Ok(value)
             }
         }
         const VARIANTS: &[&str] = &["disabled_for_team",
@@ -1951,40 +1846,18 @@ impl<'de> ::serde::de::Deserialize<'de> for GetFileRequestError {
                     Some(".tag") => map.next_value()?,
                     _ => return Err(de::Error::missing_field(".tag"))
                 };
-                match tag {
-                    "disabled_for_team" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(GetFileRequestError::DisabledForTeam)
-                    }
-                    "not_found" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(GetFileRequestError::NotFound)
-                    }
-                    "not_a_folder" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(GetFileRequestError::NotAFolder)
-                    }
-                    "app_lacks_access" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(GetFileRequestError::AppLacksAccess)
-                    }
-                    "no_permission" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(GetFileRequestError::NoPermission)
-                    }
-                    "email_unverified" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(GetFileRequestError::EmailUnverified)
-                    }
-                    "validation_error" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(GetFileRequestError::ValidationError)
-                    }
-                    _ => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(GetFileRequestError::Other)
-                    }
-                }
+                let value = match tag {
+                    "disabled_for_team" => GetFileRequestError::DisabledForTeam,
+                    "not_found" => GetFileRequestError::NotFound,
+                    "not_a_folder" => GetFileRequestError::NotAFolder,
+                    "app_lacks_access" => GetFileRequestError::AppLacksAccess,
+                    "no_permission" => GetFileRequestError::NoPermission,
+                    "email_unverified" => GetFileRequestError::EmailUnverified,
+                    "validation_error" => GetFileRequestError::ValidationError,
+                    _ => GetFileRequestError::Other,
+                };
+                crate::eat_json_fields(&mut map)?;
+                Ok(value)
             }
         }
         const VARIANTS: &[&str] = &["disabled_for_team",
@@ -2096,32 +1969,16 @@ impl<'de> ::serde::de::Deserialize<'de> for GracePeriod {
                     Some(".tag") => map.next_value()?,
                     _ => return Err(de::Error::missing_field(".tag"))
                 };
-                match tag {
-                    "one_day" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(GracePeriod::OneDay)
-                    }
-                    "two_days" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(GracePeriod::TwoDays)
-                    }
-                    "seven_days" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(GracePeriod::SevenDays)
-                    }
-                    "thirty_days" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(GracePeriod::ThirtyDays)
-                    }
-                    "always" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(GracePeriod::Always)
-                    }
-                    _ => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(GracePeriod::Other)
-                    }
-                }
+                let value = match tag {
+                    "one_day" => GracePeriod::OneDay,
+                    "two_days" => GracePeriod::TwoDays,
+                    "seven_days" => GracePeriod::SevenDays,
+                    "thirty_days" => GracePeriod::ThirtyDays,
+                    "always" => GracePeriod::Always,
+                    _ => GracePeriod::Other,
+                };
+                crate::eat_json_fields(&mut map)?;
+                Ok(value)
             }
         }
         const VARIANTS: &[&str] = &["one_day",
@@ -2379,20 +2236,13 @@ impl<'de> ::serde::de::Deserialize<'de> for ListFileRequestsContinueError {
                     Some(".tag") => map.next_value()?,
                     _ => return Err(de::Error::missing_field(".tag"))
                 };
-                match tag {
-                    "disabled_for_team" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(ListFileRequestsContinueError::DisabledForTeam)
-                    }
-                    "invalid_cursor" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(ListFileRequestsContinueError::InvalidCursor)
-                    }
-                    _ => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(ListFileRequestsContinueError::Other)
-                    }
-                }
+                let value = match tag {
+                    "disabled_for_team" => ListFileRequestsContinueError::DisabledForTeam,
+                    "invalid_cursor" => ListFileRequestsContinueError::InvalidCursor,
+                    _ => ListFileRequestsContinueError::Other,
+                };
+                crate::eat_json_fields(&mut map)?;
+                Ok(value)
             }
         }
         const VARIANTS: &[&str] = &["disabled_for_team",
@@ -2463,16 +2313,12 @@ impl<'de> ::serde::de::Deserialize<'de> for ListFileRequestsError {
                     Some(".tag") => map.next_value()?,
                     _ => return Err(de::Error::missing_field(".tag"))
                 };
-                match tag {
-                    "disabled_for_team" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(ListFileRequestsError::DisabledForTeam)
-                    }
-                    _ => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(ListFileRequestsError::Other)
-                    }
-                }
+                let value = match tag {
+                    "disabled_for_team" => ListFileRequestsError::DisabledForTeam,
+                    _ => ListFileRequestsError::Other,
+                };
+                crate::eat_json_fields(&mut map)?;
+                Ok(value)
             }
         }
         const VARIANTS: &[&str] = &["disabled_for_team",
@@ -2930,17 +2776,13 @@ impl<'de> ::serde::de::Deserialize<'de> for UpdateFileRequestDeadline {
                     Some(".tag") => map.next_value()?,
                     _ => return Err(de::Error::missing_field(".tag"))
                 };
-                match tag {
-                    "no_update" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(UpdateFileRequestDeadline::NoUpdate)
-                    }
-                    "update" => Ok(UpdateFileRequestDeadline::Update(FileRequestDeadline::internal_deserialize_opt(map, true)?)),
-                    _ => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(UpdateFileRequestDeadline::Other)
-                    }
-                }
+                let value = match tag {
+                    "no_update" => UpdateFileRequestDeadline::NoUpdate,
+                    "update" => UpdateFileRequestDeadline::Update(FileRequestDeadline::internal_deserialize_opt(&mut map, true)?),
+                    _ => UpdateFileRequestDeadline::Other,
+                };
+                crate::eat_json_fields(&mut map)?;
+                Ok(value)
             }
         }
         const VARIANTS: &[&str] = &["no_update",
@@ -3018,40 +2860,18 @@ impl<'de> ::serde::de::Deserialize<'de> for UpdateFileRequestError {
                     Some(".tag") => map.next_value()?,
                     _ => return Err(de::Error::missing_field(".tag"))
                 };
-                match tag {
-                    "disabled_for_team" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(UpdateFileRequestError::DisabledForTeam)
-                    }
-                    "not_found" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(UpdateFileRequestError::NotFound)
-                    }
-                    "not_a_folder" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(UpdateFileRequestError::NotAFolder)
-                    }
-                    "app_lacks_access" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(UpdateFileRequestError::AppLacksAccess)
-                    }
-                    "no_permission" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(UpdateFileRequestError::NoPermission)
-                    }
-                    "email_unverified" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(UpdateFileRequestError::EmailUnverified)
-                    }
-                    "validation_error" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(UpdateFileRequestError::ValidationError)
-                    }
-                    _ => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(UpdateFileRequestError::Other)
-                    }
-                }
+                let value = match tag {
+                    "disabled_for_team" => UpdateFileRequestError::DisabledForTeam,
+                    "not_found" => UpdateFileRequestError::NotFound,
+                    "not_a_folder" => UpdateFileRequestError::NotAFolder,
+                    "app_lacks_access" => UpdateFileRequestError::AppLacksAccess,
+                    "no_permission" => UpdateFileRequestError::NoPermission,
+                    "email_unverified" => UpdateFileRequestError::EmailUnverified,
+                    "validation_error" => UpdateFileRequestError::ValidationError,
+                    _ => UpdateFileRequestError::Other,
+                };
+                crate::eat_json_fields(&mut map)?;
+                Ok(value)
             }
         }
         const VARIANTS: &[&str] = &["disabled_for_team",

--- a/src/generated/files.rs
+++ b/src/generated/files.rs
@@ -1415,23 +1415,25 @@ impl<'de> ::serde::de::Deserialize<'de> for AlphaGetMetadataError {
                     Some(".tag") => map.next_value()?,
                     _ => return Err(de::Error::missing_field(".tag"))
                 };
-                match tag {
+                let value = match tag {
                     "path" => {
                         match map.next_key()? {
-                            Some("path") => Ok(AlphaGetMetadataError::Path(map.next_value()?)),
-                            None => Err(de::Error::missing_field("path")),
-                            _ => Err(de::Error::unknown_field(tag, VARIANTS))
+                            Some("path") => AlphaGetMetadataError::Path(map.next_value()?),
+                            None => return Err(de::Error::missing_field("path")),
+                            _ => return Err(de::Error::unknown_field(tag, VARIANTS))
                         }
                     }
                     "properties_error" => {
                         match map.next_key()? {
-                            Some("properties_error") => Ok(AlphaGetMetadataError::PropertiesError(map.next_value()?)),
-                            None => Err(de::Error::missing_field("properties_error")),
-                            _ => Err(de::Error::unknown_field(tag, VARIANTS))
+                            Some("properties_error") => AlphaGetMetadataError::PropertiesError(map.next_value()?),
+                            None => return Err(de::Error::missing_field("properties_error")),
+                            _ => return Err(de::Error::unknown_field(tag, VARIANTS))
                         }
                     }
-                    _ => Err(de::Error::unknown_variant(tag, VARIANTS))
-                }
+                    _ => return Err(de::Error::unknown_variant(tag, VARIANTS))
+                };
+                crate::eat_json_fields(&mut map)?;
+                Ok(value)
             }
         }
         const VARIANTS: &[&str] = &["path",
@@ -2371,16 +2373,12 @@ impl<'de> ::serde::de::Deserialize<'de> for CreateFolderBatchError {
                     Some(".tag") => map.next_value()?,
                     _ => return Err(de::Error::missing_field(".tag"))
                 };
-                match tag {
-                    "too_many_files" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(CreateFolderBatchError::TooManyFiles)
-                    }
-                    _ => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(CreateFolderBatchError::Other)
-                    }
-                }
+                let value = match tag {
+                    "too_many_files" => CreateFolderBatchError::TooManyFiles,
+                    _ => CreateFolderBatchError::Other,
+                };
+                crate::eat_json_fields(&mut map)?;
+                Ok(value)
             }
         }
         const VARIANTS: &[&str] = &["too_many_files",
@@ -2446,24 +2444,20 @@ impl<'de> ::serde::de::Deserialize<'de> for CreateFolderBatchJobStatus {
                     Some(".tag") => map.next_value()?,
                     _ => return Err(de::Error::missing_field(".tag"))
                 };
-                match tag {
-                    "in_progress" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(CreateFolderBatchJobStatus::InProgress)
-                    }
-                    "complete" => Ok(CreateFolderBatchJobStatus::Complete(CreateFolderBatchResult::internal_deserialize(map)?)),
+                let value = match tag {
+                    "in_progress" => CreateFolderBatchJobStatus::InProgress,
+                    "complete" => CreateFolderBatchJobStatus::Complete(CreateFolderBatchResult::internal_deserialize(&mut map)?),
                     "failed" => {
                         match map.next_key()? {
-                            Some("failed") => Ok(CreateFolderBatchJobStatus::Failed(map.next_value()?)),
-                            None => Err(de::Error::missing_field("failed")),
-                            _ => Err(de::Error::unknown_field(tag, VARIANTS))
+                            Some("failed") => CreateFolderBatchJobStatus::Failed(map.next_value()?),
+                            None => return Err(de::Error::missing_field("failed")),
+                            _ => return Err(de::Error::unknown_field(tag, VARIANTS))
                         }
                     }
-                    _ => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(CreateFolderBatchJobStatus::Other)
-                    }
-                }
+                    _ => CreateFolderBatchJobStatus::Other,
+                };
+                crate::eat_json_fields(&mut map)?;
+                Ok(value)
             }
         }
         const VARIANTS: &[&str] = &["in_progress",
@@ -2533,20 +2527,19 @@ impl<'de> ::serde::de::Deserialize<'de> for CreateFolderBatchLaunch {
                     Some(".tag") => map.next_value()?,
                     _ => return Err(de::Error::missing_field(".tag"))
                 };
-                match tag {
+                let value = match tag {
                     "async_job_id" => {
                         match map.next_key()? {
-                            Some("async_job_id") => Ok(CreateFolderBatchLaunch::AsyncJobId(map.next_value()?)),
-                            None => Err(de::Error::missing_field("async_job_id")),
-                            _ => Err(de::Error::unknown_field(tag, VARIANTS))
+                            Some("async_job_id") => CreateFolderBatchLaunch::AsyncJobId(map.next_value()?),
+                            None => return Err(de::Error::missing_field("async_job_id")),
+                            _ => return Err(de::Error::unknown_field(tag, VARIANTS))
                         }
                     }
-                    "complete" => Ok(CreateFolderBatchLaunch::Complete(CreateFolderBatchResult::internal_deserialize(map)?)),
-                    _ => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(CreateFolderBatchLaunch::Other)
-                    }
-                }
+                    "complete" => CreateFolderBatchLaunch::Complete(CreateFolderBatchResult::internal_deserialize(&mut map)?),
+                    _ => CreateFolderBatchLaunch::Other,
+                };
+                crate::eat_json_fields(&mut map)?;
+                Ok(value)
             }
         }
         const VARIANTS: &[&str] = &["async_job_id",
@@ -2692,17 +2685,19 @@ impl<'de> ::serde::de::Deserialize<'de> for CreateFolderBatchResultEntry {
                     Some(".tag") => map.next_value()?,
                     _ => return Err(de::Error::missing_field(".tag"))
                 };
-                match tag {
-                    "success" => Ok(CreateFolderBatchResultEntry::Success(CreateFolderEntryResult::internal_deserialize(map)?)),
+                let value = match tag {
+                    "success" => CreateFolderBatchResultEntry::Success(CreateFolderEntryResult::internal_deserialize(&mut map)?),
                     "failure" => {
                         match map.next_key()? {
-                            Some("failure") => Ok(CreateFolderBatchResultEntry::Failure(map.next_value()?)),
-                            None => Err(de::Error::missing_field("failure")),
-                            _ => Err(de::Error::unknown_field(tag, VARIANTS))
+                            Some("failure") => CreateFolderBatchResultEntry::Failure(map.next_value()?),
+                            None => return Err(de::Error::missing_field("failure")),
+                            _ => return Err(de::Error::unknown_field(tag, VARIANTS))
                         }
                     }
-                    _ => Err(de::Error::unknown_variant(tag, VARIANTS))
-                }
+                    _ => return Err(de::Error::unknown_variant(tag, VARIANTS))
+                };
+                crate::eat_json_fields(&mut map)?;
+                Ok(value)
             }
         }
         const VARIANTS: &[&str] = &["success",
@@ -2758,19 +2753,18 @@ impl<'de> ::serde::de::Deserialize<'de> for CreateFolderEntryError {
                     Some(".tag") => map.next_value()?,
                     _ => return Err(de::Error::missing_field(".tag"))
                 };
-                match tag {
+                let value = match tag {
                     "path" => {
                         match map.next_key()? {
-                            Some("path") => Ok(CreateFolderEntryError::Path(map.next_value()?)),
-                            None => Err(de::Error::missing_field("path")),
-                            _ => Err(de::Error::unknown_field(tag, VARIANTS))
+                            Some("path") => CreateFolderEntryError::Path(map.next_value()?),
+                            None => return Err(de::Error::missing_field("path")),
+                            _ => return Err(de::Error::unknown_field(tag, VARIANTS))
                         }
                     }
-                    _ => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(CreateFolderEntryError::Other)
-                    }
-                }
+                    _ => CreateFolderEntryError::Other,
+                };
+                crate::eat_json_fields(&mut map)?;
+                Ok(value)
             }
         }
         const VARIANTS: &[&str] = &["path",
@@ -2924,16 +2918,18 @@ impl<'de> ::serde::de::Deserialize<'de> for CreateFolderError {
                     Some(".tag") => map.next_value()?,
                     _ => return Err(de::Error::missing_field(".tag"))
                 };
-                match tag {
+                let value = match tag {
                     "path" => {
                         match map.next_key()? {
-                            Some("path") => Ok(CreateFolderError::Path(map.next_value()?)),
-                            None => Err(de::Error::missing_field("path")),
-                            _ => Err(de::Error::unknown_field(tag, VARIANTS))
+                            Some("path") => CreateFolderError::Path(map.next_value()?),
+                            None => return Err(de::Error::missing_field("path")),
+                            _ => return Err(de::Error::unknown_field(tag, VARIANTS))
                         }
                     }
-                    _ => Err(de::Error::unknown_variant(tag, VARIANTS))
-                }
+                    _ => return Err(de::Error::unknown_variant(tag, VARIANTS))
+                };
+                crate::eat_json_fields(&mut map)?;
+                Ok(value)
             }
         }
         const VARIANTS: &[&str] = &["path"];
@@ -3288,16 +3284,12 @@ impl<'de> ::serde::de::Deserialize<'de> for DeleteBatchError {
                     Some(".tag") => map.next_value()?,
                     _ => return Err(de::Error::missing_field(".tag"))
                 };
-                match tag {
-                    "too_many_write_operations" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(DeleteBatchError::TooManyWriteOperations)
-                    }
-                    _ => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(DeleteBatchError::Other)
-                    }
-                }
+                let value = match tag {
+                    "too_many_write_operations" => DeleteBatchError::TooManyWriteOperations,
+                    _ => DeleteBatchError::Other,
+                };
+                crate::eat_json_fields(&mut map)?;
+                Ok(value)
             }
         }
         const VARIANTS: &[&str] = &["too_many_write_operations",
@@ -3360,24 +3352,20 @@ impl<'de> ::serde::de::Deserialize<'de> for DeleteBatchJobStatus {
                     Some(".tag") => map.next_value()?,
                     _ => return Err(de::Error::missing_field(".tag"))
                 };
-                match tag {
-                    "in_progress" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(DeleteBatchJobStatus::InProgress)
-                    }
-                    "complete" => Ok(DeleteBatchJobStatus::Complete(DeleteBatchResult::internal_deserialize(map)?)),
+                let value = match tag {
+                    "in_progress" => DeleteBatchJobStatus::InProgress,
+                    "complete" => DeleteBatchJobStatus::Complete(DeleteBatchResult::internal_deserialize(&mut map)?),
                     "failed" => {
                         match map.next_key()? {
-                            Some("failed") => Ok(DeleteBatchJobStatus::Failed(map.next_value()?)),
-                            None => Err(de::Error::missing_field("failed")),
-                            _ => Err(de::Error::unknown_field(tag, VARIANTS))
+                            Some("failed") => DeleteBatchJobStatus::Failed(map.next_value()?),
+                            None => return Err(de::Error::missing_field("failed")),
+                            _ => return Err(de::Error::unknown_field(tag, VARIANTS))
                         }
                     }
-                    _ => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(DeleteBatchJobStatus::Other)
-                    }
-                }
+                    _ => DeleteBatchJobStatus::Other,
+                };
+                crate::eat_json_fields(&mut map)?;
+                Ok(value)
             }
         }
         const VARIANTS: &[&str] = &["in_progress",
@@ -3447,20 +3435,19 @@ impl<'de> ::serde::de::Deserialize<'de> for DeleteBatchLaunch {
                     Some(".tag") => map.next_value()?,
                     _ => return Err(de::Error::missing_field(".tag"))
                 };
-                match tag {
+                let value = match tag {
                     "async_job_id" => {
                         match map.next_key()? {
-                            Some("async_job_id") => Ok(DeleteBatchLaunch::AsyncJobId(map.next_value()?)),
-                            None => Err(de::Error::missing_field("async_job_id")),
-                            _ => Err(de::Error::unknown_field(tag, VARIANTS))
+                            Some("async_job_id") => DeleteBatchLaunch::AsyncJobId(map.next_value()?),
+                            None => return Err(de::Error::missing_field("async_job_id")),
+                            _ => return Err(de::Error::unknown_field(tag, VARIANTS))
                         }
                     }
-                    "complete" => Ok(DeleteBatchLaunch::Complete(DeleteBatchResult::internal_deserialize(map)?)),
-                    _ => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(DeleteBatchLaunch::Other)
-                    }
-                }
+                    "complete" => DeleteBatchLaunch::Complete(DeleteBatchResult::internal_deserialize(&mut map)?),
+                    _ => DeleteBatchLaunch::Other,
+                };
+                crate::eat_json_fields(&mut map)?;
+                Ok(value)
             }
         }
         const VARIANTS: &[&str] = &["async_job_id",
@@ -3696,17 +3683,19 @@ impl<'de> ::serde::de::Deserialize<'de> for DeleteBatchResultEntry {
                     Some(".tag") => map.next_value()?,
                     _ => return Err(de::Error::missing_field(".tag"))
                 };
-                match tag {
-                    "success" => Ok(DeleteBatchResultEntry::Success(DeleteBatchResultData::internal_deserialize(map)?)),
+                let value = match tag {
+                    "success" => DeleteBatchResultEntry::Success(DeleteBatchResultData::internal_deserialize(&mut map)?),
                     "failure" => {
                         match map.next_key()? {
-                            Some("failure") => Ok(DeleteBatchResultEntry::Failure(map.next_value()?)),
-                            None => Err(de::Error::missing_field("failure")),
-                            _ => Err(de::Error::unknown_field(tag, VARIANTS))
+                            Some("failure") => DeleteBatchResultEntry::Failure(map.next_value()?),
+                            None => return Err(de::Error::missing_field("failure")),
+                            _ => return Err(de::Error::unknown_field(tag, VARIANTS))
                         }
                     }
-                    _ => Err(de::Error::unknown_variant(tag, VARIANTS))
-                }
+                    _ => return Err(de::Error::unknown_variant(tag, VARIANTS))
+                };
+                crate::eat_json_fields(&mut map)?;
+                Ok(value)
             }
         }
         const VARIANTS: &[&str] = &["success",
@@ -3767,34 +3756,27 @@ impl<'de> ::serde::de::Deserialize<'de> for DeleteError {
                     Some(".tag") => map.next_value()?,
                     _ => return Err(de::Error::missing_field(".tag"))
                 };
-                match tag {
+                let value = match tag {
                     "path_lookup" => {
                         match map.next_key()? {
-                            Some("path_lookup") => Ok(DeleteError::PathLookup(map.next_value()?)),
-                            None => Err(de::Error::missing_field("path_lookup")),
-                            _ => Err(de::Error::unknown_field(tag, VARIANTS))
+                            Some("path_lookup") => DeleteError::PathLookup(map.next_value()?),
+                            None => return Err(de::Error::missing_field("path_lookup")),
+                            _ => return Err(de::Error::unknown_field(tag, VARIANTS))
                         }
                     }
                     "path_write" => {
                         match map.next_key()? {
-                            Some("path_write") => Ok(DeleteError::PathWrite(map.next_value()?)),
-                            None => Err(de::Error::missing_field("path_write")),
-                            _ => Err(de::Error::unknown_field(tag, VARIANTS))
+                            Some("path_write") => DeleteError::PathWrite(map.next_value()?),
+                            None => return Err(de::Error::missing_field("path_write")),
+                            _ => return Err(de::Error::unknown_field(tag, VARIANTS))
                         }
                     }
-                    "too_many_write_operations" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(DeleteError::TooManyWriteOperations)
-                    }
-                    "too_many_files" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(DeleteError::TooManyFiles)
-                    }
-                    _ => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(DeleteError::Other)
-                    }
-                }
+                    "too_many_write_operations" => DeleteError::TooManyWriteOperations,
+                    "too_many_files" => DeleteError::TooManyFiles,
+                    _ => DeleteError::Other,
+                };
+                crate::eat_json_fields(&mut map)?;
+                Ok(value)
             }
         }
         const VARIANTS: &[&str] = &["path_lookup",
@@ -4344,23 +4326,19 @@ impl<'de> ::serde::de::Deserialize<'de> for DownloadError {
                     Some(".tag") => map.next_value()?,
                     _ => return Err(de::Error::missing_field(".tag"))
                 };
-                match tag {
+                let value = match tag {
                     "path" => {
                         match map.next_key()? {
-                            Some("path") => Ok(DownloadError::Path(map.next_value()?)),
-                            None => Err(de::Error::missing_field("path")),
-                            _ => Err(de::Error::unknown_field(tag, VARIANTS))
+                            Some("path") => DownloadError::Path(map.next_value()?),
+                            None => return Err(de::Error::missing_field("path")),
+                            _ => return Err(de::Error::unknown_field(tag, VARIANTS))
                         }
                     }
-                    "unsupported_file" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(DownloadError::UnsupportedFile)
-                    }
-                    _ => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(DownloadError::Other)
-                    }
-                }
+                    "unsupported_file" => DownloadError::UnsupportedFile,
+                    _ => DownloadError::Other,
+                };
+                crate::eat_json_fields(&mut map)?;
+                Ok(value)
             }
         }
         const VARIANTS: &[&str] = &["path",
@@ -4529,27 +4507,20 @@ impl<'de> ::serde::de::Deserialize<'de> for DownloadZipError {
                     Some(".tag") => map.next_value()?,
                     _ => return Err(de::Error::missing_field(".tag"))
                 };
-                match tag {
+                let value = match tag {
                     "path" => {
                         match map.next_key()? {
-                            Some("path") => Ok(DownloadZipError::Path(map.next_value()?)),
-                            None => Err(de::Error::missing_field("path")),
-                            _ => Err(de::Error::unknown_field(tag, VARIANTS))
+                            Some("path") => DownloadZipError::Path(map.next_value()?),
+                            None => return Err(de::Error::missing_field("path")),
+                            _ => return Err(de::Error::unknown_field(tag, VARIANTS))
                         }
                     }
-                    "too_large" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(DownloadZipError::TooLarge)
-                    }
-                    "too_many_files" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(DownloadZipError::TooManyFiles)
-                    }
-                    _ => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(DownloadZipError::Other)
-                    }
-                }
+                    "too_large" => DownloadZipError::TooLarge,
+                    "too_many_files" => DownloadZipError::TooManyFiles,
+                    _ => DownloadZipError::Other,
+                };
+                crate::eat_json_fields(&mut map)?;
+                Ok(value)
             }
         }
         const VARIANTS: &[&str] = &["path",
@@ -4838,31 +4809,21 @@ impl<'de> ::serde::de::Deserialize<'de> for ExportError {
                     Some(".tag") => map.next_value()?,
                     _ => return Err(de::Error::missing_field(".tag"))
                 };
-                match tag {
+                let value = match tag {
                     "path" => {
                         match map.next_key()? {
-                            Some("path") => Ok(ExportError::Path(map.next_value()?)),
-                            None => Err(de::Error::missing_field("path")),
-                            _ => Err(de::Error::unknown_field(tag, VARIANTS))
+                            Some("path") => ExportError::Path(map.next_value()?),
+                            None => return Err(de::Error::missing_field("path")),
+                            _ => return Err(de::Error::unknown_field(tag, VARIANTS))
                         }
                     }
-                    "non_exportable" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(ExportError::NonExportable)
-                    }
-                    "invalid_export_format" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(ExportError::InvalidExportFormat)
-                    }
-                    "retry_error" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(ExportError::RetryError)
-                    }
-                    _ => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(ExportError::Other)
-                    }
-                }
+                    "non_exportable" => ExportError::NonExportable,
+                    "invalid_export_format" => ExportError::InvalidExportFormat,
+                    "retry_error" => ExportError::RetryError,
+                    _ => ExportError::Other,
+                };
+                crate::eat_json_fields(&mut map)?;
+                Ok(value)
             }
         }
         const VARIANTS: &[&str] = &["path",
@@ -5323,52 +5284,21 @@ impl<'de> ::serde::de::Deserialize<'de> for FileCategory {
                     Some(".tag") => map.next_value()?,
                     _ => return Err(de::Error::missing_field(".tag"))
                 };
-                match tag {
-                    "image" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(FileCategory::Image)
-                    }
-                    "document" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(FileCategory::Document)
-                    }
-                    "pdf" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(FileCategory::Pdf)
-                    }
-                    "spreadsheet" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(FileCategory::Spreadsheet)
-                    }
-                    "presentation" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(FileCategory::Presentation)
-                    }
-                    "audio" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(FileCategory::Audio)
-                    }
-                    "video" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(FileCategory::Video)
-                    }
-                    "folder" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(FileCategory::Folder)
-                    }
-                    "paper" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(FileCategory::Paper)
-                    }
-                    "others" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(FileCategory::Others)
-                    }
-                    _ => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(FileCategory::Other)
-                    }
-                }
+                let value = match tag {
+                    "image" => FileCategory::Image,
+                    "document" => FileCategory::Document,
+                    "pdf" => FileCategory::Pdf,
+                    "spreadsheet" => FileCategory::Spreadsheet,
+                    "presentation" => FileCategory::Presentation,
+                    "audio" => FileCategory::Audio,
+                    "video" => FileCategory::Video,
+                    "folder" => FileCategory::Folder,
+                    "paper" => FileCategory::Paper,
+                    "others" => FileCategory::Others,
+                    _ => FileCategory::Other,
+                };
+                crate::eat_json_fields(&mut map)?;
+                Ok(value)
             }
         }
         const VARIANTS: &[&str] = &["image",
@@ -5573,17 +5503,13 @@ impl<'de> ::serde::de::Deserialize<'de> for FileLockContent {
                     Some(".tag") => map.next_value()?,
                     _ => return Err(de::Error::missing_field(".tag"))
                 };
-                match tag {
-                    "unlocked" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(FileLockContent::Unlocked)
-                    }
-                    "single_user" => Ok(FileLockContent::SingleUser(SingleUserLock::internal_deserialize(map)?)),
-                    _ => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(FileLockContent::Other)
-                    }
-                }
+                let value = match tag {
+                    "unlocked" => FileLockContent::Unlocked,
+                    "single_user" => FileLockContent::SingleUser(SingleUserLock::internal_deserialize(&mut map)?),
+                    _ => FileLockContent::Other,
+                };
+                crate::eat_json_fields(&mut map)?;
+                Ok(value)
             }
         }
         const VARIANTS: &[&str] = &["unlocked",
@@ -6357,20 +6283,13 @@ impl<'de> ::serde::de::Deserialize<'de> for FileStatus {
                     Some(".tag") => map.next_value()?,
                     _ => return Err(de::Error::missing_field(".tag"))
                 };
-                match tag {
-                    "active" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(FileStatus::Active)
-                    }
-                    "deleted" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(FileStatus::Deleted)
-                    }
-                    _ => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(FileStatus::Other)
-                    }
-                }
+                let value = match tag {
+                    "active" => FileStatus::Active,
+                    "deleted" => FileStatus::Deleted,
+                    _ => FileStatus::Other,
+                };
+                crate::eat_json_fields(&mut map)?;
+                Ok(value)
             }
         }
         const VARIANTS: &[&str] = &["active",
@@ -6906,19 +6825,18 @@ impl<'de> ::serde::de::Deserialize<'de> for GetCopyReferenceError {
                     Some(".tag") => map.next_value()?,
                     _ => return Err(de::Error::missing_field(".tag"))
                 };
-                match tag {
+                let value = match tag {
                     "path" => {
                         match map.next_key()? {
-                            Some("path") => Ok(GetCopyReferenceError::Path(map.next_value()?)),
-                            None => Err(de::Error::missing_field("path")),
-                            _ => Err(de::Error::unknown_field(tag, VARIANTS))
+                            Some("path") => GetCopyReferenceError::Path(map.next_value()?),
+                            None => return Err(de::Error::missing_field("path")),
+                            _ => return Err(de::Error::unknown_field(tag, VARIANTS))
                         }
                     }
-                    _ => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(GetCopyReferenceError::Other)
-                    }
-                }
+                    _ => GetCopyReferenceError::Other,
+                };
+                crate::eat_json_fields(&mut map)?;
+                Ok(value)
             }
         }
         const VARIANTS: &[&str] = &["path",
@@ -7271,16 +7189,18 @@ impl<'de> ::serde::de::Deserialize<'de> for GetMetadataError {
                     Some(".tag") => map.next_value()?,
                     _ => return Err(de::Error::missing_field(".tag"))
                 };
-                match tag {
+                let value = match tag {
                     "path" => {
                         match map.next_key()? {
-                            Some("path") => Ok(GetMetadataError::Path(map.next_value()?)),
-                            None => Err(de::Error::missing_field("path")),
-                            _ => Err(de::Error::unknown_field(tag, VARIANTS))
+                            Some("path") => GetMetadataError::Path(map.next_value()?),
+                            None => return Err(de::Error::missing_field("path")),
+                            _ => return Err(de::Error::unknown_field(tag, VARIANTS))
                         }
                     }
-                    _ => Err(de::Error::unknown_variant(tag, VARIANTS))
-                }
+                    _ => return Err(de::Error::unknown_variant(tag, VARIANTS))
+                };
+                crate::eat_json_fields(&mut map)?;
+                Ok(value)
             }
         }
         const VARIANTS: &[&str] = &["path"];
@@ -7444,31 +7364,21 @@ impl<'de> ::serde::de::Deserialize<'de> for GetTemporaryLinkError {
                     Some(".tag") => map.next_value()?,
                     _ => return Err(de::Error::missing_field(".tag"))
                 };
-                match tag {
+                let value = match tag {
                     "path" => {
                         match map.next_key()? {
-                            Some("path") => Ok(GetTemporaryLinkError::Path(map.next_value()?)),
-                            None => Err(de::Error::missing_field("path")),
-                            _ => Err(de::Error::unknown_field(tag, VARIANTS))
+                            Some("path") => GetTemporaryLinkError::Path(map.next_value()?),
+                            None => return Err(de::Error::missing_field("path")),
+                            _ => return Err(de::Error::unknown_field(tag, VARIANTS))
                         }
                     }
-                    "email_not_verified" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(GetTemporaryLinkError::EmailNotVerified)
-                    }
-                    "unsupported_file" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(GetTemporaryLinkError::UnsupportedFile)
-                    }
-                    "not_allowed" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(GetTemporaryLinkError::NotAllowed)
-                    }
-                    _ => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(GetTemporaryLinkError::Other)
-                    }
-                }
+                    "email_not_verified" => GetTemporaryLinkError::EmailNotVerified,
+                    "unsupported_file" => GetTemporaryLinkError::UnsupportedFile,
+                    "not_allowed" => GetTemporaryLinkError::NotAllowed,
+                    _ => GetTemporaryLinkError::Other,
+                };
+                crate::eat_json_fields(&mut map)?;
+                Ok(value)
             }
         }
         const VARIANTS: &[&str] = &["path",
@@ -7952,16 +7862,12 @@ impl<'de> ::serde::de::Deserialize<'de> for GetThumbnailBatchError {
                     Some(".tag") => map.next_value()?,
                     _ => return Err(de::Error::missing_field(".tag"))
                 };
-                match tag {
-                    "too_many_files" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(GetThumbnailBatchError::TooManyFiles)
-                    }
-                    _ => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(GetThumbnailBatchError::Other)
-                    }
-                }
+                let value = match tag {
+                    "too_many_files" => GetThumbnailBatchError::TooManyFiles,
+                    _ => GetThumbnailBatchError::Other,
+                };
+                crate::eat_json_fields(&mut map)?;
+                Ok(value)
             }
         }
         const VARIANTS: &[&str] = &["too_many_files",
@@ -8216,20 +8122,19 @@ impl<'de> ::serde::de::Deserialize<'de> for GetThumbnailBatchResultEntry {
                     Some(".tag") => map.next_value()?,
                     _ => return Err(de::Error::missing_field(".tag"))
                 };
-                match tag {
-                    "success" => Ok(GetThumbnailBatchResultEntry::Success(GetThumbnailBatchResultData::internal_deserialize(map)?)),
+                let value = match tag {
+                    "success" => GetThumbnailBatchResultEntry::Success(GetThumbnailBatchResultData::internal_deserialize(&mut map)?),
                     "failure" => {
                         match map.next_key()? {
-                            Some("failure") => Ok(GetThumbnailBatchResultEntry::Failure(map.next_value()?)),
-                            None => Err(de::Error::missing_field("failure")),
-                            _ => Err(de::Error::unknown_field(tag, VARIANTS))
+                            Some("failure") => GetThumbnailBatchResultEntry::Failure(map.next_value()?),
+                            None => return Err(de::Error::missing_field("failure")),
+                            _ => return Err(de::Error::unknown_field(tag, VARIANTS))
                         }
                     }
-                    _ => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(GetThumbnailBatchResultEntry::Other)
-                    }
-                }
+                    _ => GetThumbnailBatchResultEntry::Other,
+                };
+                crate::eat_json_fields(&mut map)?;
+                Ok(value)
             }
         }
         const VARIANTS: &[&str] = &["success",
@@ -8500,24 +8405,14 @@ impl<'de> ::serde::de::Deserialize<'de> for ImportFormat {
                     Some(".tag") => map.next_value()?,
                     _ => return Err(de::Error::missing_field(".tag"))
                 };
-                match tag {
-                    "html" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(ImportFormat::Html)
-                    }
-                    "markdown" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(ImportFormat::Markdown)
-                    }
-                    "plain_text" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(ImportFormat::PlainText)
-                    }
-                    _ => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(ImportFormat::Other)
-                    }
-                }
+                let value = match tag {
+                    "html" => ImportFormat::Html,
+                    "markdown" => ImportFormat::Markdown,
+                    "plain_text" => ImportFormat::PlainText,
+                    _ => ImportFormat::Other,
+                };
+                crate::eat_json_fields(&mut map)?;
+                Ok(value)
             }
         }
         const VARIANTS: &[&str] = &["html",
@@ -8938,23 +8833,19 @@ impl<'de> ::serde::de::Deserialize<'de> for ListFolderContinueError {
                     Some(".tag") => map.next_value()?,
                     _ => return Err(de::Error::missing_field(".tag"))
                 };
-                match tag {
+                let value = match tag {
                     "path" => {
                         match map.next_key()? {
-                            Some("path") => Ok(ListFolderContinueError::Path(map.next_value()?)),
-                            None => Err(de::Error::missing_field("path")),
-                            _ => Err(de::Error::unknown_field(tag, VARIANTS))
+                            Some("path") => ListFolderContinueError::Path(map.next_value()?),
+                            None => return Err(de::Error::missing_field("path")),
+                            _ => return Err(de::Error::unknown_field(tag, VARIANTS))
                         }
                     }
-                    "reset" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(ListFolderContinueError::Reset)
-                    }
-                    _ => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(ListFolderContinueError::Other)
-                    }
-                }
+                    "reset" => ListFolderContinueError::Reset,
+                    _ => ListFolderContinueError::Other,
+                };
+                crate::eat_json_fields(&mut map)?;
+                Ok(value)
             }
         }
         const VARIANTS: &[&str] = &["path",
@@ -9030,26 +8921,25 @@ impl<'de> ::serde::de::Deserialize<'de> for ListFolderError {
                     Some(".tag") => map.next_value()?,
                     _ => return Err(de::Error::missing_field(".tag"))
                 };
-                match tag {
+                let value = match tag {
                     "path" => {
                         match map.next_key()? {
-                            Some("path") => Ok(ListFolderError::Path(map.next_value()?)),
-                            None => Err(de::Error::missing_field("path")),
-                            _ => Err(de::Error::unknown_field(tag, VARIANTS))
+                            Some("path") => ListFolderError::Path(map.next_value()?),
+                            None => return Err(de::Error::missing_field("path")),
+                            _ => return Err(de::Error::unknown_field(tag, VARIANTS))
                         }
                     }
                     "template_error" => {
                         match map.next_key()? {
-                            Some("template_error") => Ok(ListFolderError::TemplateError(map.next_value()?)),
-                            None => Err(de::Error::missing_field("template_error")),
-                            _ => Err(de::Error::unknown_field(tag, VARIANTS))
+                            Some("template_error") => ListFolderError::TemplateError(map.next_value()?),
+                            None => return Err(de::Error::missing_field("template_error")),
+                            _ => return Err(de::Error::unknown_field(tag, VARIANTS))
                         }
                     }
-                    _ => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(ListFolderError::Other)
-                    }
-                }
+                    _ => ListFolderError::Other,
+                };
+                crate::eat_json_fields(&mut map)?;
+                Ok(value)
             }
         }
         const VARIANTS: &[&str] = &["path",
@@ -9332,16 +9222,12 @@ impl<'de> ::serde::de::Deserialize<'de> for ListFolderLongpollError {
                     Some(".tag") => map.next_value()?,
                     _ => return Err(de::Error::missing_field(".tag"))
                 };
-                match tag {
-                    "reset" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(ListFolderLongpollError::Reset)
-                    }
-                    _ => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(ListFolderLongpollError::Other)
-                    }
-                }
+                let value = match tag {
+                    "reset" => ListFolderLongpollError::Reset,
+                    _ => ListFolderLongpollError::Other,
+                };
+                crate::eat_json_fields(&mut map)?;
+                Ok(value)
             }
         }
         const VARIANTS: &[&str] = &["reset",
@@ -9753,19 +9639,18 @@ impl<'de> ::serde::de::Deserialize<'de> for ListRevisionsError {
                     Some(".tag") => map.next_value()?,
                     _ => return Err(de::Error::missing_field(".tag"))
                 };
-                match tag {
+                let value = match tag {
                     "path" => {
                         match map.next_key()? {
-                            Some("path") => Ok(ListRevisionsError::Path(map.next_value()?)),
-                            None => Err(de::Error::missing_field("path")),
-                            _ => Err(de::Error::unknown_field(tag, VARIANTS))
+                            Some("path") => ListRevisionsError::Path(map.next_value()?),
+                            None => return Err(de::Error::missing_field("path")),
+                            _ => return Err(de::Error::unknown_field(tag, VARIANTS))
                         }
                     }
-                    _ => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(ListRevisionsError::Other)
-                    }
-                }
+                    _ => ListRevisionsError::Other,
+                };
+                crate::eat_json_fields(&mut map)?;
+                Ok(value)
             }
         }
         const VARIANTS: &[&str] = &["path",
@@ -9838,20 +9723,13 @@ impl<'de> ::serde::de::Deserialize<'de> for ListRevisionsMode {
                     Some(".tag") => map.next_value()?,
                     _ => return Err(de::Error::missing_field(".tag"))
                 };
-                match tag {
-                    "path" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(ListRevisionsMode::Path)
-                    }
-                    "id" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(ListRevisionsMode::Id)
-                    }
-                    _ => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(ListRevisionsMode::Other)
-                    }
-                }
+                let value = match tag {
+                    "path" => ListRevisionsMode::Path,
+                    "id" => ListRevisionsMode::Id,
+                    _ => ListRevisionsMode::Other,
+                };
+                crate::eat_json_fields(&mut map)?;
+                Ok(value)
             }
         }
         const VARIANTS: &[&str] = &["path",
@@ -10406,44 +10284,25 @@ impl<'de> ::serde::de::Deserialize<'de> for LockFileError {
                     Some(".tag") => map.next_value()?,
                     _ => return Err(de::Error::missing_field(".tag"))
                 };
-                match tag {
+                let value = match tag {
                     "path_lookup" => {
                         match map.next_key()? {
-                            Some("path_lookup") => Ok(LockFileError::PathLookup(map.next_value()?)),
-                            None => Err(de::Error::missing_field("path_lookup")),
-                            _ => Err(de::Error::unknown_field(tag, VARIANTS))
+                            Some("path_lookup") => LockFileError::PathLookup(map.next_value()?),
+                            None => return Err(de::Error::missing_field("path_lookup")),
+                            _ => return Err(de::Error::unknown_field(tag, VARIANTS))
                         }
                     }
-                    "too_many_write_operations" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(LockFileError::TooManyWriteOperations)
-                    }
-                    "too_many_files" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(LockFileError::TooManyFiles)
-                    }
-                    "no_write_permission" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(LockFileError::NoWritePermission)
-                    }
-                    "cannot_be_locked" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(LockFileError::CannotBeLocked)
-                    }
-                    "file_not_shared" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(LockFileError::FileNotShared)
-                    }
-                    "lock_conflict" => Ok(LockFileError::LockConflict(LockConflictError::internal_deserialize(map)?)),
-                    "internal_error" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(LockFileError::InternalError)
-                    }
-                    _ => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(LockFileError::Other)
-                    }
-                }
+                    "too_many_write_operations" => LockFileError::TooManyWriteOperations,
+                    "too_many_files" => LockFileError::TooManyFiles,
+                    "no_write_permission" => LockFileError::NoWritePermission,
+                    "cannot_be_locked" => LockFileError::CannotBeLocked,
+                    "file_not_shared" => LockFileError::FileNotShared,
+                    "lock_conflict" => LockFileError::LockConflict(LockConflictError::internal_deserialize(&mut map)?),
+                    "internal_error" => LockFileError::InternalError,
+                    _ => LockFileError::Other,
+                };
+                crate::eat_json_fields(&mut map)?;
+                Ok(value)
             }
         }
         const VARIANTS: &[&str] = &["path_lookup",
@@ -10668,17 +10527,19 @@ impl<'de> ::serde::de::Deserialize<'de> for LockFileResultEntry {
                     Some(".tag") => map.next_value()?,
                     _ => return Err(de::Error::missing_field(".tag"))
                 };
-                match tag {
-                    "success" => Ok(LockFileResultEntry::Success(LockFileResult::internal_deserialize(map)?)),
+                let value = match tag {
+                    "success" => LockFileResultEntry::Success(LockFileResult::internal_deserialize(&mut map)?),
                     "failure" => {
                         match map.next_key()? {
-                            Some("failure") => Ok(LockFileResultEntry::Failure(map.next_value()?)),
-                            None => Err(de::Error::missing_field("failure")),
-                            _ => Err(de::Error::unknown_field(tag, VARIANTS))
+                            Some("failure") => LockFileResultEntry::Failure(map.next_value()?),
+                            None => return Err(de::Error::missing_field("failure")),
+                            _ => return Err(de::Error::unknown_field(tag, VARIANTS))
                         }
                     }
-                    _ => Err(de::Error::unknown_variant(tag, VARIANTS))
-                }
+                    _ => return Err(de::Error::unknown_variant(tag, VARIANTS))
+                };
+                crate::eat_json_fields(&mut map)?;
+                Ok(value)
             }
         }
         const VARIANTS: &[&str] = &["success",
@@ -10750,43 +10611,24 @@ impl<'de> ::serde::de::Deserialize<'de> for LookupError {
                     Some(".tag") => map.next_value()?,
                     _ => return Err(de::Error::missing_field(".tag"))
                 };
-                match tag {
+                let value = match tag {
                     "malformed_path" => {
                         match map.next_key()? {
-                            Some("malformed_path") => Ok(LookupError::MalformedPath(map.next_value()?)),
-                            None => Ok(LookupError::MalformedPath(None)),
-                            _ => Err(de::Error::unknown_field(tag, VARIANTS))
+                            Some("malformed_path") => LookupError::MalformedPath(map.next_value()?),
+                            None => LookupError::MalformedPath(None),
+                            _ => return Err(de::Error::unknown_field(tag, VARIANTS))
                         }
                     }
-                    "not_found" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(LookupError::NotFound)
-                    }
-                    "not_file" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(LookupError::NotFile)
-                    }
-                    "not_folder" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(LookupError::NotFolder)
-                    }
-                    "restricted_content" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(LookupError::RestrictedContent)
-                    }
-                    "unsupported_content_type" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(LookupError::UnsupportedContentType)
-                    }
-                    "locked" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(LookupError::Locked)
-                    }
-                    _ => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(LookupError::Other)
-                    }
-                }
+                    "not_found" => LookupError::NotFound,
+                    "not_file" => LookupError::NotFile,
+                    "not_folder" => LookupError::NotFolder,
+                    "restricted_content" => LookupError::RestrictedContent,
+                    "unsupported_content_type" => LookupError::UnsupportedContentType,
+                    "locked" => LookupError::Locked,
+                    _ => LookupError::Other,
+                };
+                crate::eat_json_fields(&mut map)?;
+                Ok(value)
             }
         }
         const VARIANTS: &[&str] = &["malformed_path",
@@ -10898,20 +10740,19 @@ impl<'de> ::serde::de::Deserialize<'de> for MediaInfo {
                     Some(".tag") => map.next_value()?,
                     _ => return Err(de::Error::missing_field(".tag"))
                 };
-                match tag {
-                    "pending" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(MediaInfo::Pending)
-                    }
+                let value = match tag {
+                    "pending" => MediaInfo::Pending,
                     "metadata" => {
                         match map.next_key()? {
-                            Some("metadata") => Ok(MediaInfo::Metadata(map.next_value()?)),
-                            None => Err(de::Error::missing_field("metadata")),
-                            _ => Err(de::Error::unknown_field(tag, VARIANTS))
+                            Some("metadata") => MediaInfo::Metadata(map.next_value()?),
+                            None => return Err(de::Error::missing_field("metadata")),
+                            _ => return Err(de::Error::unknown_field(tag, VARIANTS))
                         }
                     }
-                    _ => Err(de::Error::unknown_variant(tag, VARIANTS))
-                }
+                    _ => return Err(de::Error::unknown_variant(tag, VARIANTS))
+                };
+                crate::eat_json_fields(&mut map)?;
+                Ok(value)
             }
         }
         const VARIANTS: &[&str] = &["pending",
@@ -11120,19 +10961,18 @@ impl<'de> ::serde::de::Deserialize<'de> for MetadataV2 {
                     Some(".tag") => map.next_value()?,
                     _ => return Err(de::Error::missing_field(".tag"))
                 };
-                match tag {
+                let value = match tag {
                     "metadata" => {
                         match map.next_key()? {
-                            Some("metadata") => Ok(MetadataV2::Metadata(map.next_value()?)),
-                            None => Err(de::Error::missing_field("metadata")),
-                            _ => Err(de::Error::unknown_field(tag, VARIANTS))
+                            Some("metadata") => MetadataV2::Metadata(map.next_value()?),
+                            None => return Err(de::Error::missing_field("metadata")),
+                            _ => return Err(de::Error::unknown_field(tag, VARIANTS))
                         }
                     }
-                    _ => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(MetadataV2::Other)
-                    }
-                }
+                    _ => MetadataV2::Other,
+                };
+                crate::eat_json_fields(&mut map)?;
+                Ok(value)
             }
         }
         const VARIANTS: &[&str] = &["metadata",
@@ -11452,16 +11292,12 @@ impl<'de> ::serde::de::Deserialize<'de> for MoveIntoVaultError {
                     Some(".tag") => map.next_value()?,
                     _ => return Err(de::Error::missing_field(".tag"))
                 };
-                match tag {
-                    "is_shared_folder" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(MoveIntoVaultError::IsSharedFolder)
-                    }
-                    _ => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(MoveIntoVaultError::Other)
-                    }
-                }
+                let value = match tag {
+                    "is_shared_folder" => MoveIntoVaultError::IsSharedFolder,
+                    _ => MoveIntoVaultError::Other,
+                };
+                crate::eat_json_fields(&mut map)?;
+                Ok(value)
             }
         }
         const VARIANTS: &[&str] = &["is_shared_folder",
@@ -11530,28 +11366,15 @@ impl<'de> ::serde::de::Deserialize<'de> for PaperContentError {
                     Some(".tag") => map.next_value()?,
                     _ => return Err(de::Error::missing_field(".tag"))
                 };
-                match tag {
-                    "insufficient_permissions" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(PaperContentError::InsufficientPermissions)
-                    }
-                    "content_malformed" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(PaperContentError::ContentMalformed)
-                    }
-                    "doc_length_exceeded" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(PaperContentError::DocLengthExceeded)
-                    }
-                    "image_size_exceeded" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(PaperContentError::ImageSizeExceeded)
-                    }
-                    _ => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(PaperContentError::Other)
-                    }
-                }
+                let value = match tag {
+                    "insufficient_permissions" => PaperContentError::InsufficientPermissions,
+                    "content_malformed" => PaperContentError::ContentMalformed,
+                    "doc_length_exceeded" => PaperContentError::DocLengthExceeded,
+                    "image_size_exceeded" => PaperContentError::ImageSizeExceeded,
+                    _ => PaperContentError::Other,
+                };
+                crate::eat_json_fields(&mut map)?;
+                Ok(value)
             }
         }
         const VARIANTS: &[&str] = &["insufficient_permissions",
@@ -11756,44 +11579,19 @@ impl<'de> ::serde::de::Deserialize<'de> for PaperCreateError {
                     Some(".tag") => map.next_value()?,
                     _ => return Err(de::Error::missing_field(".tag"))
                 };
-                match tag {
-                    "insufficient_permissions" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(PaperCreateError::InsufficientPermissions)
-                    }
-                    "content_malformed" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(PaperCreateError::ContentMalformed)
-                    }
-                    "doc_length_exceeded" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(PaperCreateError::DocLengthExceeded)
-                    }
-                    "image_size_exceeded" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(PaperCreateError::ImageSizeExceeded)
-                    }
-                    "invalid_path" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(PaperCreateError::InvalidPath)
-                    }
-                    "email_unverified" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(PaperCreateError::EmailUnverified)
-                    }
-                    "invalid_file_extension" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(PaperCreateError::InvalidFileExtension)
-                    }
-                    "paper_disabled" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(PaperCreateError::PaperDisabled)
-                    }
-                    _ => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(PaperCreateError::Other)
-                    }
-                }
+                let value = match tag {
+                    "insufficient_permissions" => PaperCreateError::InsufficientPermissions,
+                    "content_malformed" => PaperCreateError::ContentMalformed,
+                    "doc_length_exceeded" => PaperCreateError::DocLengthExceeded,
+                    "image_size_exceeded" => PaperCreateError::ImageSizeExceeded,
+                    "invalid_path" => PaperCreateError::InvalidPath,
+                    "email_unverified" => PaperCreateError::EmailUnverified,
+                    "invalid_file_extension" => PaperCreateError::InvalidFileExtension,
+                    "paper_disabled" => PaperCreateError::PaperDisabled,
+                    _ => PaperCreateError::Other,
+                };
+                crate::eat_json_fields(&mut map)?;
+                Ok(value)
             }
         }
         const VARIANTS: &[&str] = &["insufficient_permissions",
@@ -12047,28 +11845,15 @@ impl<'de> ::serde::de::Deserialize<'de> for PaperDocUpdatePolicy {
                     Some(".tag") => map.next_value()?,
                     _ => return Err(de::Error::missing_field(".tag"))
                 };
-                match tag {
-                    "update" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(PaperDocUpdatePolicy::Update)
-                    }
-                    "overwrite" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(PaperDocUpdatePolicy::Overwrite)
-                    }
-                    "prepend" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(PaperDocUpdatePolicy::Prepend)
-                    }
-                    "append" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(PaperDocUpdatePolicy::Append)
-                    }
-                    _ => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(PaperDocUpdatePolicy::Other)
-                    }
-                }
+                let value = match tag {
+                    "update" => PaperDocUpdatePolicy::Update,
+                    "overwrite" => PaperDocUpdatePolicy::Overwrite,
+                    "prepend" => PaperDocUpdatePolicy::Prepend,
+                    "append" => PaperDocUpdatePolicy::Append,
+                    _ => PaperDocUpdatePolicy::Other,
+                };
+                crate::eat_json_fields(&mut map)?;
+                Ok(value)
             }
         }
         const VARIANTS: &[&str] = &["update",
@@ -12293,47 +12078,25 @@ impl<'de> ::serde::de::Deserialize<'de> for PaperUpdateError {
                     Some(".tag") => map.next_value()?,
                     _ => return Err(de::Error::missing_field(".tag"))
                 };
-                match tag {
-                    "insufficient_permissions" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(PaperUpdateError::InsufficientPermissions)
-                    }
-                    "content_malformed" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(PaperUpdateError::ContentMalformed)
-                    }
-                    "doc_length_exceeded" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(PaperUpdateError::DocLengthExceeded)
-                    }
-                    "image_size_exceeded" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(PaperUpdateError::ImageSizeExceeded)
-                    }
+                let value = match tag {
+                    "insufficient_permissions" => PaperUpdateError::InsufficientPermissions,
+                    "content_malformed" => PaperUpdateError::ContentMalformed,
+                    "doc_length_exceeded" => PaperUpdateError::DocLengthExceeded,
+                    "image_size_exceeded" => PaperUpdateError::ImageSizeExceeded,
                     "path" => {
                         match map.next_key()? {
-                            Some("path") => Ok(PaperUpdateError::Path(map.next_value()?)),
-                            None => Err(de::Error::missing_field("path")),
-                            _ => Err(de::Error::unknown_field(tag, VARIANTS))
+                            Some("path") => PaperUpdateError::Path(map.next_value()?),
+                            None => return Err(de::Error::missing_field("path")),
+                            _ => return Err(de::Error::unknown_field(tag, VARIANTS))
                         }
                     }
-                    "revision_mismatch" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(PaperUpdateError::RevisionMismatch)
-                    }
-                    "doc_archived" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(PaperUpdateError::DocArchived)
-                    }
-                    "doc_deleted" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(PaperUpdateError::DocDeleted)
-                    }
-                    _ => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(PaperUpdateError::Other)
-                    }
-                }
+                    "revision_mismatch" => PaperUpdateError::RevisionMismatch,
+                    "doc_archived" => PaperUpdateError::DocArchived,
+                    "doc_deleted" => PaperUpdateError::DocDeleted,
+                    _ => PaperUpdateError::Other,
+                };
+                crate::eat_json_fields(&mut map)?;
+                Ok(value)
             }
         }
         const VARIANTS: &[&str] = &["insufficient_permissions",
@@ -12548,20 +12311,19 @@ impl<'de> ::serde::de::Deserialize<'de> for PathOrLink {
                     Some(".tag") => map.next_value()?,
                     _ => return Err(de::Error::missing_field(".tag"))
                 };
-                match tag {
+                let value = match tag {
                     "path" => {
                         match map.next_key()? {
-                            Some("path") => Ok(PathOrLink::Path(map.next_value()?)),
-                            None => Err(de::Error::missing_field("path")),
-                            _ => Err(de::Error::unknown_field(tag, VARIANTS))
+                            Some("path") => PathOrLink::Path(map.next_value()?),
+                            None => return Err(de::Error::missing_field("path")),
+                            _ => return Err(de::Error::unknown_field(tag, VARIANTS))
                         }
                     }
-                    "link" => Ok(PathOrLink::Link(SharedLinkFileInfo::internal_deserialize(map)?)),
-                    _ => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(PathOrLink::Other)
-                    }
-                }
+                    "link" => PathOrLink::Link(SharedLinkFileInfo::internal_deserialize(&mut map)?),
+                    _ => PathOrLink::Other,
+                };
+                crate::eat_json_fields(&mut map)?;
+                Ok(value)
             }
         }
         const VARIANTS: &[&str] = &["path",
@@ -12853,28 +12615,21 @@ impl<'de> ::serde::de::Deserialize<'de> for PreviewError {
                     Some(".tag") => map.next_value()?,
                     _ => return Err(de::Error::missing_field(".tag"))
                 };
-                match tag {
+                let value = match tag {
                     "path" => {
                         match map.next_key()? {
-                            Some("path") => Ok(PreviewError::Path(map.next_value()?)),
-                            None => Err(de::Error::missing_field("path")),
-                            _ => Err(de::Error::unknown_field(tag, VARIANTS))
+                            Some("path") => PreviewError::Path(map.next_value()?),
+                            None => return Err(de::Error::missing_field("path")),
+                            _ => return Err(de::Error::unknown_field(tag, VARIANTS))
                         }
                     }
-                    "in_progress" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(PreviewError::InProgress)
-                    }
-                    "unsupported_extension" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(PreviewError::UnsupportedExtension)
-                    }
-                    "unsupported_content" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(PreviewError::UnsupportedContent)
-                    }
-                    _ => Err(de::Error::unknown_variant(tag, VARIANTS))
-                }
+                    "in_progress" => PreviewError::InProgress,
+                    "unsupported_extension" => PreviewError::UnsupportedExtension,
+                    "unsupported_content" => PreviewError::UnsupportedContent,
+                    _ => return Err(de::Error::unknown_variant(tag, VARIANTS))
+                };
+                crate::eat_json_fields(&mut map)?;
+                Ok(value)
             }
         }
         const VARIANTS: &[&str] = &["path",
@@ -13510,80 +13265,49 @@ impl<'de> ::serde::de::Deserialize<'de> for RelocationBatchError {
                     Some(".tag") => map.next_value()?,
                     _ => return Err(de::Error::missing_field(".tag"))
                 };
-                match tag {
+                let value = match tag {
                     "from_lookup" => {
                         match map.next_key()? {
-                            Some("from_lookup") => Ok(RelocationBatchError::FromLookup(map.next_value()?)),
-                            None => Err(de::Error::missing_field("from_lookup")),
-                            _ => Err(de::Error::unknown_field(tag, VARIANTS))
+                            Some("from_lookup") => RelocationBatchError::FromLookup(map.next_value()?),
+                            None => return Err(de::Error::missing_field("from_lookup")),
+                            _ => return Err(de::Error::unknown_field(tag, VARIANTS))
                         }
                     }
                     "from_write" => {
                         match map.next_key()? {
-                            Some("from_write") => Ok(RelocationBatchError::FromWrite(map.next_value()?)),
-                            None => Err(de::Error::missing_field("from_write")),
-                            _ => Err(de::Error::unknown_field(tag, VARIANTS))
+                            Some("from_write") => RelocationBatchError::FromWrite(map.next_value()?),
+                            None => return Err(de::Error::missing_field("from_write")),
+                            _ => return Err(de::Error::unknown_field(tag, VARIANTS))
                         }
                     }
                     "to" => {
                         match map.next_key()? {
-                            Some("to") => Ok(RelocationBatchError::To(map.next_value()?)),
-                            None => Err(de::Error::missing_field("to")),
-                            _ => Err(de::Error::unknown_field(tag, VARIANTS))
+                            Some("to") => RelocationBatchError::To(map.next_value()?),
+                            None => return Err(de::Error::missing_field("to")),
+                            _ => return Err(de::Error::unknown_field(tag, VARIANTS))
                         }
                     }
-                    "cant_copy_shared_folder" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(RelocationBatchError::CantCopySharedFolder)
-                    }
-                    "cant_nest_shared_folder" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(RelocationBatchError::CantNestSharedFolder)
-                    }
-                    "cant_move_folder_into_itself" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(RelocationBatchError::CantMoveFolderIntoItself)
-                    }
-                    "too_many_files" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(RelocationBatchError::TooManyFiles)
-                    }
-                    "duplicated_or_nested_paths" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(RelocationBatchError::DuplicatedOrNestedPaths)
-                    }
-                    "cant_transfer_ownership" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(RelocationBatchError::CantTransferOwnership)
-                    }
-                    "insufficient_quota" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(RelocationBatchError::InsufficientQuota)
-                    }
-                    "internal_error" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(RelocationBatchError::InternalError)
-                    }
-                    "cant_move_shared_folder" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(RelocationBatchError::CantMoveSharedFolder)
-                    }
+                    "cant_copy_shared_folder" => RelocationBatchError::CantCopySharedFolder,
+                    "cant_nest_shared_folder" => RelocationBatchError::CantNestSharedFolder,
+                    "cant_move_folder_into_itself" => RelocationBatchError::CantMoveFolderIntoItself,
+                    "too_many_files" => RelocationBatchError::TooManyFiles,
+                    "duplicated_or_nested_paths" => RelocationBatchError::DuplicatedOrNestedPaths,
+                    "cant_transfer_ownership" => RelocationBatchError::CantTransferOwnership,
+                    "insufficient_quota" => RelocationBatchError::InsufficientQuota,
+                    "internal_error" => RelocationBatchError::InternalError,
+                    "cant_move_shared_folder" => RelocationBatchError::CantMoveSharedFolder,
                     "cant_move_into_vault" => {
                         match map.next_key()? {
-                            Some("cant_move_into_vault") => Ok(RelocationBatchError::CantMoveIntoVault(map.next_value()?)),
-                            None => Err(de::Error::missing_field("cant_move_into_vault")),
-                            _ => Err(de::Error::unknown_field(tag, VARIANTS))
+                            Some("cant_move_into_vault") => RelocationBatchError::CantMoveIntoVault(map.next_value()?),
+                            None => return Err(de::Error::missing_field("cant_move_into_vault")),
+                            _ => return Err(de::Error::unknown_field(tag, VARIANTS))
                         }
                     }
-                    "too_many_write_operations" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(RelocationBatchError::TooManyWriteOperations)
-                    }
-                    _ => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(RelocationBatchError::Other)
-                    }
-                }
+                    "too_many_write_operations" => RelocationBatchError::TooManyWriteOperations,
+                    _ => RelocationBatchError::Other,
+                };
+                crate::eat_json_fields(&mut map)?;
+                Ok(value)
             }
         }
         const VARIANTS: &[&str] = &["from_lookup",
@@ -13765,27 +13489,20 @@ impl<'de> ::serde::de::Deserialize<'de> for RelocationBatchErrorEntry {
                     Some(".tag") => map.next_value()?,
                     _ => return Err(de::Error::missing_field(".tag"))
                 };
-                match tag {
+                let value = match tag {
                     "relocation_error" => {
                         match map.next_key()? {
-                            Some("relocation_error") => Ok(RelocationBatchErrorEntry::RelocationError(map.next_value()?)),
-                            None => Err(de::Error::missing_field("relocation_error")),
-                            _ => Err(de::Error::unknown_field(tag, VARIANTS))
+                            Some("relocation_error") => RelocationBatchErrorEntry::RelocationError(map.next_value()?),
+                            None => return Err(de::Error::missing_field("relocation_error")),
+                            _ => return Err(de::Error::unknown_field(tag, VARIANTS))
                         }
                     }
-                    "internal_error" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(RelocationBatchErrorEntry::InternalError)
-                    }
-                    "too_many_write_operations" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(RelocationBatchErrorEntry::TooManyWriteOperations)
-                    }
-                    _ => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(RelocationBatchErrorEntry::Other)
-                    }
-                }
+                    "internal_error" => RelocationBatchErrorEntry::InternalError,
+                    "too_many_write_operations" => RelocationBatchErrorEntry::TooManyWriteOperations,
+                    _ => RelocationBatchErrorEntry::Other,
+                };
+                crate::eat_json_fields(&mut map)?;
+                Ok(value)
             }
         }
         const VARIANTS: &[&str] = &["relocation_error",
@@ -13850,21 +13567,20 @@ impl<'de> ::serde::de::Deserialize<'de> for RelocationBatchJobStatus {
                     Some(".tag") => map.next_value()?,
                     _ => return Err(de::Error::missing_field(".tag"))
                 };
-                match tag {
-                    "in_progress" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(RelocationBatchJobStatus::InProgress)
-                    }
-                    "complete" => Ok(RelocationBatchJobStatus::Complete(RelocationBatchResult::internal_deserialize(map)?)),
+                let value = match tag {
+                    "in_progress" => RelocationBatchJobStatus::InProgress,
+                    "complete" => RelocationBatchJobStatus::Complete(RelocationBatchResult::internal_deserialize(&mut map)?),
                     "failed" => {
                         match map.next_key()? {
-                            Some("failed") => Ok(RelocationBatchJobStatus::Failed(map.next_value()?)),
-                            None => Err(de::Error::missing_field("failed")),
-                            _ => Err(de::Error::unknown_field(tag, VARIANTS))
+                            Some("failed") => RelocationBatchJobStatus::Failed(map.next_value()?),
+                            None => return Err(de::Error::missing_field("failed")),
+                            _ => return Err(de::Error::unknown_field(tag, VARIANTS))
                         }
                     }
-                    _ => Err(de::Error::unknown_variant(tag, VARIANTS))
-                }
+                    _ => return Err(de::Error::unknown_variant(tag, VARIANTS))
+                };
+                crate::eat_json_fields(&mut map)?;
+                Ok(value)
             }
         }
         const VARIANTS: &[&str] = &["in_progress",
@@ -13932,20 +13648,19 @@ impl<'de> ::serde::de::Deserialize<'de> for RelocationBatchLaunch {
                     Some(".tag") => map.next_value()?,
                     _ => return Err(de::Error::missing_field(".tag"))
                 };
-                match tag {
+                let value = match tag {
                     "async_job_id" => {
                         match map.next_key()? {
-                            Some("async_job_id") => Ok(RelocationBatchLaunch::AsyncJobId(map.next_value()?)),
-                            None => Err(de::Error::missing_field("async_job_id")),
-                            _ => Err(de::Error::unknown_field(tag, VARIANTS))
+                            Some("async_job_id") => RelocationBatchLaunch::AsyncJobId(map.next_value()?),
+                            None => return Err(de::Error::missing_field("async_job_id")),
+                            _ => return Err(de::Error::unknown_field(tag, VARIANTS))
                         }
                     }
-                    "complete" => Ok(RelocationBatchLaunch::Complete(RelocationBatchResult::internal_deserialize(map)?)),
-                    _ => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(RelocationBatchLaunch::Other)
-                    }
-                }
+                    "complete" => RelocationBatchLaunch::Complete(RelocationBatchResult::internal_deserialize(&mut map)?),
+                    _ => RelocationBatchLaunch::Other,
+                };
+                crate::eat_json_fields(&mut map)?;
+                Ok(value)
             }
         }
         const VARIANTS: &[&str] = &["async_job_id",
@@ -14183,26 +13898,25 @@ impl<'de> ::serde::de::Deserialize<'de> for RelocationBatchResultEntry {
                     Some(".tag") => map.next_value()?,
                     _ => return Err(de::Error::missing_field(".tag"))
                 };
-                match tag {
+                let value = match tag {
                     "success" => {
                         match map.next_key()? {
-                            Some("success") => Ok(RelocationBatchResultEntry::Success(map.next_value()?)),
-                            None => Err(de::Error::missing_field("success")),
-                            _ => Err(de::Error::unknown_field(tag, VARIANTS))
+                            Some("success") => RelocationBatchResultEntry::Success(map.next_value()?),
+                            None => return Err(de::Error::missing_field("success")),
+                            _ => return Err(de::Error::unknown_field(tag, VARIANTS))
                         }
                     }
                     "failure" => {
                         match map.next_key()? {
-                            Some("failure") => Ok(RelocationBatchResultEntry::Failure(map.next_value()?)),
-                            None => Err(de::Error::missing_field("failure")),
-                            _ => Err(de::Error::unknown_field(tag, VARIANTS))
+                            Some("failure") => RelocationBatchResultEntry::Failure(map.next_value()?),
+                            None => return Err(de::Error::missing_field("failure")),
+                            _ => return Err(de::Error::unknown_field(tag, VARIANTS))
                         }
                     }
-                    _ => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(RelocationBatchResultEntry::Other)
-                    }
-                }
+                    _ => RelocationBatchResultEntry::Other,
+                };
+                crate::eat_json_fields(&mut map)?;
+                Ok(value)
             }
         }
         const VARIANTS: &[&str] = &["success",
@@ -14262,14 +13976,13 @@ impl<'de> ::serde::de::Deserialize<'de> for RelocationBatchV2JobStatus {
                     Some(".tag") => map.next_value()?,
                     _ => return Err(de::Error::missing_field(".tag"))
                 };
-                match tag {
-                    "in_progress" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(RelocationBatchV2JobStatus::InProgress)
-                    }
-                    "complete" => Ok(RelocationBatchV2JobStatus::Complete(RelocationBatchV2Result::internal_deserialize(map)?)),
-                    _ => Err(de::Error::unknown_variant(tag, VARIANTS))
-                }
+                let value = match tag {
+                    "in_progress" => RelocationBatchV2JobStatus::InProgress,
+                    "complete" => RelocationBatchV2JobStatus::Complete(RelocationBatchV2Result::internal_deserialize(&mut map)?),
+                    _ => return Err(de::Error::unknown_variant(tag, VARIANTS))
+                };
+                crate::eat_json_fields(&mut map)?;
+                Ok(value)
             }
         }
         const VARIANTS: &[&str] = &["in_progress",
@@ -14325,17 +14038,19 @@ impl<'de> ::serde::de::Deserialize<'de> for RelocationBatchV2Launch {
                     Some(".tag") => map.next_value()?,
                     _ => return Err(de::Error::missing_field(".tag"))
                 };
-                match tag {
+                let value = match tag {
                     "async_job_id" => {
                         match map.next_key()? {
-                            Some("async_job_id") => Ok(RelocationBatchV2Launch::AsyncJobId(map.next_value()?)),
-                            None => Err(de::Error::missing_field("async_job_id")),
-                            _ => Err(de::Error::unknown_field(tag, VARIANTS))
+                            Some("async_job_id") => RelocationBatchV2Launch::AsyncJobId(map.next_value()?),
+                            None => return Err(de::Error::missing_field("async_job_id")),
+                            _ => return Err(de::Error::unknown_field(tag, VARIANTS))
                         }
                     }
-                    "complete" => Ok(RelocationBatchV2Launch::Complete(RelocationBatchV2Result::internal_deserialize(map)?)),
-                    _ => Err(de::Error::unknown_variant(tag, VARIANTS))
-                }
+                    "complete" => RelocationBatchV2Launch::Complete(RelocationBatchV2Result::internal_deserialize(&mut map)?),
+                    _ => return Err(de::Error::unknown_variant(tag, VARIANTS))
+                };
+                crate::eat_json_fields(&mut map)?;
+                Ok(value)
             }
         }
         const VARIANTS: &[&str] = &["async_job_id",
@@ -14507,76 +14222,48 @@ impl<'de> ::serde::de::Deserialize<'de> for RelocationError {
                     Some(".tag") => map.next_value()?,
                     _ => return Err(de::Error::missing_field(".tag"))
                 };
-                match tag {
+                let value = match tag {
                     "from_lookup" => {
                         match map.next_key()? {
-                            Some("from_lookup") => Ok(RelocationError::FromLookup(map.next_value()?)),
-                            None => Err(de::Error::missing_field("from_lookup")),
-                            _ => Err(de::Error::unknown_field(tag, VARIANTS))
+                            Some("from_lookup") => RelocationError::FromLookup(map.next_value()?),
+                            None => return Err(de::Error::missing_field("from_lookup")),
+                            _ => return Err(de::Error::unknown_field(tag, VARIANTS))
                         }
                     }
                     "from_write" => {
                         match map.next_key()? {
-                            Some("from_write") => Ok(RelocationError::FromWrite(map.next_value()?)),
-                            None => Err(de::Error::missing_field("from_write")),
-                            _ => Err(de::Error::unknown_field(tag, VARIANTS))
+                            Some("from_write") => RelocationError::FromWrite(map.next_value()?),
+                            None => return Err(de::Error::missing_field("from_write")),
+                            _ => return Err(de::Error::unknown_field(tag, VARIANTS))
                         }
                     }
                     "to" => {
                         match map.next_key()? {
-                            Some("to") => Ok(RelocationError::To(map.next_value()?)),
-                            None => Err(de::Error::missing_field("to")),
-                            _ => Err(de::Error::unknown_field(tag, VARIANTS))
+                            Some("to") => RelocationError::To(map.next_value()?),
+                            None => return Err(de::Error::missing_field("to")),
+                            _ => return Err(de::Error::unknown_field(tag, VARIANTS))
                         }
                     }
-                    "cant_copy_shared_folder" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(RelocationError::CantCopySharedFolder)
-                    }
-                    "cant_nest_shared_folder" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(RelocationError::CantNestSharedFolder)
-                    }
-                    "cant_move_folder_into_itself" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(RelocationError::CantMoveFolderIntoItself)
-                    }
-                    "too_many_files" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(RelocationError::TooManyFiles)
-                    }
-                    "duplicated_or_nested_paths" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(RelocationError::DuplicatedOrNestedPaths)
-                    }
-                    "cant_transfer_ownership" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(RelocationError::CantTransferOwnership)
-                    }
-                    "insufficient_quota" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(RelocationError::InsufficientQuota)
-                    }
-                    "internal_error" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(RelocationError::InternalError)
-                    }
-                    "cant_move_shared_folder" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(RelocationError::CantMoveSharedFolder)
-                    }
+                    "cant_copy_shared_folder" => RelocationError::CantCopySharedFolder,
+                    "cant_nest_shared_folder" => RelocationError::CantNestSharedFolder,
+                    "cant_move_folder_into_itself" => RelocationError::CantMoveFolderIntoItself,
+                    "too_many_files" => RelocationError::TooManyFiles,
+                    "duplicated_or_nested_paths" => RelocationError::DuplicatedOrNestedPaths,
+                    "cant_transfer_ownership" => RelocationError::CantTransferOwnership,
+                    "insufficient_quota" => RelocationError::InsufficientQuota,
+                    "internal_error" => RelocationError::InternalError,
+                    "cant_move_shared_folder" => RelocationError::CantMoveSharedFolder,
                     "cant_move_into_vault" => {
                         match map.next_key()? {
-                            Some("cant_move_into_vault") => Ok(RelocationError::CantMoveIntoVault(map.next_value()?)),
-                            None => Err(de::Error::missing_field("cant_move_into_vault")),
-                            _ => Err(de::Error::unknown_field(tag, VARIANTS))
+                            Some("cant_move_into_vault") => RelocationError::CantMoveIntoVault(map.next_value()?),
+                            None => return Err(de::Error::missing_field("cant_move_into_vault")),
+                            _ => return Err(de::Error::unknown_field(tag, VARIANTS))
                         }
                     }
-                    _ => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(RelocationError::Other)
-                    }
-                }
+                    _ => RelocationError::Other,
+                };
+                crate::eat_json_fields(&mut map)?;
+                Ok(value)
             }
         }
         const VARIANTS: &[&str] = &["from_lookup",
@@ -15047,34 +14734,27 @@ impl<'de> ::serde::de::Deserialize<'de> for RestoreError {
                     Some(".tag") => map.next_value()?,
                     _ => return Err(de::Error::missing_field(".tag"))
                 };
-                match tag {
+                let value = match tag {
                     "path_lookup" => {
                         match map.next_key()? {
-                            Some("path_lookup") => Ok(RestoreError::PathLookup(map.next_value()?)),
-                            None => Err(de::Error::missing_field("path_lookup")),
-                            _ => Err(de::Error::unknown_field(tag, VARIANTS))
+                            Some("path_lookup") => RestoreError::PathLookup(map.next_value()?),
+                            None => return Err(de::Error::missing_field("path_lookup")),
+                            _ => return Err(de::Error::unknown_field(tag, VARIANTS))
                         }
                     }
                     "path_write" => {
                         match map.next_key()? {
-                            Some("path_write") => Ok(RestoreError::PathWrite(map.next_value()?)),
-                            None => Err(de::Error::missing_field("path_write")),
-                            _ => Err(de::Error::unknown_field(tag, VARIANTS))
+                            Some("path_write") => RestoreError::PathWrite(map.next_value()?),
+                            None => return Err(de::Error::missing_field("path_write")),
+                            _ => return Err(de::Error::unknown_field(tag, VARIANTS))
                         }
                     }
-                    "invalid_revision" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(RestoreError::InvalidRevision)
-                    }
-                    "in_progress" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(RestoreError::InProgress)
-                    }
-                    _ => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(RestoreError::Other)
-                    }
-                }
+                    "invalid_revision" => RestoreError::InvalidRevision,
+                    "in_progress" => RestoreError::InProgress,
+                    _ => RestoreError::Other,
+                };
+                crate::eat_json_fields(&mut map)?;
+                Ok(value)
             }
         }
         const VARIANTS: &[&str] = &["path_lookup",
@@ -15280,35 +14960,22 @@ impl<'de> ::serde::de::Deserialize<'de> for SaveCopyReferenceError {
                     Some(".tag") => map.next_value()?,
                     _ => return Err(de::Error::missing_field(".tag"))
                 };
-                match tag {
+                let value = match tag {
                     "path" => {
                         match map.next_key()? {
-                            Some("path") => Ok(SaveCopyReferenceError::Path(map.next_value()?)),
-                            None => Err(de::Error::missing_field("path")),
-                            _ => Err(de::Error::unknown_field(tag, VARIANTS))
+                            Some("path") => SaveCopyReferenceError::Path(map.next_value()?),
+                            None => return Err(de::Error::missing_field("path")),
+                            _ => return Err(de::Error::unknown_field(tag, VARIANTS))
                         }
                     }
-                    "invalid_copy_reference" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(SaveCopyReferenceError::InvalidCopyReference)
-                    }
-                    "no_permission" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(SaveCopyReferenceError::NoPermission)
-                    }
-                    "not_found" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(SaveCopyReferenceError::NotFound)
-                    }
-                    "too_many_files" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(SaveCopyReferenceError::TooManyFiles)
-                    }
-                    _ => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(SaveCopyReferenceError::Other)
-                    }
-                }
+                    "invalid_copy_reference" => SaveCopyReferenceError::InvalidCopyReference,
+                    "no_permission" => SaveCopyReferenceError::NoPermission,
+                    "not_found" => SaveCopyReferenceError::NotFound,
+                    "too_many_files" => SaveCopyReferenceError::TooManyFiles,
+                    _ => SaveCopyReferenceError::Other,
+                };
+                crate::eat_json_fields(&mut map)?;
+                Ok(value)
             }
         }
         const VARIANTS: &[&str] = &["path",
@@ -15608,31 +15275,21 @@ impl<'de> ::serde::de::Deserialize<'de> for SaveUrlError {
                     Some(".tag") => map.next_value()?,
                     _ => return Err(de::Error::missing_field(".tag"))
                 };
-                match tag {
+                let value = match tag {
                     "path" => {
                         match map.next_key()? {
-                            Some("path") => Ok(SaveUrlError::Path(map.next_value()?)),
-                            None => Err(de::Error::missing_field("path")),
-                            _ => Err(de::Error::unknown_field(tag, VARIANTS))
+                            Some("path") => SaveUrlError::Path(map.next_value()?),
+                            None => return Err(de::Error::missing_field("path")),
+                            _ => return Err(de::Error::unknown_field(tag, VARIANTS))
                         }
                     }
-                    "download_failed" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(SaveUrlError::DownloadFailed)
-                    }
-                    "invalid_url" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(SaveUrlError::InvalidUrl)
-                    }
-                    "not_found" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(SaveUrlError::NotFound)
-                    }
-                    _ => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(SaveUrlError::Other)
-                    }
-                }
+                    "download_failed" => SaveUrlError::DownloadFailed,
+                    "invalid_url" => SaveUrlError::InvalidUrl,
+                    "not_found" => SaveUrlError::NotFound,
+                    _ => SaveUrlError::Other,
+                };
+                crate::eat_json_fields(&mut map)?;
+                Ok(value)
             }
         }
         const VARIANTS: &[&str] = &["path",
@@ -15724,21 +15381,20 @@ impl<'de> ::serde::de::Deserialize<'de> for SaveUrlJobStatus {
                     Some(".tag") => map.next_value()?,
                     _ => return Err(de::Error::missing_field(".tag"))
                 };
-                match tag {
-                    "in_progress" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(SaveUrlJobStatus::InProgress)
-                    }
-                    "complete" => Ok(SaveUrlJobStatus::Complete(FileMetadata::internal_deserialize(map)?)),
+                let value = match tag {
+                    "in_progress" => SaveUrlJobStatus::InProgress,
+                    "complete" => SaveUrlJobStatus::Complete(FileMetadata::internal_deserialize(&mut map)?),
                     "failed" => {
                         match map.next_key()? {
-                            Some("failed") => Ok(SaveUrlJobStatus::Failed(map.next_value()?)),
-                            None => Err(de::Error::missing_field("failed")),
-                            _ => Err(de::Error::unknown_field(tag, VARIANTS))
+                            Some("failed") => SaveUrlJobStatus::Failed(map.next_value()?),
+                            None => return Err(de::Error::missing_field("failed")),
+                            _ => return Err(de::Error::unknown_field(tag, VARIANTS))
                         }
                     }
-                    _ => Err(de::Error::unknown_variant(tag, VARIANTS))
-                }
+                    _ => return Err(de::Error::unknown_variant(tag, VARIANTS))
+                };
+                crate::eat_json_fields(&mut map)?;
+                Ok(value)
             }
         }
         const VARIANTS: &[&str] = &["in_progress",
@@ -15801,17 +15457,19 @@ impl<'de> ::serde::de::Deserialize<'de> for SaveUrlResult {
                     Some(".tag") => map.next_value()?,
                     _ => return Err(de::Error::missing_field(".tag"))
                 };
-                match tag {
+                let value = match tag {
                     "async_job_id" => {
                         match map.next_key()? {
-                            Some("async_job_id") => Ok(SaveUrlResult::AsyncJobId(map.next_value()?)),
-                            None => Err(de::Error::missing_field("async_job_id")),
-                            _ => Err(de::Error::unknown_field(tag, VARIANTS))
+                            Some("async_job_id") => SaveUrlResult::AsyncJobId(map.next_value()?),
+                            None => return Err(de::Error::missing_field("async_job_id")),
+                            _ => return Err(de::Error::unknown_field(tag, VARIANTS))
                         }
                     }
-                    "complete" => Ok(SaveUrlResult::Complete(FileMetadata::internal_deserialize(map)?)),
-                    _ => Err(de::Error::unknown_variant(tag, VARIANTS))
-                }
+                    "complete" => SaveUrlResult::Complete(FileMetadata::internal_deserialize(&mut map)?),
+                    _ => return Err(de::Error::unknown_variant(tag, VARIANTS))
+                };
+                crate::eat_json_fields(&mut map)?;
+                Ok(value)
             }
         }
         const VARIANTS: &[&str] = &["async_job_id",
@@ -16030,30 +15688,26 @@ impl<'de> ::serde::de::Deserialize<'de> for SearchError {
                     Some(".tag") => map.next_value()?,
                     _ => return Err(de::Error::missing_field(".tag"))
                 };
-                match tag {
+                let value = match tag {
                     "path" => {
                         match map.next_key()? {
-                            Some("path") => Ok(SearchError::Path(map.next_value()?)),
-                            None => Err(de::Error::missing_field("path")),
-                            _ => Err(de::Error::unknown_field(tag, VARIANTS))
+                            Some("path") => SearchError::Path(map.next_value()?),
+                            None => return Err(de::Error::missing_field("path")),
+                            _ => return Err(de::Error::unknown_field(tag, VARIANTS))
                         }
                     }
                     "invalid_argument" => {
                         match map.next_key()? {
-                            Some("invalid_argument") => Ok(SearchError::InvalidArgument(map.next_value()?)),
-                            None => Ok(SearchError::InvalidArgument(None)),
-                            _ => Err(de::Error::unknown_field(tag, VARIANTS))
+                            Some("invalid_argument") => SearchError::InvalidArgument(map.next_value()?),
+                            None => SearchError::InvalidArgument(None),
+                            _ => return Err(de::Error::unknown_field(tag, VARIANTS))
                         }
                     }
-                    "internal_error" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(SearchError::InternalError)
-                    }
-                    _ => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(SearchError::Other)
-                    }
-                }
+                    "internal_error" => SearchError::InternalError,
+                    _ => SearchError::Other,
+                };
+                crate::eat_json_fields(&mut map)?;
+                Ok(value)
             }
         }
         const VARIANTS: &[&str] = &["path",
@@ -16333,21 +15987,14 @@ impl<'de> ::serde::de::Deserialize<'de> for SearchMatchType {
                     Some(".tag") => map.next_value()?,
                     _ => return Err(de::Error::missing_field(".tag"))
                 };
-                match tag {
-                    "filename" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(SearchMatchType::Filename)
-                    }
-                    "content" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(SearchMatchType::Content)
-                    }
-                    "both" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(SearchMatchType::Both)
-                    }
-                    _ => Err(de::Error::unknown_variant(tag, VARIANTS))
-                }
+                let value = match tag {
+                    "filename" => SearchMatchType::Filename,
+                    "content" => SearchMatchType::Content,
+                    "both" => SearchMatchType::Both,
+                    _ => return Err(de::Error::unknown_variant(tag, VARIANTS))
+                };
+                crate::eat_json_fields(&mut map)?;
+                Ok(value)
             }
         }
         const VARIANTS: &[&str] = &["filename",
@@ -16416,28 +16063,15 @@ impl<'de> ::serde::de::Deserialize<'de> for SearchMatchTypeV2 {
                     Some(".tag") => map.next_value()?,
                     _ => return Err(de::Error::missing_field(".tag"))
                 };
-                match tag {
-                    "filename" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(SearchMatchTypeV2::Filename)
-                    }
-                    "file_content" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(SearchMatchTypeV2::FileContent)
-                    }
-                    "filename_and_content" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(SearchMatchTypeV2::FilenameAndContent)
-                    }
-                    "image_content" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(SearchMatchTypeV2::ImageContent)
-                    }
-                    _ => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(SearchMatchTypeV2::Other)
-                    }
-                }
+                let value = match tag {
+                    "filename" => SearchMatchTypeV2::Filename,
+                    "file_content" => SearchMatchTypeV2::FileContent,
+                    "filename_and_content" => SearchMatchTypeV2::FilenameAndContent,
+                    "image_content" => SearchMatchTypeV2::ImageContent,
+                    _ => SearchMatchTypeV2::Other,
+                };
+                crate::eat_json_fields(&mut map)?;
+                Ok(value)
             }
         }
         const VARIANTS: &[&str] = &["filename",
@@ -16634,21 +16268,14 @@ impl<'de> ::serde::de::Deserialize<'de> for SearchMode {
                     Some(".tag") => map.next_value()?,
                     _ => return Err(de::Error::missing_field(".tag"))
                 };
-                match tag {
-                    "filename" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(SearchMode::Filename)
-                    }
-                    "filename_and_content" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(SearchMode::FilenameAndContent)
-                    }
-                    "deleted_filename" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(SearchMode::DeletedFilename)
-                    }
-                    _ => Err(de::Error::unknown_variant(tag, VARIANTS))
-                }
+                let value = match tag {
+                    "filename" => SearchMode::Filename,
+                    "filename_and_content" => SearchMode::FilenameAndContent,
+                    "deleted_filename" => SearchMode::DeletedFilename,
+                    _ => return Err(de::Error::unknown_variant(tag, VARIANTS))
+                };
+                crate::eat_json_fields(&mut map)?;
+                Ok(value)
             }
         }
         const VARIANTS: &[&str] = &["filename",
@@ -16907,20 +16534,13 @@ impl<'de> ::serde::de::Deserialize<'de> for SearchOrderBy {
                     Some(".tag") => map.next_value()?,
                     _ => return Err(de::Error::missing_field(".tag"))
                 };
-                match tag {
-                    "relevance" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(SearchOrderBy::Relevance)
-                    }
-                    "last_modified_time" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(SearchOrderBy::LastModifiedTime)
-                    }
-                    _ => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(SearchOrderBy::Other)
-                    }
-                }
+                let value = match tag {
+                    "relevance" => SearchOrderBy::Relevance,
+                    "last_modified_time" => SearchOrderBy::LastModifiedTime,
+                    _ => SearchOrderBy::Other,
+                };
+                crate::eat_json_fields(&mut map)?;
+                Ok(value)
             }
         }
         const VARIANTS: &[&str] = &["relevance",
@@ -18003,24 +17623,14 @@ impl<'de> ::serde::de::Deserialize<'de> for SyncSetting {
                     Some(".tag") => map.next_value()?,
                     _ => return Err(de::Error::missing_field(".tag"))
                 };
-                match tag {
-                    "default" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(SyncSetting::Default)
-                    }
-                    "not_synced" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(SyncSetting::NotSynced)
-                    }
-                    "not_synced_inactive" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(SyncSetting::NotSyncedInactive)
-                    }
-                    _ => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(SyncSetting::Other)
-                    }
-                }
+                let value = match tag {
+                    "default" => SyncSetting::Default,
+                    "not_synced" => SyncSetting::NotSynced,
+                    "not_synced_inactive" => SyncSetting::NotSyncedInactive,
+                    _ => SyncSetting::Other,
+                };
+                crate::eat_json_fields(&mut map)?;
+                Ok(value)
             }
         }
         const VARIANTS: &[&str] = &["default",
@@ -18088,20 +17698,13 @@ impl<'de> ::serde::de::Deserialize<'de> for SyncSettingArg {
                     Some(".tag") => map.next_value()?,
                     _ => return Err(de::Error::missing_field(".tag"))
                 };
-                match tag {
-                    "default" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(SyncSettingArg::Default)
-                    }
-                    "not_synced" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(SyncSettingArg::NotSynced)
-                    }
-                    _ => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(SyncSettingArg::Other)
-                    }
-                }
+                let value = match tag {
+                    "default" => SyncSettingArg::Default,
+                    "not_synced" => SyncSettingArg::NotSynced,
+                    _ => SyncSettingArg::Other,
+                };
+                crate::eat_json_fields(&mut map)?;
+                Ok(value)
             }
         }
         const VARIANTS: &[&str] = &["default",
@@ -18161,27 +17764,20 @@ impl<'de> ::serde::de::Deserialize<'de> for SyncSettingsError {
                     Some(".tag") => map.next_value()?,
                     _ => return Err(de::Error::missing_field(".tag"))
                 };
-                match tag {
+                let value = match tag {
                     "path" => {
                         match map.next_key()? {
-                            Some("path") => Ok(SyncSettingsError::Path(map.next_value()?)),
-                            None => Err(de::Error::missing_field("path")),
-                            _ => Err(de::Error::unknown_field(tag, VARIANTS))
+                            Some("path") => SyncSettingsError::Path(map.next_value()?),
+                            None => return Err(de::Error::missing_field("path")),
+                            _ => return Err(de::Error::unknown_field(tag, VARIANTS))
                         }
                     }
-                    "unsupported_combination" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(SyncSettingsError::UnsupportedCombination)
-                    }
-                    "unsupported_configuration" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(SyncSettingsError::UnsupportedConfiguration)
-                    }
-                    _ => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(SyncSettingsError::Other)
-                    }
-                }
+                    "unsupported_combination" => SyncSettingsError::UnsupportedCombination,
+                    "unsupported_configuration" => SyncSettingsError::UnsupportedConfiguration,
+                    _ => SyncSettingsError::Other,
+                };
+                crate::eat_json_fields(&mut map)?;
+                Ok(value)
             }
         }
         const VARIANTS: &[&str] = &["path",
@@ -18413,28 +18009,21 @@ impl<'de> ::serde::de::Deserialize<'de> for ThumbnailError {
                     Some(".tag") => map.next_value()?,
                     _ => return Err(de::Error::missing_field(".tag"))
                 };
-                match tag {
+                let value = match tag {
                     "path" => {
                         match map.next_key()? {
-                            Some("path") => Ok(ThumbnailError::Path(map.next_value()?)),
-                            None => Err(de::Error::missing_field("path")),
-                            _ => Err(de::Error::unknown_field(tag, VARIANTS))
+                            Some("path") => ThumbnailError::Path(map.next_value()?),
+                            None => return Err(de::Error::missing_field("path")),
+                            _ => return Err(de::Error::unknown_field(tag, VARIANTS))
                         }
                     }
-                    "unsupported_extension" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(ThumbnailError::UnsupportedExtension)
-                    }
-                    "unsupported_image" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(ThumbnailError::UnsupportedImage)
-                    }
-                    "conversion_error" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(ThumbnailError::ConversionError)
-                    }
-                    _ => Err(de::Error::unknown_variant(tag, VARIANTS))
-                }
+                    "unsupported_extension" => ThumbnailError::UnsupportedExtension,
+                    "unsupported_image" => ThumbnailError::UnsupportedImage,
+                    "conversion_error" => ThumbnailError::ConversionError,
+                    _ => return Err(de::Error::unknown_variant(tag, VARIANTS))
+                };
+                crate::eat_json_fields(&mut map)?;
+                Ok(value)
             }
         }
         const VARIANTS: &[&str] = &["path",
@@ -18520,17 +18109,13 @@ impl<'de> ::serde::de::Deserialize<'de> for ThumbnailFormat {
                     Some(".tag") => map.next_value()?,
                     _ => return Err(de::Error::missing_field(".tag"))
                 };
-                match tag {
-                    "jpeg" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(ThumbnailFormat::Jpeg)
-                    }
-                    "png" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(ThumbnailFormat::Png)
-                    }
-                    _ => Err(de::Error::unknown_variant(tag, VARIANTS))
-                }
+                let value = match tag {
+                    "jpeg" => ThumbnailFormat::Jpeg,
+                    "png" => ThumbnailFormat::Png,
+                    _ => return Err(de::Error::unknown_variant(tag, VARIANTS))
+                };
+                crate::eat_json_fields(&mut map)?;
+                Ok(value)
             }
         }
         const VARIANTS: &[&str] = &["jpeg",
@@ -18585,21 +18170,14 @@ impl<'de> ::serde::de::Deserialize<'de> for ThumbnailMode {
                     Some(".tag") => map.next_value()?,
                     _ => return Err(de::Error::missing_field(".tag"))
                 };
-                match tag {
-                    "strict" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(ThumbnailMode::Strict)
-                    }
-                    "bestfit" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(ThumbnailMode::Bestfit)
-                    }
-                    "fitone_bestfit" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(ThumbnailMode::FitoneBestfit)
-                    }
-                    _ => Err(de::Error::unknown_variant(tag, VARIANTS))
-                }
+                let value = match tag {
+                    "strict" => ThumbnailMode::Strict,
+                    "bestfit" => ThumbnailMode::Bestfit,
+                    "fitone_bestfit" => ThumbnailMode::FitoneBestfit,
+                    _ => return Err(de::Error::unknown_variant(tag, VARIANTS))
+                };
+                crate::eat_json_fields(&mut map)?;
+                Ok(value)
             }
         }
         const VARIANTS: &[&str] = &["strict",
@@ -18673,45 +18251,20 @@ impl<'de> ::serde::de::Deserialize<'de> for ThumbnailSize {
                     Some(".tag") => map.next_value()?,
                     _ => return Err(de::Error::missing_field(".tag"))
                 };
-                match tag {
-                    "w32h32" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(ThumbnailSize::W32h32)
-                    }
-                    "w64h64" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(ThumbnailSize::W64h64)
-                    }
-                    "w128h128" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(ThumbnailSize::W128h128)
-                    }
-                    "w256h256" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(ThumbnailSize::W256h256)
-                    }
-                    "w480h320" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(ThumbnailSize::W480h320)
-                    }
-                    "w640h480" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(ThumbnailSize::W640h480)
-                    }
-                    "w960h640" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(ThumbnailSize::W960h640)
-                    }
-                    "w1024h768" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(ThumbnailSize::W1024h768)
-                    }
-                    "w2048h1536" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(ThumbnailSize::W2048h1536)
-                    }
-                    _ => Err(de::Error::unknown_variant(tag, VARIANTS))
-                }
+                let value = match tag {
+                    "w32h32" => ThumbnailSize::W32h32,
+                    "w64h64" => ThumbnailSize::W64h64,
+                    "w128h128" => ThumbnailSize::W128h128,
+                    "w256h256" => ThumbnailSize::W256h256,
+                    "w480h320" => ThumbnailSize::W480h320,
+                    "w640h480" => ThumbnailSize::W640h480,
+                    "w960h640" => ThumbnailSize::W960h640,
+                    "w1024h768" => ThumbnailSize::W1024h768,
+                    "w2048h1536" => ThumbnailSize::W2048h1536,
+                    _ => return Err(de::Error::unknown_variant(tag, VARIANTS))
+                };
+                crate::eat_json_fields(&mut map)?;
+                Ok(value)
             }
         }
         const VARIANTS: &[&str] = &["w32h32",
@@ -18971,39 +18524,23 @@ impl<'de> ::serde::de::Deserialize<'de> for ThumbnailV2Error {
                     Some(".tag") => map.next_value()?,
                     _ => return Err(de::Error::missing_field(".tag"))
                 };
-                match tag {
+                let value = match tag {
                     "path" => {
                         match map.next_key()? {
-                            Some("path") => Ok(ThumbnailV2Error::Path(map.next_value()?)),
-                            None => Err(de::Error::missing_field("path")),
-                            _ => Err(de::Error::unknown_field(tag, VARIANTS))
+                            Some("path") => ThumbnailV2Error::Path(map.next_value()?),
+                            None => return Err(de::Error::missing_field("path")),
+                            _ => return Err(de::Error::unknown_field(tag, VARIANTS))
                         }
                     }
-                    "unsupported_extension" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(ThumbnailV2Error::UnsupportedExtension)
-                    }
-                    "unsupported_image" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(ThumbnailV2Error::UnsupportedImage)
-                    }
-                    "conversion_error" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(ThumbnailV2Error::ConversionError)
-                    }
-                    "access_denied" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(ThumbnailV2Error::AccessDenied)
-                    }
-                    "not_found" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(ThumbnailV2Error::NotFound)
-                    }
-                    _ => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(ThumbnailV2Error::Other)
-                    }
-                }
+                    "unsupported_extension" => ThumbnailV2Error::UnsupportedExtension,
+                    "unsupported_image" => ThumbnailV2Error::UnsupportedImage,
+                    "conversion_error" => ThumbnailV2Error::ConversionError,
+                    "access_denied" => ThumbnailV2Error::AccessDenied,
+                    "not_found" => ThumbnailV2Error::NotFound,
+                    _ => ThumbnailV2Error::Other,
+                };
+                crate::eat_json_fields(&mut map)?;
+                Ok(value)
             }
         }
         const VARIANTS: &[&str] = &["path",
@@ -19295,20 +18832,19 @@ impl<'de> ::serde::de::Deserialize<'de> for UploadError {
                     Some(".tag") => map.next_value()?,
                     _ => return Err(de::Error::missing_field(".tag"))
                 };
-                match tag {
-                    "path" => Ok(UploadError::Path(UploadWriteFailed::internal_deserialize(map)?)),
+                let value = match tag {
+                    "path" => UploadError::Path(UploadWriteFailed::internal_deserialize(&mut map)?),
                     "properties_error" => {
                         match map.next_key()? {
-                            Some("properties_error") => Ok(UploadError::PropertiesError(map.next_value()?)),
-                            None => Err(de::Error::missing_field("properties_error")),
-                            _ => Err(de::Error::unknown_field(tag, VARIANTS))
+                            Some("properties_error") => UploadError::PropertiesError(map.next_value()?),
+                            None => return Err(de::Error::missing_field("properties_error")),
+                            _ => return Err(de::Error::unknown_field(tag, VARIANTS))
                         }
                     }
-                    _ => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(UploadError::Other)
-                    }
-                }
+                    _ => UploadError::Other,
+                };
+                crate::eat_json_fields(&mut map)?;
+                Ok(value)
             }
         }
         const VARIANTS: &[&str] = &["path",
@@ -19388,20 +18924,19 @@ impl<'de> ::serde::de::Deserialize<'de> for UploadErrorWithProperties {
                     Some(".tag") => map.next_value()?,
                     _ => return Err(de::Error::missing_field(".tag"))
                 };
-                match tag {
-                    "path" => Ok(UploadErrorWithProperties::Path(UploadWriteFailed::internal_deserialize(map)?)),
+                let value = match tag {
+                    "path" => UploadErrorWithProperties::Path(UploadWriteFailed::internal_deserialize(&mut map)?),
                     "properties_error" => {
                         match map.next_key()? {
-                            Some("properties_error") => Ok(UploadErrorWithProperties::PropertiesError(map.next_value()?)),
-                            None => Err(de::Error::missing_field("properties_error")),
-                            _ => Err(de::Error::unknown_field(tag, VARIANTS))
+                            Some("properties_error") => UploadErrorWithProperties::PropertiesError(map.next_value()?),
+                            None => return Err(de::Error::missing_field("properties_error")),
+                            _ => return Err(de::Error::unknown_field(tag, VARIANTS))
                         }
                     }
-                    _ => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(UploadErrorWithProperties::Other)
-                    }
-                }
+                    _ => UploadErrorWithProperties::Other,
+                };
+                crate::eat_json_fields(&mut map)?;
+                Ok(value)
             }
         }
         const VARIANTS: &[&str] = &["path",
@@ -19883,14 +19418,13 @@ impl<'de> ::serde::de::Deserialize<'de> for UploadSessionFinishBatchJobStatus {
                     Some(".tag") => map.next_value()?,
                     _ => return Err(de::Error::missing_field(".tag"))
                 };
-                match tag {
-                    "in_progress" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(UploadSessionFinishBatchJobStatus::InProgress)
-                    }
-                    "complete" => Ok(UploadSessionFinishBatchJobStatus::Complete(UploadSessionFinishBatchResult::internal_deserialize(map)?)),
-                    _ => Err(de::Error::unknown_variant(tag, VARIANTS))
-                }
+                let value = match tag {
+                    "in_progress" => UploadSessionFinishBatchJobStatus::InProgress,
+                    "complete" => UploadSessionFinishBatchJobStatus::Complete(UploadSessionFinishBatchResult::internal_deserialize(&mut map)?),
+                    _ => return Err(de::Error::unknown_variant(tag, VARIANTS))
+                };
+                crate::eat_json_fields(&mut map)?;
+                Ok(value)
             }
         }
         const VARIANTS: &[&str] = &["in_progress",
@@ -19950,20 +19484,19 @@ impl<'de> ::serde::de::Deserialize<'de> for UploadSessionFinishBatchLaunch {
                     Some(".tag") => map.next_value()?,
                     _ => return Err(de::Error::missing_field(".tag"))
                 };
-                match tag {
+                let value = match tag {
                     "async_job_id" => {
                         match map.next_key()? {
-                            Some("async_job_id") => Ok(UploadSessionFinishBatchLaunch::AsyncJobId(map.next_value()?)),
-                            None => Err(de::Error::missing_field("async_job_id")),
-                            _ => Err(de::Error::unknown_field(tag, VARIANTS))
+                            Some("async_job_id") => UploadSessionFinishBatchLaunch::AsyncJobId(map.next_value()?),
+                            None => return Err(de::Error::missing_field("async_job_id")),
+                            _ => return Err(de::Error::unknown_field(tag, VARIANTS))
                         }
                     }
-                    "complete" => Ok(UploadSessionFinishBatchLaunch::Complete(UploadSessionFinishBatchResult::internal_deserialize(map)?)),
-                    _ => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(UploadSessionFinishBatchLaunch::Other)
-                    }
-                }
+                    "complete" => UploadSessionFinishBatchLaunch::Complete(UploadSessionFinishBatchResult::internal_deserialize(&mut map)?),
+                    _ => UploadSessionFinishBatchLaunch::Other,
+                };
+                crate::eat_json_fields(&mut map)?;
+                Ok(value)
             }
         }
         const VARIANTS: &[&str] = &["async_job_id",
@@ -20110,17 +19643,19 @@ impl<'de> ::serde::de::Deserialize<'de> for UploadSessionFinishBatchResultEntry 
                     Some(".tag") => map.next_value()?,
                     _ => return Err(de::Error::missing_field(".tag"))
                 };
-                match tag {
-                    "success" => Ok(UploadSessionFinishBatchResultEntry::Success(FileMetadata::internal_deserialize(map)?)),
+                let value = match tag {
+                    "success" => UploadSessionFinishBatchResultEntry::Success(FileMetadata::internal_deserialize(&mut map)?),
                     "failure" => {
                         match map.next_key()? {
-                            Some("failure") => Ok(UploadSessionFinishBatchResultEntry::Failure(map.next_value()?)),
-                            None => Err(de::Error::missing_field("failure")),
-                            _ => Err(de::Error::unknown_field(tag, VARIANTS))
+                            Some("failure") => UploadSessionFinishBatchResultEntry::Failure(map.next_value()?),
+                            None => return Err(de::Error::missing_field("failure")),
+                            _ => return Err(de::Error::unknown_field(tag, VARIANTS))
                         }
                     }
-                    _ => Err(de::Error::unknown_variant(tag, VARIANTS))
-                }
+                    _ => return Err(de::Error::unknown_variant(tag, VARIANTS))
+                };
+                crate::eat_json_fields(&mut map)?;
+                Ok(value)
             }
         }
         const VARIANTS: &[&str] = &["success",
@@ -20194,53 +19729,37 @@ impl<'de> ::serde::de::Deserialize<'de> for UploadSessionFinishError {
                     Some(".tag") => map.next_value()?,
                     _ => return Err(de::Error::missing_field(".tag"))
                 };
-                match tag {
+                let value = match tag {
                     "lookup_failed" => {
                         match map.next_key()? {
-                            Some("lookup_failed") => Ok(UploadSessionFinishError::LookupFailed(map.next_value()?)),
-                            None => Err(de::Error::missing_field("lookup_failed")),
-                            _ => Err(de::Error::unknown_field(tag, VARIANTS))
+                            Some("lookup_failed") => UploadSessionFinishError::LookupFailed(map.next_value()?),
+                            None => return Err(de::Error::missing_field("lookup_failed")),
+                            _ => return Err(de::Error::unknown_field(tag, VARIANTS))
                         }
                     }
                     "path" => {
                         match map.next_key()? {
-                            Some("path") => Ok(UploadSessionFinishError::Path(map.next_value()?)),
-                            None => Err(de::Error::missing_field("path")),
-                            _ => Err(de::Error::unknown_field(tag, VARIANTS))
+                            Some("path") => UploadSessionFinishError::Path(map.next_value()?),
+                            None => return Err(de::Error::missing_field("path")),
+                            _ => return Err(de::Error::unknown_field(tag, VARIANTS))
                         }
                     }
                     "properties_error" => {
                         match map.next_key()? {
-                            Some("properties_error") => Ok(UploadSessionFinishError::PropertiesError(map.next_value()?)),
-                            None => Err(de::Error::missing_field("properties_error")),
-                            _ => Err(de::Error::unknown_field(tag, VARIANTS))
+                            Some("properties_error") => UploadSessionFinishError::PropertiesError(map.next_value()?),
+                            None => return Err(de::Error::missing_field("properties_error")),
+                            _ => return Err(de::Error::unknown_field(tag, VARIANTS))
                         }
                     }
-                    "too_many_shared_folder_targets" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(UploadSessionFinishError::TooManySharedFolderTargets)
-                    }
-                    "too_many_write_operations" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(UploadSessionFinishError::TooManyWriteOperations)
-                    }
-                    "concurrent_session_data_not_allowed" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(UploadSessionFinishError::ConcurrentSessionDataNotAllowed)
-                    }
-                    "concurrent_session_not_closed" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(UploadSessionFinishError::ConcurrentSessionNotClosed)
-                    }
-                    "concurrent_session_missing_data" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(UploadSessionFinishError::ConcurrentSessionMissingData)
-                    }
-                    _ => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(UploadSessionFinishError::Other)
-                    }
-                }
+                    "too_many_shared_folder_targets" => UploadSessionFinishError::TooManySharedFolderTargets,
+                    "too_many_write_operations" => UploadSessionFinishError::TooManyWriteOperations,
+                    "concurrent_session_data_not_allowed" => UploadSessionFinishError::ConcurrentSessionDataNotAllowed,
+                    "concurrent_session_not_closed" => UploadSessionFinishError::ConcurrentSessionNotClosed,
+                    "concurrent_session_missing_data" => UploadSessionFinishError::ConcurrentSessionMissingData,
+                    _ => UploadSessionFinishError::Other,
+                };
+                crate::eat_json_fields(&mut map)?;
+                Ok(value)
             }
         }
         const VARIANTS: &[&str] = &["lookup_failed",
@@ -20386,37 +19905,18 @@ impl<'de> ::serde::de::Deserialize<'de> for UploadSessionLookupError {
                     Some(".tag") => map.next_value()?,
                     _ => return Err(de::Error::missing_field(".tag"))
                 };
-                match tag {
-                    "not_found" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(UploadSessionLookupError::NotFound)
-                    }
-                    "incorrect_offset" => Ok(UploadSessionLookupError::IncorrectOffset(UploadSessionOffsetError::internal_deserialize(map)?)),
-                    "closed" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(UploadSessionLookupError::Closed)
-                    }
-                    "not_closed" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(UploadSessionLookupError::NotClosed)
-                    }
-                    "too_large" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(UploadSessionLookupError::TooLarge)
-                    }
-                    "concurrent_session_invalid_offset" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(UploadSessionLookupError::ConcurrentSessionInvalidOffset)
-                    }
-                    "concurrent_session_invalid_data_size" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(UploadSessionLookupError::ConcurrentSessionInvalidDataSize)
-                    }
-                    _ => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(UploadSessionLookupError::Other)
-                    }
-                }
+                let value = match tag {
+                    "not_found" => UploadSessionLookupError::NotFound,
+                    "incorrect_offset" => UploadSessionLookupError::IncorrectOffset(UploadSessionOffsetError::internal_deserialize(&mut map)?),
+                    "closed" => UploadSessionLookupError::Closed,
+                    "not_closed" => UploadSessionLookupError::NotClosed,
+                    "too_large" => UploadSessionLookupError::TooLarge,
+                    "concurrent_session_invalid_offset" => UploadSessionLookupError::ConcurrentSessionInvalidOffset,
+                    "concurrent_session_invalid_data_size" => UploadSessionLookupError::ConcurrentSessionInvalidDataSize,
+                    _ => UploadSessionLookupError::Other,
+                };
+                crate::eat_json_fields(&mut map)?;
+                Ok(value)
             }
         }
         const VARIANTS: &[&str] = &["not_found",
@@ -20725,20 +20225,13 @@ impl<'de> ::serde::de::Deserialize<'de> for UploadSessionStartError {
                     Some(".tag") => map.next_value()?,
                     _ => return Err(de::Error::missing_field(".tag"))
                 };
-                match tag {
-                    "concurrent_session_data_not_allowed" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(UploadSessionStartError::ConcurrentSessionDataNotAllowed)
-                    }
-                    "concurrent_session_close_not_allowed" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(UploadSessionStartError::ConcurrentSessionCloseNotAllowed)
-                    }
-                    _ => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(UploadSessionStartError::Other)
-                    }
-                }
+                let value = match tag {
+                    "concurrent_session_data_not_allowed" => UploadSessionStartError::ConcurrentSessionDataNotAllowed,
+                    "concurrent_session_close_not_allowed" => UploadSessionStartError::ConcurrentSessionCloseNotAllowed,
+                    _ => UploadSessionStartError::Other,
+                };
+                crate::eat_json_fields(&mut map)?;
+                Ok(value)
             }
         }
         const VARIANTS: &[&str] = &["concurrent_session_data_not_allowed",
@@ -20902,20 +20395,13 @@ impl<'de> ::serde::de::Deserialize<'de> for UploadSessionType {
                     Some(".tag") => map.next_value()?,
                     _ => return Err(de::Error::missing_field(".tag"))
                 };
-                match tag {
-                    "sequential" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(UploadSessionType::Sequential)
-                    }
-                    "concurrent" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(UploadSessionType::Concurrent)
-                    }
-                    _ => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(UploadSessionType::Other)
-                    }
-                }
+                let value = match tag {
+                    "sequential" => UploadSessionType::Sequential,
+                    "concurrent" => UploadSessionType::Concurrent,
+                    _ => UploadSessionType::Other,
+                };
+                crate::eat_json_fields(&mut map)?;
+                Ok(value)
             }
         }
         const VARIANTS: &[&str] = &["sequential",
@@ -21222,24 +20708,14 @@ impl<'de> ::serde::de::Deserialize<'de> for WriteConflictError {
                     Some(".tag") => map.next_value()?,
                     _ => return Err(de::Error::missing_field(".tag"))
                 };
-                match tag {
-                    "file" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(WriteConflictError::File)
-                    }
-                    "folder" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(WriteConflictError::Folder)
-                    }
-                    "file_ancestor" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(WriteConflictError::FileAncestor)
-                    }
-                    _ => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(WriteConflictError::Other)
-                    }
-                }
+                let value = match tag {
+                    "file" => WriteConflictError::File,
+                    "folder" => WriteConflictError::Folder,
+                    "file_ancestor" => WriteConflictError::FileAncestor,
+                    _ => WriteConflictError::Other,
+                };
+                crate::eat_json_fields(&mut map)?;
+                Ok(value)
             }
         }
         const VARIANTS: &[&str] = &["file",
@@ -21333,50 +20809,31 @@ impl<'de> ::serde::de::Deserialize<'de> for WriteError {
                     Some(".tag") => map.next_value()?,
                     _ => return Err(de::Error::missing_field(".tag"))
                 };
-                match tag {
+                let value = match tag {
                     "malformed_path" => {
                         match map.next_key()? {
-                            Some("malformed_path") => Ok(WriteError::MalformedPath(map.next_value()?)),
-                            None => Ok(WriteError::MalformedPath(None)),
-                            _ => Err(de::Error::unknown_field(tag, VARIANTS))
+                            Some("malformed_path") => WriteError::MalformedPath(map.next_value()?),
+                            None => WriteError::MalformedPath(None),
+                            _ => return Err(de::Error::unknown_field(tag, VARIANTS))
                         }
                     }
                     "conflict" => {
                         match map.next_key()? {
-                            Some("conflict") => Ok(WriteError::Conflict(map.next_value()?)),
-                            None => Err(de::Error::missing_field("conflict")),
-                            _ => Err(de::Error::unknown_field(tag, VARIANTS))
+                            Some("conflict") => WriteError::Conflict(map.next_value()?),
+                            None => return Err(de::Error::missing_field("conflict")),
+                            _ => return Err(de::Error::unknown_field(tag, VARIANTS))
                         }
                     }
-                    "no_write_permission" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(WriteError::NoWritePermission)
-                    }
-                    "insufficient_space" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(WriteError::InsufficientSpace)
-                    }
-                    "disallowed_name" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(WriteError::DisallowedName)
-                    }
-                    "team_folder" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(WriteError::TeamFolder)
-                    }
-                    "operation_suppressed" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(WriteError::OperationSuppressed)
-                    }
-                    "too_many_write_operations" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(WriteError::TooManyWriteOperations)
-                    }
-                    _ => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(WriteError::Other)
-                    }
-                }
+                    "no_write_permission" => WriteError::NoWritePermission,
+                    "insufficient_space" => WriteError::InsufficientSpace,
+                    "disallowed_name" => WriteError::DisallowedName,
+                    "team_folder" => WriteError::TeamFolder,
+                    "operation_suppressed" => WriteError::OperationSuppressed,
+                    "too_many_write_operations" => WriteError::TooManyWriteOperations,
+                    _ => WriteError::Other,
+                };
+                crate::eat_json_fields(&mut map)?;
+                Ok(value)
             }
         }
         const VARIANTS: &[&str] = &["malformed_path",
@@ -21517,24 +20974,20 @@ impl<'de> ::serde::de::Deserialize<'de> for WriteMode {
                     Some(".tag") => map.next_value()?,
                     _ => return Err(de::Error::missing_field(".tag"))
                 };
-                match tag {
-                    "add" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(WriteMode::Add)
-                    }
-                    "overwrite" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(WriteMode::Overwrite)
-                    }
+                let value = match tag {
+                    "add" => WriteMode::Add,
+                    "overwrite" => WriteMode::Overwrite,
                     "update" => {
                         match map.next_key()? {
-                            Some("update") => Ok(WriteMode::Update(map.next_value()?)),
-                            None => Err(de::Error::missing_field("update")),
-                            _ => Err(de::Error::unknown_field(tag, VARIANTS))
+                            Some("update") => WriteMode::Update(map.next_value()?),
+                            None => return Err(de::Error::missing_field("update")),
+                            _ => return Err(de::Error::unknown_field(tag, VARIANTS))
                         }
                     }
-                    _ => Err(de::Error::unknown_variant(tag, VARIANTS))
-                }
+                    _ => return Err(de::Error::unknown_variant(tag, VARIANTS))
+                };
+                crate::eat_json_fields(&mut map)?;
+                Ok(value)
             }
         }
         const VARIANTS: &[&str] = &["add",

--- a/src/generated/paper.rs
+++ b/src/generated/paper.rs
@@ -776,40 +776,18 @@ impl<'de> ::serde::de::Deserialize<'de> for AddPaperDocUserResult {
                     Some(".tag") => map.next_value()?,
                     _ => return Err(de::Error::missing_field(".tag"))
                 };
-                match tag {
-                    "success" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(AddPaperDocUserResult::Success)
-                    }
-                    "unknown_error" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(AddPaperDocUserResult::UnknownError)
-                    }
-                    "sharing_outside_team_disabled" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(AddPaperDocUserResult::SharingOutsideTeamDisabled)
-                    }
-                    "daily_limit_reached" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(AddPaperDocUserResult::DailyLimitReached)
-                    }
-                    "user_is_owner" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(AddPaperDocUserResult::UserIsOwner)
-                    }
-                    "failed_user_data_retrieval" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(AddPaperDocUserResult::FailedUserDataRetrieval)
-                    }
-                    "permission_already_granted" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(AddPaperDocUserResult::PermissionAlreadyGranted)
-                    }
-                    _ => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(AddPaperDocUserResult::Other)
-                    }
-                }
+                let value = match tag {
+                    "success" => AddPaperDocUserResult::Success,
+                    "unknown_error" => AddPaperDocUserResult::UnknownError,
+                    "sharing_outside_team_disabled" => AddPaperDocUserResult::SharingOutsideTeamDisabled,
+                    "daily_limit_reached" => AddPaperDocUserResult::DailyLimitReached,
+                    "user_is_owner" => AddPaperDocUserResult::UserIsOwner,
+                    "failed_user_data_retrieval" => AddPaperDocUserResult::FailedUserDataRetrieval,
+                    "permission_already_granted" => AddPaperDocUserResult::PermissionAlreadyGranted,
+                    _ => AddPaperDocUserResult::Other,
+                };
+                crate::eat_json_fields(&mut map)?;
+                Ok(value)
             }
         }
         const VARIANTS: &[&str] = &["success",
@@ -1023,20 +1001,13 @@ impl<'de> ::serde::de::Deserialize<'de> for DocLookupError {
                     Some(".tag") => map.next_value()?,
                     _ => return Err(de::Error::missing_field(".tag"))
                 };
-                match tag {
-                    "insufficient_permissions" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(DocLookupError::InsufficientPermissions)
-                    }
-                    "doc_not_found" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(DocLookupError::DocNotFound)
-                    }
-                    _ => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(DocLookupError::Other)
-                    }
-                }
+                let value = match tag {
+                    "insufficient_permissions" => DocLookupError::InsufficientPermissions,
+                    "doc_not_found" => DocLookupError::DocNotFound,
+                    _ => DocLookupError::Other,
+                };
+                crate::eat_json_fields(&mut map)?;
+                Ok(value)
             }
         }
         const VARIANTS: &[&str] = &["insufficient_permissions",
@@ -1108,25 +1079,15 @@ impl<'de> ::serde::de::Deserialize<'de> for DocSubscriptionLevel {
                     Some(".tag") => map.next_value()?,
                     _ => return Err(de::Error::missing_field(".tag"))
                 };
-                match tag {
-                    "default" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(DocSubscriptionLevel::Default)
-                    }
-                    "ignore" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(DocSubscriptionLevel::Ignore)
-                    }
-                    "every" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(DocSubscriptionLevel::Every)
-                    }
-                    "no_email" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(DocSubscriptionLevel::NoEmail)
-                    }
-                    _ => Err(de::Error::unknown_variant(tag, VARIANTS))
-                }
+                let value = match tag {
+                    "default" => DocSubscriptionLevel::Default,
+                    "ignore" => DocSubscriptionLevel::Ignore,
+                    "every" => DocSubscriptionLevel::Every,
+                    "no_email" => DocSubscriptionLevel::NoEmail,
+                    _ => return Err(de::Error::unknown_variant(tag, VARIANTS))
+                };
+                crate::eat_json_fields(&mut map)?;
+                Ok(value)
             }
         }
         const VARIANTS: &[&str] = &["default",
@@ -1198,20 +1159,13 @@ impl<'de> ::serde::de::Deserialize<'de> for ExportFormat {
                     Some(".tag") => map.next_value()?,
                     _ => return Err(de::Error::missing_field(".tag"))
                 };
-                match tag {
-                    "html" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(ExportFormat::Html)
-                    }
-                    "markdown" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(ExportFormat::Markdown)
-                    }
-                    _ => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(ExportFormat::Other)
-                    }
-                }
+                let value = match tag {
+                    "html" => ExportFormat::Html,
+                    "markdown" => ExportFormat::Markdown,
+                    _ => ExportFormat::Other,
+                };
+                crate::eat_json_fields(&mut map)?;
+                Ok(value)
             }
         }
         const VARIANTS: &[&str] = &["html",
@@ -1372,17 +1326,13 @@ impl<'de> ::serde::de::Deserialize<'de> for FolderSharingPolicyType {
                     Some(".tag") => map.next_value()?,
                     _ => return Err(de::Error::missing_field(".tag"))
                 };
-                match tag {
-                    "team" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(FolderSharingPolicyType::Team)
-                    }
-                    "invite_only" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(FolderSharingPolicyType::InviteOnly)
-                    }
-                    _ => Err(de::Error::unknown_variant(tag, VARIANTS))
-                }
+                let value = match tag {
+                    "team" => FolderSharingPolicyType::Team,
+                    "invite_only" => FolderSharingPolicyType::InviteOnly,
+                    _ => return Err(de::Error::unknown_variant(tag, VARIANTS))
+                };
+                crate::eat_json_fields(&mut map)?;
+                Ok(value)
             }
         }
         const VARIANTS: &[&str] = &["team",
@@ -1440,25 +1390,15 @@ impl<'de> ::serde::de::Deserialize<'de> for FolderSubscriptionLevel {
                     Some(".tag") => map.next_value()?,
                     _ => return Err(de::Error::missing_field(".tag"))
                 };
-                match tag {
-                    "none" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(FolderSubscriptionLevel::None)
-                    }
-                    "activity_only" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(FolderSubscriptionLevel::ActivityOnly)
-                    }
-                    "daily_emails" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(FolderSubscriptionLevel::DailyEmails)
-                    }
-                    "weekly_emails" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(FolderSubscriptionLevel::WeeklyEmails)
-                    }
-                    _ => Err(de::Error::unknown_variant(tag, VARIANTS))
-                }
+                let value = match tag {
+                    "none" => FolderSubscriptionLevel::None,
+                    "activity_only" => FolderSubscriptionLevel::ActivityOnly,
+                    "daily_emails" => FolderSubscriptionLevel::DailyEmails,
+                    "weekly_emails" => FolderSubscriptionLevel::WeeklyEmails,
+                    _ => return Err(de::Error::unknown_variant(tag, VARIANTS))
+                };
+                crate::eat_json_fields(&mut map)?;
+                Ok(value)
             }
         }
         const VARIANTS: &[&str] = &["none",
@@ -1639,24 +1579,14 @@ impl<'de> ::serde::de::Deserialize<'de> for ImportFormat {
                     Some(".tag") => map.next_value()?,
                     _ => return Err(de::Error::missing_field(".tag"))
                 };
-                match tag {
-                    "html" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(ImportFormat::Html)
-                    }
-                    "markdown" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(ImportFormat::Markdown)
-                    }
-                    "plain_text" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(ImportFormat::PlainText)
-                    }
-                    _ => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(ImportFormat::Other)
-                    }
-                }
+                let value = match tag {
+                    "html" => ImportFormat::Html,
+                    "markdown" => ImportFormat::Markdown,
+                    "plain_text" => ImportFormat::PlainText,
+                    _ => ImportFormat::Other,
+                };
+                crate::eat_json_fields(&mut map)?;
+                Ok(value)
             }
         }
         const VARIANTS: &[&str] = &["html",
@@ -1825,19 +1755,18 @@ impl<'de> ::serde::de::Deserialize<'de> for ListDocsCursorError {
                     Some(".tag") => map.next_value()?,
                     _ => return Err(de::Error::missing_field(".tag"))
                 };
-                match tag {
+                let value = match tag {
                     "cursor_error" => {
                         match map.next_key()? {
-                            Some("cursor_error") => Ok(ListDocsCursorError::CursorError(map.next_value()?)),
-                            None => Err(de::Error::missing_field("cursor_error")),
-                            _ => Err(de::Error::unknown_field(tag, VARIANTS))
+                            Some("cursor_error") => ListDocsCursorError::CursorError(map.next_value()?),
+                            None => return Err(de::Error::missing_field("cursor_error")),
+                            _ => return Err(de::Error::unknown_field(tag, VARIANTS))
                         }
                     }
-                    _ => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(ListDocsCursorError::Other)
-                    }
-                }
+                    _ => ListDocsCursorError::Other,
+                };
+                crate::eat_json_fields(&mut map)?;
+                Ok(value)
             }
         }
         const VARIANTS: &[&str] = &["cursor_error",
@@ -2140,20 +2069,13 @@ impl<'de> ::serde::de::Deserialize<'de> for ListPaperDocsFilterBy {
                     Some(".tag") => map.next_value()?,
                     _ => return Err(de::Error::missing_field(".tag"))
                 };
-                match tag {
-                    "docs_accessed" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(ListPaperDocsFilterBy::DocsAccessed)
-                    }
-                    "docs_created" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(ListPaperDocsFilterBy::DocsCreated)
-                    }
-                    _ => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(ListPaperDocsFilterBy::Other)
-                    }
-                }
+                let value = match tag {
+                    "docs_accessed" => ListPaperDocsFilterBy::DocsAccessed,
+                    "docs_created" => ListPaperDocsFilterBy::DocsCreated,
+                    _ => ListPaperDocsFilterBy::Other,
+                };
+                crate::eat_json_fields(&mut map)?;
+                Ok(value)
             }
         }
         const VARIANTS: &[&str] = &["docs_accessed",
@@ -2337,24 +2259,14 @@ impl<'de> ::serde::de::Deserialize<'de> for ListPaperDocsSortBy {
                     Some(".tag") => map.next_value()?,
                     _ => return Err(de::Error::missing_field(".tag"))
                 };
-                match tag {
-                    "accessed" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(ListPaperDocsSortBy::Accessed)
-                    }
-                    "modified" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(ListPaperDocsSortBy::Modified)
-                    }
-                    "created" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(ListPaperDocsSortBy::Created)
-                    }
-                    _ => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(ListPaperDocsSortBy::Other)
-                    }
-                }
+                let value = match tag {
+                    "accessed" => ListPaperDocsSortBy::Accessed,
+                    "modified" => ListPaperDocsSortBy::Modified,
+                    "created" => ListPaperDocsSortBy::Created,
+                    _ => ListPaperDocsSortBy::Other,
+                };
+                crate::eat_json_fields(&mut map)?;
+                Ok(value)
             }
         }
         const VARIANTS: &[&str] = &["accessed",
@@ -2420,20 +2332,13 @@ impl<'de> ::serde::de::Deserialize<'de> for ListPaperDocsSortOrder {
                     Some(".tag") => map.next_value()?,
                     _ => return Err(de::Error::missing_field(".tag"))
                 };
-                match tag {
-                    "ascending" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(ListPaperDocsSortOrder::Ascending)
-                    }
-                    "descending" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(ListPaperDocsSortOrder::Descending)
-                    }
-                    _ => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(ListPaperDocsSortOrder::Other)
-                    }
-                }
+                let value = match tag {
+                    "ascending" => ListPaperDocsSortOrder::Ascending,
+                    "descending" => ListPaperDocsSortOrder::Descending,
+                    _ => ListPaperDocsSortOrder::Other,
+                };
+                crate::eat_json_fields(&mut map)?;
+                Ok(value)
             }
         }
         const VARIANTS: &[&str] = &["ascending",
@@ -2496,27 +2401,20 @@ impl<'de> ::serde::de::Deserialize<'de> for ListUsersCursorError {
                     Some(".tag") => map.next_value()?,
                     _ => return Err(de::Error::missing_field(".tag"))
                 };
-                match tag {
-                    "insufficient_permissions" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(ListUsersCursorError::InsufficientPermissions)
-                    }
-                    "doc_not_found" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(ListUsersCursorError::DocNotFound)
-                    }
+                let value = match tag {
+                    "insufficient_permissions" => ListUsersCursorError::InsufficientPermissions,
+                    "doc_not_found" => ListUsersCursorError::DocNotFound,
                     "cursor_error" => {
                         match map.next_key()? {
-                            Some("cursor_error") => Ok(ListUsersCursorError::CursorError(map.next_value()?)),
-                            None => Err(de::Error::missing_field("cursor_error")),
-                            _ => Err(de::Error::unknown_field(tag, VARIANTS))
+                            Some("cursor_error") => ListUsersCursorError::CursorError(map.next_value()?),
+                            None => return Err(de::Error::missing_field("cursor_error")),
+                            _ => return Err(de::Error::unknown_field(tag, VARIANTS))
                         }
                     }
-                    _ => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(ListUsersCursorError::Other)
-                    }
-                }
+                    _ => ListUsersCursorError::Other,
+                };
+                crate::eat_json_fields(&mut map)?;
+                Ok(value)
             }
         }
         const VARIANTS: &[&str] = &["insufficient_permissions",
@@ -3341,16 +3239,12 @@ impl<'de> ::serde::de::Deserialize<'de> for PaperApiBaseError {
                     Some(".tag") => map.next_value()?,
                     _ => return Err(de::Error::missing_field(".tag"))
                 };
-                match tag {
-                    "insufficient_permissions" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(PaperApiBaseError::InsufficientPermissions)
-                    }
-                    _ => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(PaperApiBaseError::Other)
-                    }
-                }
+                let value = match tag {
+                    "insufficient_permissions" => PaperApiBaseError::InsufficientPermissions,
+                    _ => PaperApiBaseError::Other,
+                };
+                crate::eat_json_fields(&mut map)?;
+                Ok(value)
             }
         }
         const VARIANTS: &[&str] = &["insufficient_permissions",
@@ -3416,28 +3310,15 @@ impl<'de> ::serde::de::Deserialize<'de> for PaperApiCursorError {
                     Some(".tag") => map.next_value()?,
                     _ => return Err(de::Error::missing_field(".tag"))
                 };
-                match tag {
-                    "expired_cursor" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(PaperApiCursorError::ExpiredCursor)
-                    }
-                    "invalid_cursor" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(PaperApiCursorError::InvalidCursor)
-                    }
-                    "wrong_user_in_cursor" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(PaperApiCursorError::WrongUserInCursor)
-                    }
-                    "reset" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(PaperApiCursorError::Reset)
-                    }
-                    _ => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(PaperApiCursorError::Other)
-                    }
-                }
+                let value = match tag {
+                    "expired_cursor" => PaperApiCursorError::ExpiredCursor,
+                    "invalid_cursor" => PaperApiCursorError::InvalidCursor,
+                    "wrong_user_in_cursor" => PaperApiCursorError::WrongUserInCursor,
+                    "reset" => PaperApiCursorError::Reset,
+                    _ => PaperApiCursorError::Other,
+                };
+                crate::eat_json_fields(&mut map)?;
+                Ok(value)
             }
         }
         const VARIANTS: &[&str] = &["expired_cursor",
@@ -3644,32 +3525,16 @@ impl<'de> ::serde::de::Deserialize<'de> for PaperDocCreateError {
                     Some(".tag") => map.next_value()?,
                     _ => return Err(de::Error::missing_field(".tag"))
                 };
-                match tag {
-                    "insufficient_permissions" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(PaperDocCreateError::InsufficientPermissions)
-                    }
-                    "content_malformed" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(PaperDocCreateError::ContentMalformed)
-                    }
-                    "folder_not_found" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(PaperDocCreateError::FolderNotFound)
-                    }
-                    "doc_length_exceeded" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(PaperDocCreateError::DocLengthExceeded)
-                    }
-                    "image_size_exceeded" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(PaperDocCreateError::ImageSizeExceeded)
-                    }
-                    _ => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(PaperDocCreateError::Other)
-                    }
-                }
+                let value = match tag {
+                    "insufficient_permissions" => PaperDocCreateError::InsufficientPermissions,
+                    "content_malformed" => PaperDocCreateError::ContentMalformed,
+                    "folder_not_found" => PaperDocCreateError::FolderNotFound,
+                    "doc_length_exceeded" => PaperDocCreateError::DocLengthExceeded,
+                    "image_size_exceeded" => PaperDocCreateError::ImageSizeExceeded,
+                    _ => PaperDocCreateError::Other,
+                };
+                crate::eat_json_fields(&mut map)?;
+                Ok(value)
             }
         }
         const VARIANTS: &[&str] = &["insufficient_permissions",
@@ -4112,20 +3977,13 @@ impl<'de> ::serde::de::Deserialize<'de> for PaperDocPermissionLevel {
                     Some(".tag") => map.next_value()?,
                     _ => return Err(de::Error::missing_field(".tag"))
                 };
-                match tag {
-                    "edit" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(PaperDocPermissionLevel::Edit)
-                    }
-                    "view_and_comment" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(PaperDocPermissionLevel::ViewAndComment)
-                    }
-                    _ => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(PaperDocPermissionLevel::Other)
-                    }
-                }
+                let value = match tag {
+                    "edit" => PaperDocPermissionLevel::Edit,
+                    "view_and_comment" => PaperDocPermissionLevel::ViewAndComment,
+                    _ => PaperDocPermissionLevel::Other,
+                };
+                crate::eat_json_fields(&mut map)?;
+                Ok(value)
             }
         }
         const VARIANTS: &[&str] = &["edit",
@@ -4438,44 +4296,19 @@ impl<'de> ::serde::de::Deserialize<'de> for PaperDocUpdateError {
                     Some(".tag") => map.next_value()?,
                     _ => return Err(de::Error::missing_field(".tag"))
                 };
-                match tag {
-                    "insufficient_permissions" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(PaperDocUpdateError::InsufficientPermissions)
-                    }
-                    "doc_not_found" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(PaperDocUpdateError::DocNotFound)
-                    }
-                    "content_malformed" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(PaperDocUpdateError::ContentMalformed)
-                    }
-                    "revision_mismatch" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(PaperDocUpdateError::RevisionMismatch)
-                    }
-                    "doc_length_exceeded" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(PaperDocUpdateError::DocLengthExceeded)
-                    }
-                    "image_size_exceeded" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(PaperDocUpdateError::ImageSizeExceeded)
-                    }
-                    "doc_archived" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(PaperDocUpdateError::DocArchived)
-                    }
-                    "doc_deleted" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(PaperDocUpdateError::DocDeleted)
-                    }
-                    _ => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(PaperDocUpdateError::Other)
-                    }
-                }
+                let value = match tag {
+                    "insufficient_permissions" => PaperDocUpdateError::InsufficientPermissions,
+                    "doc_not_found" => PaperDocUpdateError::DocNotFound,
+                    "content_malformed" => PaperDocUpdateError::ContentMalformed,
+                    "revision_mismatch" => PaperDocUpdateError::RevisionMismatch,
+                    "doc_length_exceeded" => PaperDocUpdateError::DocLengthExceeded,
+                    "image_size_exceeded" => PaperDocUpdateError::ImageSizeExceeded,
+                    "doc_archived" => PaperDocUpdateError::DocArchived,
+                    "doc_deleted" => PaperDocUpdateError::DocDeleted,
+                    _ => PaperDocUpdateError::Other,
+                };
+                crate::eat_json_fields(&mut map)?;
+                Ok(value)
             }
         }
         const VARIANTS: &[&str] = &["insufficient_permissions",
@@ -4596,24 +4429,14 @@ impl<'de> ::serde::de::Deserialize<'de> for PaperDocUpdatePolicy {
                     Some(".tag") => map.next_value()?,
                     _ => return Err(de::Error::missing_field(".tag"))
                 };
-                match tag {
-                    "append" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(PaperDocUpdatePolicy::Append)
-                    }
-                    "prepend" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(PaperDocUpdatePolicy::Prepend)
-                    }
-                    "overwrite_all" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(PaperDocUpdatePolicy::OverwriteAll)
-                    }
-                    _ => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(PaperDocUpdatePolicy::Other)
-                    }
-                }
+                let value = match tag {
+                    "append" => PaperDocUpdatePolicy::Append,
+                    "prepend" => PaperDocUpdatePolicy::Prepend,
+                    "overwrite_all" => PaperDocUpdatePolicy::OverwriteAll,
+                    _ => PaperDocUpdatePolicy::Other,
+                };
+                crate::eat_json_fields(&mut map)?;
+                Ok(value)
             }
         }
         const VARIANTS: &[&str] = &["append",
@@ -4815,24 +4638,14 @@ impl<'de> ::serde::de::Deserialize<'de> for PaperFolderCreateError {
                     Some(".tag") => map.next_value()?,
                     _ => return Err(de::Error::missing_field(".tag"))
                 };
-                match tag {
-                    "insufficient_permissions" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(PaperFolderCreateError::InsufficientPermissions)
-                    }
-                    "folder_not_found" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(PaperFolderCreateError::FolderNotFound)
-                    }
-                    "invalid_folder_id" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(PaperFolderCreateError::InvalidFolderId)
-                    }
-                    _ => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(PaperFolderCreateError::Other)
-                    }
-                }
+                let value = match tag {
+                    "insufficient_permissions" => PaperFolderCreateError::InsufficientPermissions,
+                    "folder_not_found" => PaperFolderCreateError::FolderNotFound,
+                    "invalid_folder_id" => PaperFolderCreateError::InvalidFolderId,
+                    _ => PaperFolderCreateError::Other,
+                };
+                crate::eat_json_fields(&mut map)?;
+                Ok(value)
             }
         }
         const VARIANTS: &[&str] = &["insufficient_permissions",
@@ -5300,25 +5113,15 @@ impl<'de> ::serde::de::Deserialize<'de> for SharingPublicPolicyType {
                     Some(".tag") => map.next_value()?,
                     _ => return Err(de::Error::missing_field(".tag"))
                 };
-                match tag {
-                    "people_with_link_can_edit" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(SharingPublicPolicyType::PeopleWithLinkCanEdit)
-                    }
-                    "people_with_link_can_view_and_comment" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(SharingPublicPolicyType::PeopleWithLinkCanViewAndComment)
-                    }
-                    "invite_only" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(SharingPublicPolicyType::InviteOnly)
-                    }
-                    "disabled" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(SharingPublicPolicyType::Disabled)
-                    }
-                    _ => Err(de::Error::unknown_variant(tag, VARIANTS))
-                }
+                let value = match tag {
+                    "people_with_link_can_edit" => SharingPublicPolicyType::PeopleWithLinkCanEdit,
+                    "people_with_link_can_view_and_comment" => SharingPublicPolicyType::PeopleWithLinkCanViewAndComment,
+                    "invite_only" => SharingPublicPolicyType::InviteOnly,
+                    "disabled" => SharingPublicPolicyType::Disabled,
+                    _ => return Err(de::Error::unknown_variant(tag, VARIANTS))
+                };
+                crate::eat_json_fields(&mut map)?;
+                Ok(value)
             }
         }
         const VARIANTS: &[&str] = &["people_with_link_can_edit",
@@ -5388,21 +5191,14 @@ impl<'de> ::serde::de::Deserialize<'de> for SharingTeamPolicyType {
                     Some(".tag") => map.next_value()?,
                     _ => return Err(de::Error::missing_field(".tag"))
                 };
-                match tag {
-                    "people_with_link_can_edit" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(SharingTeamPolicyType::PeopleWithLinkCanEdit)
-                    }
-                    "people_with_link_can_view_and_comment" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(SharingTeamPolicyType::PeopleWithLinkCanViewAndComment)
-                    }
-                    "invite_only" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(SharingTeamPolicyType::InviteOnly)
-                    }
-                    _ => Err(de::Error::unknown_variant(tag, VARIANTS))
-                }
+                let value = match tag {
+                    "people_with_link_can_edit" => SharingTeamPolicyType::PeopleWithLinkCanEdit,
+                    "people_with_link_can_view_and_comment" => SharingTeamPolicyType::PeopleWithLinkCanViewAndComment,
+                    "invite_only" => SharingTeamPolicyType::InviteOnly,
+                    _ => return Err(de::Error::unknown_variant(tag, VARIANTS))
+                };
+                crate::eat_json_fields(&mut map)?;
+                Ok(value)
             }
         }
         const VARIANTS: &[&str] = &["people_with_link_can_edit",
@@ -5570,20 +5366,13 @@ impl<'de> ::serde::de::Deserialize<'de> for UserOnPaperDocFilter {
                     Some(".tag") => map.next_value()?,
                     _ => return Err(de::Error::missing_field(".tag"))
                 };
-                match tag {
-                    "visited" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(UserOnPaperDocFilter::Visited)
-                    }
-                    "shared" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(UserOnPaperDocFilter::Shared)
-                    }
-                    _ => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(UserOnPaperDocFilter::Other)
-                    }
-                }
+                let value = match tag {
+                    "visited" => UserOnPaperDocFilter::Visited,
+                    "shared" => UserOnPaperDocFilter::Shared,
+                    _ => UserOnPaperDocFilter::Other,
+                };
+                crate::eat_json_fields(&mut map)?;
+                Ok(value)
             }
         }
         const VARIANTS: &[&str] = &["visited",

--- a/src/generated/seen_state.rs
+++ b/src/generated/seen_state.rs
@@ -46,40 +46,18 @@ impl<'de> ::serde::de::Deserialize<'de> for PlatformType {
                     Some(".tag") => map.next_value()?,
                     _ => return Err(de::Error::missing_field(".tag"))
                 };
-                match tag {
-                    "web" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(PlatformType::Web)
-                    }
-                    "desktop" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(PlatformType::Desktop)
-                    }
-                    "mobile_ios" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(PlatformType::MobileIos)
-                    }
-                    "mobile_android" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(PlatformType::MobileAndroid)
-                    }
-                    "api" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(PlatformType::Api)
-                    }
-                    "unknown" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(PlatformType::Unknown)
-                    }
-                    "mobile" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(PlatformType::Mobile)
-                    }
-                    _ => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(PlatformType::Other)
-                    }
-                }
+                let value = match tag {
+                    "web" => PlatformType::Web,
+                    "desktop" => PlatformType::Desktop,
+                    "mobile_ios" => PlatformType::MobileIos,
+                    "mobile_android" => PlatformType::MobileAndroid,
+                    "api" => PlatformType::Api,
+                    "unknown" => PlatformType::Unknown,
+                    "mobile" => PlatformType::Mobile,
+                    _ => PlatformType::Other,
+                };
+                crate::eat_json_fields(&mut map)?;
+                Ok(value)
             }
         }
         const VARIANTS: &[&str] = &["web",

--- a/src/generated/sharing.rs
+++ b/src/generated/sharing.rs
@@ -719,20 +719,13 @@ impl<'de> ::serde::de::Deserialize<'de> for AccessInheritance {
                     Some(".tag") => map.next_value()?,
                     _ => return Err(de::Error::missing_field(".tag"))
                 };
-                match tag {
-                    "inherit" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(AccessInheritance::Inherit)
-                    }
-                    "no_inherit" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(AccessInheritance::NoInherit)
-                    }
-                    _ => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(AccessInheritance::Other)
-                    }
-                }
+                let value = match tag {
+                    "inherit" => AccessInheritance::Inherit,
+                    "no_inherit" => AccessInheritance::NoInherit,
+                    _ => AccessInheritance::Other,
+                };
+                crate::eat_json_fields(&mut map)?;
+                Ok(value)
             }
         }
         const VARIANTS: &[&str] = &["inherit",
@@ -798,28 +791,15 @@ impl<'de> ::serde::de::Deserialize<'de> for AccessLevel {
                     Some(".tag") => map.next_value()?,
                     _ => return Err(de::Error::missing_field(".tag"))
                 };
-                match tag {
-                    "owner" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(AccessLevel::Owner)
-                    }
-                    "editor" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(AccessLevel::Editor)
-                    }
-                    "viewer" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(AccessLevel::Viewer)
-                    }
-                    "viewer_no_comment" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(AccessLevel::ViewerNoComment)
-                    }
-                    _ => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(AccessLevel::Other)
-                    }
-                }
+                let value = match tag {
+                    "owner" => AccessLevel::Owner,
+                    "editor" => AccessLevel::Editor,
+                    "viewer" => AccessLevel::Viewer,
+                    "viewer_no_comment" => AccessLevel::ViewerNoComment,
+                    _ => AccessLevel::Other,
+                };
+                crate::eat_json_fields(&mut map)?;
+                Ok(value)
             }
         }
         const VARIANTS: &[&str] = &["owner",
@@ -894,20 +874,13 @@ impl<'de> ::serde::de::Deserialize<'de> for AclUpdatePolicy {
                     Some(".tag") => map.next_value()?,
                     _ => return Err(de::Error::missing_field(".tag"))
                 };
-                match tag {
-                    "owner" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(AclUpdatePolicy::Owner)
-                    }
-                    "editors" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(AclUpdatePolicy::Editors)
-                    }
-                    _ => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(AclUpdatePolicy::Other)
-                    }
-                }
+                let value = match tag {
+                    "owner" => AclUpdatePolicy::Owner,
+                    "editors" => AclUpdatePolicy::Editors,
+                    _ => AclUpdatePolicy::Other,
+                };
+                crate::eat_json_fields(&mut map)?;
+                Ok(value)
             }
         }
         const VARIANTS: &[&str] = &["owner",
@@ -1146,34 +1119,27 @@ impl<'de> ::serde::de::Deserialize<'de> for AddFileMemberError {
                     Some(".tag") => map.next_value()?,
                     _ => return Err(de::Error::missing_field(".tag"))
                 };
-                match tag {
+                let value = match tag {
                     "user_error" => {
                         match map.next_key()? {
-                            Some("user_error") => Ok(AddFileMemberError::UserError(map.next_value()?)),
-                            None => Err(de::Error::missing_field("user_error")),
-                            _ => Err(de::Error::unknown_field(tag, VARIANTS))
+                            Some("user_error") => AddFileMemberError::UserError(map.next_value()?),
+                            None => return Err(de::Error::missing_field("user_error")),
+                            _ => return Err(de::Error::unknown_field(tag, VARIANTS))
                         }
                     }
                     "access_error" => {
                         match map.next_key()? {
-                            Some("access_error") => Ok(AddFileMemberError::AccessError(map.next_value()?)),
-                            None => Err(de::Error::missing_field("access_error")),
-                            _ => Err(de::Error::unknown_field(tag, VARIANTS))
+                            Some("access_error") => AddFileMemberError::AccessError(map.next_value()?),
+                            None => return Err(de::Error::missing_field("access_error")),
+                            _ => return Err(de::Error::unknown_field(tag, VARIANTS))
                         }
                     }
-                    "rate_limit" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(AddFileMemberError::RateLimit)
-                    }
-                    "invalid_comment" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(AddFileMemberError::InvalidComment)
-                    }
-                    _ => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(AddFileMemberError::Other)
-                    }
-                }
+                    "rate_limit" => AddFileMemberError::RateLimit,
+                    "invalid_comment" => AddFileMemberError::InvalidComment,
+                    _ => AddFileMemberError::Other,
+                };
+                crate::eat_json_fields(&mut map)?;
+                Ok(value)
             }
         }
         const VARIANTS: &[&str] = &["user_error",
@@ -1436,76 +1402,48 @@ impl<'de> ::serde::de::Deserialize<'de> for AddFolderMemberError {
                     Some(".tag") => map.next_value()?,
                     _ => return Err(de::Error::missing_field(".tag"))
                 };
-                match tag {
+                let value = match tag {
                     "access_error" => {
                         match map.next_key()? {
-                            Some("access_error") => Ok(AddFolderMemberError::AccessError(map.next_value()?)),
-                            None => Err(de::Error::missing_field("access_error")),
-                            _ => Err(de::Error::unknown_field(tag, VARIANTS))
+                            Some("access_error") => AddFolderMemberError::AccessError(map.next_value()?),
+                            None => return Err(de::Error::missing_field("access_error")),
+                            _ => return Err(de::Error::unknown_field(tag, VARIANTS))
                         }
                     }
-                    "email_unverified" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(AddFolderMemberError::EmailUnverified)
-                    }
-                    "banned_member" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(AddFolderMemberError::BannedMember)
-                    }
+                    "email_unverified" => AddFolderMemberError::EmailUnverified,
+                    "banned_member" => AddFolderMemberError::BannedMember,
                     "bad_member" => {
                         match map.next_key()? {
-                            Some("bad_member") => Ok(AddFolderMemberError::BadMember(map.next_value()?)),
-                            None => Err(de::Error::missing_field("bad_member")),
-                            _ => Err(de::Error::unknown_field(tag, VARIANTS))
+                            Some("bad_member") => AddFolderMemberError::BadMember(map.next_value()?),
+                            None => return Err(de::Error::missing_field("bad_member")),
+                            _ => return Err(de::Error::unknown_field(tag, VARIANTS))
                         }
                     }
-                    "cant_share_outside_team" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(AddFolderMemberError::CantShareOutsideTeam)
-                    }
+                    "cant_share_outside_team" => AddFolderMemberError::CantShareOutsideTeam,
                     "too_many_members" => {
                         match map.next_key()? {
-                            Some("too_many_members") => Ok(AddFolderMemberError::TooManyMembers(map.next_value()?)),
-                            None => Err(de::Error::missing_field("too_many_members")),
-                            _ => Err(de::Error::unknown_field(tag, VARIANTS))
+                            Some("too_many_members") => AddFolderMemberError::TooManyMembers(map.next_value()?),
+                            None => return Err(de::Error::missing_field("too_many_members")),
+                            _ => return Err(de::Error::unknown_field(tag, VARIANTS))
                         }
                     }
                     "too_many_pending_invites" => {
                         match map.next_key()? {
-                            Some("too_many_pending_invites") => Ok(AddFolderMemberError::TooManyPendingInvites(map.next_value()?)),
-                            None => Err(de::Error::missing_field("too_many_pending_invites")),
-                            _ => Err(de::Error::unknown_field(tag, VARIANTS))
+                            Some("too_many_pending_invites") => AddFolderMemberError::TooManyPendingInvites(map.next_value()?),
+                            None => return Err(de::Error::missing_field("too_many_pending_invites")),
+                            _ => return Err(de::Error::unknown_field(tag, VARIANTS))
                         }
                     }
-                    "rate_limit" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(AddFolderMemberError::RateLimit)
-                    }
-                    "too_many_invitees" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(AddFolderMemberError::TooManyInvitees)
-                    }
-                    "insufficient_plan" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(AddFolderMemberError::InsufficientPlan)
-                    }
-                    "team_folder" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(AddFolderMemberError::TeamFolder)
-                    }
-                    "no_permission" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(AddFolderMemberError::NoPermission)
-                    }
-                    "invalid_shared_folder" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(AddFolderMemberError::InvalidSharedFolder)
-                    }
-                    _ => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(AddFolderMemberError::Other)
-                    }
-                }
+                    "rate_limit" => AddFolderMemberError::RateLimit,
+                    "too_many_invitees" => AddFolderMemberError::TooManyInvitees,
+                    "insufficient_plan" => AddFolderMemberError::InsufficientPlan,
+                    "team_folder" => AddFolderMemberError::TeamFolder,
+                    "no_permission" => AddFolderMemberError::NoPermission,
+                    "invalid_shared_folder" => AddFolderMemberError::InvalidSharedFolder,
+                    _ => AddFolderMemberError::Other,
+                };
+                crate::eat_json_fields(&mut map)?;
+                Ok(value)
             }
         }
         const VARIANTS: &[&str] = &["access_error",
@@ -1795,45 +1733,35 @@ impl<'de> ::serde::de::Deserialize<'de> for AddMemberSelectorError {
                     Some(".tag") => map.next_value()?,
                     _ => return Err(de::Error::missing_field(".tag"))
                 };
-                match tag {
-                    "automatic_group" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(AddMemberSelectorError::AutomaticGroup)
-                    }
+                let value = match tag {
+                    "automatic_group" => AddMemberSelectorError::AutomaticGroup,
                     "invalid_dropbox_id" => {
                         match map.next_key()? {
-                            Some("invalid_dropbox_id") => Ok(AddMemberSelectorError::InvalidDropboxId(map.next_value()?)),
-                            None => Err(de::Error::missing_field("invalid_dropbox_id")),
-                            _ => Err(de::Error::unknown_field(tag, VARIANTS))
+                            Some("invalid_dropbox_id") => AddMemberSelectorError::InvalidDropboxId(map.next_value()?),
+                            None => return Err(de::Error::missing_field("invalid_dropbox_id")),
+                            _ => return Err(de::Error::unknown_field(tag, VARIANTS))
                         }
                     }
                     "invalid_email" => {
                         match map.next_key()? {
-                            Some("invalid_email") => Ok(AddMemberSelectorError::InvalidEmail(map.next_value()?)),
-                            None => Err(de::Error::missing_field("invalid_email")),
-                            _ => Err(de::Error::unknown_field(tag, VARIANTS))
+                            Some("invalid_email") => AddMemberSelectorError::InvalidEmail(map.next_value()?),
+                            None => return Err(de::Error::missing_field("invalid_email")),
+                            _ => return Err(de::Error::unknown_field(tag, VARIANTS))
                         }
                     }
                     "unverified_dropbox_id" => {
                         match map.next_key()? {
-                            Some("unverified_dropbox_id") => Ok(AddMemberSelectorError::UnverifiedDropboxId(map.next_value()?)),
-                            None => Err(de::Error::missing_field("unverified_dropbox_id")),
-                            _ => Err(de::Error::unknown_field(tag, VARIANTS))
+                            Some("unverified_dropbox_id") => AddMemberSelectorError::UnverifiedDropboxId(map.next_value()?),
+                            None => return Err(de::Error::missing_field("unverified_dropbox_id")),
+                            _ => return Err(de::Error::unknown_field(tag, VARIANTS))
                         }
                     }
-                    "group_deleted" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(AddMemberSelectorError::GroupDeleted)
-                    }
-                    "group_not_on_team" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(AddMemberSelectorError::GroupNotOnTeam)
-                    }
-                    _ => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(AddMemberSelectorError::Other)
-                    }
-                }
+                    "group_deleted" => AddMemberSelectorError::GroupDeleted,
+                    "group_not_on_team" => AddMemberSelectorError::GroupNotOnTeam,
+                    _ => AddMemberSelectorError::Other,
+                };
+                crate::eat_json_fields(&mut map)?;
+                Ok(value)
             }
         }
         const VARIANTS: &[&str] = &["automatic_group",
@@ -2623,19 +2551,18 @@ impl<'de> ::serde::de::Deserialize<'de> for CreateSharedLinkError {
                     Some(".tag") => map.next_value()?,
                     _ => return Err(de::Error::missing_field(".tag"))
                 };
-                match tag {
+                let value = match tag {
                     "path" => {
                         match map.next_key()? {
-                            Some("path") => Ok(CreateSharedLinkError::Path(map.next_value()?)),
-                            None => Err(de::Error::missing_field("path")),
-                            _ => Err(de::Error::unknown_field(tag, VARIANTS))
+                            Some("path") => CreateSharedLinkError::Path(map.next_value()?),
+                            None => return Err(de::Error::missing_field("path")),
+                            _ => return Err(de::Error::unknown_field(tag, VARIANTS))
                         }
                     }
-                    _ => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(CreateSharedLinkError::Other)
-                    }
-                }
+                    _ => CreateSharedLinkError::Other,
+                };
+                crate::eat_json_fields(&mut map)?;
+                Ok(value)
             }
         }
         const VARIANTS: &[&str] = &["path",
@@ -2818,38 +2745,34 @@ impl<'de> ::serde::de::Deserialize<'de> for CreateSharedLinkWithSettingsError {
                     Some(".tag") => map.next_value()?,
                     _ => return Err(de::Error::missing_field(".tag"))
                 };
-                match tag {
+                let value = match tag {
                     "path" => {
                         match map.next_key()? {
-                            Some("path") => Ok(CreateSharedLinkWithSettingsError::Path(map.next_value()?)),
-                            None => Err(de::Error::missing_field("path")),
-                            _ => Err(de::Error::unknown_field(tag, VARIANTS))
+                            Some("path") => CreateSharedLinkWithSettingsError::Path(map.next_value()?),
+                            None => return Err(de::Error::missing_field("path")),
+                            _ => return Err(de::Error::unknown_field(tag, VARIANTS))
                         }
                     }
-                    "email_not_verified" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(CreateSharedLinkWithSettingsError::EmailNotVerified)
-                    }
+                    "email_not_verified" => CreateSharedLinkWithSettingsError::EmailNotVerified,
                     "shared_link_already_exists" => {
                         match map.next_key()? {
-                            Some("shared_link_already_exists") => Ok(CreateSharedLinkWithSettingsError::SharedLinkAlreadyExists(map.next_value()?)),
-                            None => Ok(CreateSharedLinkWithSettingsError::SharedLinkAlreadyExists(None)),
-                            _ => Err(de::Error::unknown_field(tag, VARIANTS))
+                            Some("shared_link_already_exists") => CreateSharedLinkWithSettingsError::SharedLinkAlreadyExists(map.next_value()?),
+                            None => CreateSharedLinkWithSettingsError::SharedLinkAlreadyExists(None),
+                            _ => return Err(de::Error::unknown_field(tag, VARIANTS))
                         }
                     }
                     "settings_error" => {
                         match map.next_key()? {
-                            Some("settings_error") => Ok(CreateSharedLinkWithSettingsError::SettingsError(map.next_value()?)),
-                            None => Err(de::Error::missing_field("settings_error")),
-                            _ => Err(de::Error::unknown_field(tag, VARIANTS))
+                            Some("settings_error") => CreateSharedLinkWithSettingsError::SettingsError(map.next_value()?),
+                            None => return Err(de::Error::missing_field("settings_error")),
+                            _ => return Err(de::Error::unknown_field(tag, VARIANTS))
                         }
                     }
-                    "access_denied" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(CreateSharedLinkWithSettingsError::AccessDenied)
-                    }
-                    _ => Err(de::Error::unknown_variant(tag, VARIANTS))
-                }
+                    "access_denied" => CreateSharedLinkWithSettingsError::AccessDenied,
+                    _ => return Err(de::Error::unknown_variant(tag, VARIANTS))
+                };
+                crate::eat_json_fields(&mut map)?;
+                Ok(value)
             }
         }
         const VARIANTS: &[&str] = &["path",
@@ -3171,60 +3094,23 @@ impl<'de> ::serde::de::Deserialize<'de> for FileAction {
                     Some(".tag") => map.next_value()?,
                     _ => return Err(de::Error::missing_field(".tag"))
                 };
-                match tag {
-                    "disable_viewer_info" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(FileAction::DisableViewerInfo)
-                    }
-                    "edit_contents" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(FileAction::EditContents)
-                    }
-                    "enable_viewer_info" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(FileAction::EnableViewerInfo)
-                    }
-                    "invite_viewer" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(FileAction::InviteViewer)
-                    }
-                    "invite_viewer_no_comment" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(FileAction::InviteViewerNoComment)
-                    }
-                    "invite_editor" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(FileAction::InviteEditor)
-                    }
-                    "unshare" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(FileAction::Unshare)
-                    }
-                    "relinquish_membership" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(FileAction::RelinquishMembership)
-                    }
-                    "share_link" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(FileAction::ShareLink)
-                    }
-                    "create_link" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(FileAction::CreateLink)
-                    }
-                    "create_view_link" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(FileAction::CreateViewLink)
-                    }
-                    "create_edit_link" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(FileAction::CreateEditLink)
-                    }
-                    _ => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(FileAction::Other)
-                    }
-                }
+                let value = match tag {
+                    "disable_viewer_info" => FileAction::DisableViewerInfo,
+                    "edit_contents" => FileAction::EditContents,
+                    "enable_viewer_info" => FileAction::EnableViewerInfo,
+                    "invite_viewer" => FileAction::InviteViewer,
+                    "invite_viewer_no_comment" => FileAction::InviteViewerNoComment,
+                    "invite_editor" => FileAction::InviteEditor,
+                    "unshare" => FileAction::Unshare,
+                    "relinquish_membership" => FileAction::RelinquishMembership,
+                    "share_link" => FileAction::ShareLink,
+                    "create_link" => FileAction::CreateLink,
+                    "create_view_link" => FileAction::CreateViewLink,
+                    "create_edit_link" => FileAction::CreateEditLink,
+                    _ => FileAction::Other,
+                };
+                crate::eat_json_fields(&mut map)?;
+                Ok(value)
             }
         }
         const VARIANTS: &[&str] = &["disable_viewer_info",
@@ -3355,33 +3241,32 @@ impl<'de> ::serde::de::Deserialize<'de> for FileErrorResult {
                     Some(".tag") => map.next_value()?,
                     _ => return Err(de::Error::missing_field(".tag"))
                 };
-                match tag {
+                let value = match tag {
                     "file_not_found_error" => {
                         match map.next_key()? {
-                            Some("file_not_found_error") => Ok(FileErrorResult::FileNotFoundError(map.next_value()?)),
-                            None => Err(de::Error::missing_field("file_not_found_error")),
-                            _ => Err(de::Error::unknown_field(tag, VARIANTS))
+                            Some("file_not_found_error") => FileErrorResult::FileNotFoundError(map.next_value()?),
+                            None => return Err(de::Error::missing_field("file_not_found_error")),
+                            _ => return Err(de::Error::unknown_field(tag, VARIANTS))
                         }
                     }
                     "invalid_file_action_error" => {
                         match map.next_key()? {
-                            Some("invalid_file_action_error") => Ok(FileErrorResult::InvalidFileActionError(map.next_value()?)),
-                            None => Err(de::Error::missing_field("invalid_file_action_error")),
-                            _ => Err(de::Error::unknown_field(tag, VARIANTS))
+                            Some("invalid_file_action_error") => FileErrorResult::InvalidFileActionError(map.next_value()?),
+                            None => return Err(de::Error::missing_field("invalid_file_action_error")),
+                            _ => return Err(de::Error::unknown_field(tag, VARIANTS))
                         }
                     }
                     "permission_denied_error" => {
                         match map.next_key()? {
-                            Some("permission_denied_error") => Ok(FileErrorResult::PermissionDeniedError(map.next_value()?)),
-                            None => Err(de::Error::missing_field("permission_denied_error")),
-                            _ => Err(de::Error::unknown_field(tag, VARIANTS))
+                            Some("permission_denied_error") => FileErrorResult::PermissionDeniedError(map.next_value()?),
+                            None => return Err(de::Error::missing_field("permission_denied_error")),
+                            _ => return Err(de::Error::unknown_field(tag, VARIANTS))
                         }
                     }
-                    _ => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(FileErrorResult::Other)
-                    }
-                }
+                    _ => FileErrorResult::Other,
+                };
+                crate::eat_json_fields(&mut map)?;
+                Ok(value)
             }
         }
         const VARIANTS: &[&str] = &["file_not_found_error",
@@ -3731,28 +3616,21 @@ impl<'de> ::serde::de::Deserialize<'de> for FileMemberActionError {
                     Some(".tag") => map.next_value()?,
                     _ => return Err(de::Error::missing_field(".tag"))
                 };
-                match tag {
-                    "invalid_member" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(FileMemberActionError::InvalidMember)
-                    }
-                    "no_permission" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(FileMemberActionError::NoPermission)
-                    }
+                let value = match tag {
+                    "invalid_member" => FileMemberActionError::InvalidMember,
+                    "no_permission" => FileMemberActionError::NoPermission,
                     "access_error" => {
                         match map.next_key()? {
-                            Some("access_error") => Ok(FileMemberActionError::AccessError(map.next_value()?)),
-                            None => Err(de::Error::missing_field("access_error")),
-                            _ => Err(de::Error::unknown_field(tag, VARIANTS))
+                            Some("access_error") => FileMemberActionError::AccessError(map.next_value()?),
+                            None => return Err(de::Error::missing_field("access_error")),
+                            _ => return Err(de::Error::unknown_field(tag, VARIANTS))
                         }
                     }
-                    "no_explicit_access" => Ok(FileMemberActionError::NoExplicitAccess(MemberAccessLevelResult::internal_deserialize(map)?)),
-                    _ => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(FileMemberActionError::Other)
-                    }
-                }
+                    "no_explicit_access" => FileMemberActionError::NoExplicitAccess(MemberAccessLevelResult::internal_deserialize(&mut map)?),
+                    _ => FileMemberActionError::Other,
+                };
+                crate::eat_json_fields(&mut map)?;
+                Ok(value)
             }
         }
         const VARIANTS: &[&str] = &["invalid_member",
@@ -3845,23 +3723,25 @@ impl<'de> ::serde::de::Deserialize<'de> for FileMemberActionIndividualResult {
                     Some(".tag") => map.next_value()?,
                     _ => return Err(de::Error::missing_field(".tag"))
                 };
-                match tag {
+                let value = match tag {
                     "success" => {
                         match map.next_key()? {
-                            Some("success") => Ok(FileMemberActionIndividualResult::Success(map.next_value()?)),
-                            None => Ok(FileMemberActionIndividualResult::Success(None)),
-                            _ => Err(de::Error::unknown_field(tag, VARIANTS))
+                            Some("success") => FileMemberActionIndividualResult::Success(map.next_value()?),
+                            None => FileMemberActionIndividualResult::Success(None),
+                            _ => return Err(de::Error::unknown_field(tag, VARIANTS))
                         }
                     }
                     "member_error" => {
                         match map.next_key()? {
-                            Some("member_error") => Ok(FileMemberActionIndividualResult::MemberError(map.next_value()?)),
-                            None => Err(de::Error::missing_field("member_error")),
-                            _ => Err(de::Error::unknown_field(tag, VARIANTS))
+                            Some("member_error") => FileMemberActionIndividualResult::MemberError(map.next_value()?),
+                            None => return Err(de::Error::missing_field("member_error")),
+                            _ => return Err(de::Error::unknown_field(tag, VARIANTS))
                         }
                     }
-                    _ => Err(de::Error::unknown_variant(tag, VARIANTS))
-                }
+                    _ => return Err(de::Error::unknown_variant(tag, VARIANTS))
+                };
+                crate::eat_json_fields(&mut map)?;
+                Ok(value)
             }
         }
         const VARIANTS: &[&str] = &["success",
@@ -4025,20 +3905,19 @@ impl<'de> ::serde::de::Deserialize<'de> for FileMemberRemoveActionResult {
                     Some(".tag") => map.next_value()?,
                     _ => return Err(de::Error::missing_field(".tag"))
                 };
-                match tag {
-                    "success" => Ok(FileMemberRemoveActionResult::Success(MemberAccessLevelResult::internal_deserialize(map)?)),
+                let value = match tag {
+                    "success" => FileMemberRemoveActionResult::Success(MemberAccessLevelResult::internal_deserialize(&mut map)?),
                     "member_error" => {
                         match map.next_key()? {
-                            Some("member_error") => Ok(FileMemberRemoveActionResult::MemberError(map.next_value()?)),
-                            None => Err(de::Error::missing_field("member_error")),
-                            _ => Err(de::Error::unknown_field(tag, VARIANTS))
+                            Some("member_error") => FileMemberRemoveActionResult::MemberError(map.next_value()?),
+                            None => return Err(de::Error::missing_field("member_error")),
+                            _ => return Err(de::Error::unknown_field(tag, VARIANTS))
                         }
                     }
-                    _ => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(FileMemberRemoveActionResult::Other)
-                    }
-                }
+                    _ => FileMemberRemoveActionResult::Other,
+                };
+                crate::eat_json_fields(&mut map)?;
+                Ok(value)
             }
         }
         const VARIANTS: &[&str] = &["success",
@@ -4246,68 +4125,25 @@ impl<'de> ::serde::de::Deserialize<'de> for FolderAction {
                     Some(".tag") => map.next_value()?,
                     _ => return Err(de::Error::missing_field(".tag"))
                 };
-                match tag {
-                    "change_options" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(FolderAction::ChangeOptions)
-                    }
-                    "disable_viewer_info" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(FolderAction::DisableViewerInfo)
-                    }
-                    "edit_contents" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(FolderAction::EditContents)
-                    }
-                    "enable_viewer_info" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(FolderAction::EnableViewerInfo)
-                    }
-                    "invite_editor" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(FolderAction::InviteEditor)
-                    }
-                    "invite_viewer" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(FolderAction::InviteViewer)
-                    }
-                    "invite_viewer_no_comment" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(FolderAction::InviteViewerNoComment)
-                    }
-                    "relinquish_membership" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(FolderAction::RelinquishMembership)
-                    }
-                    "unmount" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(FolderAction::Unmount)
-                    }
-                    "unshare" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(FolderAction::Unshare)
-                    }
-                    "leave_a_copy" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(FolderAction::LeaveACopy)
-                    }
-                    "share_link" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(FolderAction::ShareLink)
-                    }
-                    "create_link" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(FolderAction::CreateLink)
-                    }
-                    "set_access_inheritance" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(FolderAction::SetAccessInheritance)
-                    }
-                    _ => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(FolderAction::Other)
-                    }
-                }
+                let value = match tag {
+                    "change_options" => FolderAction::ChangeOptions,
+                    "disable_viewer_info" => FolderAction::DisableViewerInfo,
+                    "edit_contents" => FolderAction::EditContents,
+                    "enable_viewer_info" => FolderAction::EnableViewerInfo,
+                    "invite_editor" => FolderAction::InviteEditor,
+                    "invite_viewer" => FolderAction::InviteViewer,
+                    "invite_viewer_no_comment" => FolderAction::InviteViewerNoComment,
+                    "relinquish_membership" => FolderAction::RelinquishMembership,
+                    "unmount" => FolderAction::Unmount,
+                    "unshare" => FolderAction::Unshare,
+                    "leave_a_copy" => FolderAction::LeaveACopy,
+                    "share_link" => FolderAction::ShareLink,
+                    "create_link" => FolderAction::CreateLink,
+                    "set_access_inheritance" => FolderAction::SetAccessInheritance,
+                    _ => FolderAction::Other,
+                };
+                crate::eat_json_fields(&mut map)?;
+                Ok(value)
             }
         }
         const VARIANTS: &[&str] = &["change_options",
@@ -5272,26 +5108,25 @@ impl<'de> ::serde::de::Deserialize<'de> for GetFileMetadataError {
                     Some(".tag") => map.next_value()?,
                     _ => return Err(de::Error::missing_field(".tag"))
                 };
-                match tag {
+                let value = match tag {
                     "user_error" => {
                         match map.next_key()? {
-                            Some("user_error") => Ok(GetFileMetadataError::UserError(map.next_value()?)),
-                            None => Err(de::Error::missing_field("user_error")),
-                            _ => Err(de::Error::unknown_field(tag, VARIANTS))
+                            Some("user_error") => GetFileMetadataError::UserError(map.next_value()?),
+                            None => return Err(de::Error::missing_field("user_error")),
+                            _ => return Err(de::Error::unknown_field(tag, VARIANTS))
                         }
                     }
                     "access_error" => {
                         match map.next_key()? {
-                            Some("access_error") => Ok(GetFileMetadataError::AccessError(map.next_value()?)),
-                            None => Err(de::Error::missing_field("access_error")),
-                            _ => Err(de::Error::unknown_field(tag, VARIANTS))
+                            Some("access_error") => GetFileMetadataError::AccessError(map.next_value()?),
+                            None => return Err(de::Error::missing_field("access_error")),
+                            _ => return Err(de::Error::unknown_field(tag, VARIANTS))
                         }
                     }
-                    _ => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(GetFileMetadataError::Other)
-                    }
-                }
+                    _ => GetFileMetadataError::Other,
+                };
+                crate::eat_json_fields(&mut map)?;
+                Ok(value)
             }
         }
         const VARIANTS: &[&str] = &["user_error",
@@ -5372,20 +5207,19 @@ impl<'de> ::serde::de::Deserialize<'de> for GetFileMetadataIndividualResult {
                     Some(".tag") => map.next_value()?,
                     _ => return Err(de::Error::missing_field(".tag"))
                 };
-                match tag {
-                    "metadata" => Ok(GetFileMetadataIndividualResult::Metadata(SharedFileMetadata::internal_deserialize(map)?)),
+                let value = match tag {
+                    "metadata" => GetFileMetadataIndividualResult::Metadata(SharedFileMetadata::internal_deserialize(&mut map)?),
                     "access_error" => {
                         match map.next_key()? {
-                            Some("access_error") => Ok(GetFileMetadataIndividualResult::AccessError(map.next_value()?)),
-                            None => Err(de::Error::missing_field("access_error")),
-                            _ => Err(de::Error::unknown_field(tag, VARIANTS))
+                            Some("access_error") => GetFileMetadataIndividualResult::AccessError(map.next_value()?),
+                            None => return Err(de::Error::missing_field("access_error")),
+                            _ => return Err(de::Error::unknown_field(tag, VARIANTS))
                         }
                     }
-                    _ => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(GetFileMetadataIndividualResult::Other)
-                    }
-                }
+                    _ => GetFileMetadataIndividualResult::Other,
+                };
+                crate::eat_json_fields(&mut map)?;
+                Ok(value)
             }
         }
         const VARIANTS: &[&str] = &["metadata",
@@ -5560,28 +5394,15 @@ impl<'de> ::serde::de::Deserialize<'de> for GetSharedLinkFileError {
                     Some(".tag") => map.next_value()?,
                     _ => return Err(de::Error::missing_field(".tag"))
                 };
-                match tag {
-                    "shared_link_not_found" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(GetSharedLinkFileError::SharedLinkNotFound)
-                    }
-                    "shared_link_access_denied" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(GetSharedLinkFileError::SharedLinkAccessDenied)
-                    }
-                    "unsupported_link_type" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(GetSharedLinkFileError::UnsupportedLinkType)
-                    }
-                    "shared_link_is_directory" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(GetSharedLinkFileError::SharedLinkIsDirectory)
-                    }
-                    _ => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(GetSharedLinkFileError::Other)
-                    }
-                }
+                let value = match tag {
+                    "shared_link_not_found" => GetSharedLinkFileError::SharedLinkNotFound,
+                    "shared_link_access_denied" => GetSharedLinkFileError::SharedLinkAccessDenied,
+                    "unsupported_link_type" => GetSharedLinkFileError::UnsupportedLinkType,
+                    "shared_link_is_directory" => GetSharedLinkFileError::SharedLinkIsDirectory,
+                    _ => GetSharedLinkFileError::Other,
+                };
+                crate::eat_json_fields(&mut map)?;
+                Ok(value)
             }
         }
         const VARIANTS: &[&str] = &["shared_link_not_found",
@@ -5878,19 +5699,18 @@ impl<'de> ::serde::de::Deserialize<'de> for GetSharedLinksError {
                     Some(".tag") => map.next_value()?,
                     _ => return Err(de::Error::missing_field(".tag"))
                 };
-                match tag {
+                let value = match tag {
                     "path" => {
                         match map.next_key()? {
-                            Some("path") => Ok(GetSharedLinksError::Path(map.next_value()?)),
-                            None => Ok(GetSharedLinksError::Path(None)),
-                            _ => Err(de::Error::unknown_field(tag, VARIANTS))
+                            Some("path") => GetSharedLinksError::Path(map.next_value()?),
+                            None => GetSharedLinksError::Path(None),
+                            _ => return Err(de::Error::unknown_field(tag, VARIANTS))
                         }
                     }
-                    _ => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(GetSharedLinksError::Other)
-                    }
-                }
+                    _ => GetSharedLinksError::Other,
+                };
+                crate::eat_json_fields(&mut map)?;
+                Ok(value)
             }
         }
         const VARIANTS: &[&str] = &["path",
@@ -6644,19 +6464,18 @@ impl<'de> ::serde::de::Deserialize<'de> for InviteeInfo {
                     Some(".tag") => map.next_value()?,
                     _ => return Err(de::Error::missing_field(".tag"))
                 };
-                match tag {
+                let value = match tag {
                     "email" => {
                         match map.next_key()? {
-                            Some("email") => Ok(InviteeInfo::Email(map.next_value()?)),
-                            None => Err(de::Error::missing_field("email")),
-                            _ => Err(de::Error::unknown_field(tag, VARIANTS))
+                            Some("email") => InviteeInfo::Email(map.next_value()?),
+                            None => return Err(de::Error::missing_field("email")),
+                            _ => return Err(de::Error::unknown_field(tag, VARIANTS))
                         }
                     }
-                    _ => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(InviteeInfo::Other)
-                    }
-                }
+                    _ => InviteeInfo::Other,
+                };
+                crate::eat_json_fields(&mut map)?;
+                Ok(value)
             }
         }
         const VARIANTS: &[&str] = &["email",
@@ -6892,33 +6711,32 @@ impl<'de> ::serde::de::Deserialize<'de> for JobError {
                     Some(".tag") => map.next_value()?,
                     _ => return Err(de::Error::missing_field(".tag"))
                 };
-                match tag {
+                let value = match tag {
                     "unshare_folder_error" => {
                         match map.next_key()? {
-                            Some("unshare_folder_error") => Ok(JobError::UnshareFolderError(map.next_value()?)),
-                            None => Err(de::Error::missing_field("unshare_folder_error")),
-                            _ => Err(de::Error::unknown_field(tag, VARIANTS))
+                            Some("unshare_folder_error") => JobError::UnshareFolderError(map.next_value()?),
+                            None => return Err(de::Error::missing_field("unshare_folder_error")),
+                            _ => return Err(de::Error::unknown_field(tag, VARIANTS))
                         }
                     }
                     "remove_folder_member_error" => {
                         match map.next_key()? {
-                            Some("remove_folder_member_error") => Ok(JobError::RemoveFolderMemberError(map.next_value()?)),
-                            None => Err(de::Error::missing_field("remove_folder_member_error")),
-                            _ => Err(de::Error::unknown_field(tag, VARIANTS))
+                            Some("remove_folder_member_error") => JobError::RemoveFolderMemberError(map.next_value()?),
+                            None => return Err(de::Error::missing_field("remove_folder_member_error")),
+                            _ => return Err(de::Error::unknown_field(tag, VARIANTS))
                         }
                     }
                     "relinquish_folder_membership_error" => {
                         match map.next_key()? {
-                            Some("relinquish_folder_membership_error") => Ok(JobError::RelinquishFolderMembershipError(map.next_value()?)),
-                            None => Err(de::Error::missing_field("relinquish_folder_membership_error")),
-                            _ => Err(de::Error::unknown_field(tag, VARIANTS))
+                            Some("relinquish_folder_membership_error") => JobError::RelinquishFolderMembershipError(map.next_value()?),
+                            None => return Err(de::Error::missing_field("relinquish_folder_membership_error")),
+                            _ => return Err(de::Error::unknown_field(tag, VARIANTS))
                         }
                     }
-                    _ => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(JobError::Other)
-                    }
-                }
+                    _ => JobError::Other,
+                };
+                crate::eat_json_fields(&mut map)?;
+                Ok(value)
             }
         }
         const VARIANTS: &[&str] = &["unshare_folder_error",
@@ -7007,24 +6825,20 @@ impl<'de> ::serde::de::Deserialize<'de> for JobStatus {
                     Some(".tag") => map.next_value()?,
                     _ => return Err(de::Error::missing_field(".tag"))
                 };
-                match tag {
-                    "in_progress" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(JobStatus::InProgress)
-                    }
-                    "complete" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(JobStatus::Complete)
-                    }
+                let value = match tag {
+                    "in_progress" => JobStatus::InProgress,
+                    "complete" => JobStatus::Complete,
                     "failed" => {
                         match map.next_key()? {
-                            Some("failed") => Ok(JobStatus::Failed(map.next_value()?)),
-                            None => Err(de::Error::missing_field("failed")),
-                            _ => Err(de::Error::unknown_field(tag, VARIANTS))
+                            Some("failed") => JobStatus::Failed(map.next_value()?),
+                            None => return Err(de::Error::missing_field("failed")),
+                            _ => return Err(de::Error::unknown_field(tag, VARIANTS))
                         }
                     }
-                    _ => Err(de::Error::unknown_variant(tag, VARIANTS))
-                }
+                    _ => return Err(de::Error::unknown_variant(tag, VARIANTS))
+                };
+                crate::eat_json_fields(&mut map)?;
+                Ok(value)
             }
         }
         const VARIANTS: &[&str] = &["in_progress",
@@ -7089,20 +6903,13 @@ impl<'de> ::serde::de::Deserialize<'de> for LinkAccessLevel {
                     Some(".tag") => map.next_value()?,
                     _ => return Err(de::Error::missing_field(".tag"))
                 };
-                match tag {
-                    "viewer" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(LinkAccessLevel::Viewer)
-                    }
-                    "editor" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(LinkAccessLevel::Editor)
-                    }
-                    _ => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(LinkAccessLevel::Other)
-                    }
-                }
+                let value = match tag {
+                    "viewer" => LinkAccessLevel::Viewer,
+                    "editor" => LinkAccessLevel::Editor,
+                    _ => LinkAccessLevel::Other,
+                };
+                crate::eat_json_fields(&mut map)?;
+                Ok(value)
             }
         }
         const VARIANTS: &[&str] = &["viewer",
@@ -7170,36 +6977,17 @@ impl<'de> ::serde::de::Deserialize<'de> for LinkAction {
                     Some(".tag") => map.next_value()?,
                     _ => return Err(de::Error::missing_field(".tag"))
                 };
-                match tag {
-                    "change_access_level" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(LinkAction::ChangeAccessLevel)
-                    }
-                    "change_audience" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(LinkAction::ChangeAudience)
-                    }
-                    "remove_expiry" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(LinkAction::RemoveExpiry)
-                    }
-                    "remove_password" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(LinkAction::RemovePassword)
-                    }
-                    "set_expiry" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(LinkAction::SetExpiry)
-                    }
-                    "set_password" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(LinkAction::SetPassword)
-                    }
-                    _ => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(LinkAction::Other)
-                    }
-                }
+                let value = match tag {
+                    "change_access_level" => LinkAction::ChangeAccessLevel,
+                    "change_audience" => LinkAction::ChangeAudience,
+                    "remove_expiry" => LinkAction::RemoveExpiry,
+                    "remove_password" => LinkAction::RemovePassword,
+                    "set_expiry" => LinkAction::SetExpiry,
+                    "set_password" => LinkAction::SetPassword,
+                    _ => LinkAction::Other,
+                };
+                crate::eat_json_fields(&mut map)?;
+                Ok(value)
             }
         }
         const VARIANTS: &[&str] = &["change_access_level",
@@ -7294,32 +7082,16 @@ impl<'de> ::serde::de::Deserialize<'de> for LinkAudience {
                     Some(".tag") => map.next_value()?,
                     _ => return Err(de::Error::missing_field(".tag"))
                 };
-                match tag {
-                    "public" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(LinkAudience::Public)
-                    }
-                    "team" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(LinkAudience::Team)
-                    }
-                    "no_one" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(LinkAudience::NoOne)
-                    }
-                    "password" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(LinkAudience::Password)
-                    }
-                    "members" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(LinkAudience::Members)
-                    }
-                    _ => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(LinkAudience::Other)
-                    }
-                }
+                let value = match tag {
+                    "public" => LinkAudience::Public,
+                    "team" => LinkAudience::Team,
+                    "no_one" => LinkAudience::NoOne,
+                    "password" => LinkAudience::Password,
+                    "members" => LinkAudience::Members,
+                    _ => LinkAudience::Other,
+                };
+                crate::eat_json_fields(&mut map)?;
+                Ok(value)
             }
         }
         const VARIANTS: &[&str] = &["public",
@@ -7399,23 +7171,19 @@ impl<'de> ::serde::de::Deserialize<'de> for LinkExpiry {
                     Some(".tag") => map.next_value()?,
                     _ => return Err(de::Error::missing_field(".tag"))
                 };
-                match tag {
-                    "remove_expiry" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(LinkExpiry::RemoveExpiry)
-                    }
+                let value = match tag {
+                    "remove_expiry" => LinkExpiry::RemoveExpiry,
                     "set_expiry" => {
                         match map.next_key()? {
-                            Some("set_expiry") => Ok(LinkExpiry::SetExpiry(map.next_value()?)),
-                            None => Err(de::Error::missing_field("set_expiry")),
-                            _ => Err(de::Error::unknown_field(tag, VARIANTS))
+                            Some("set_expiry") => LinkExpiry::SetExpiry(map.next_value()?),
+                            None => return Err(de::Error::missing_field("set_expiry")),
+                            _ => return Err(de::Error::unknown_field(tag, VARIANTS))
                         }
                     }
-                    _ => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(LinkExpiry::Other)
-                    }
-                }
+                    _ => LinkExpiry::Other,
+                };
+                crate::eat_json_fields(&mut map)?;
+                Ok(value)
             }
         }
         const VARIANTS: &[&str] = &["remove_expiry",
@@ -7545,23 +7313,19 @@ impl<'de> ::serde::de::Deserialize<'de> for LinkPassword {
                     Some(".tag") => map.next_value()?,
                     _ => return Err(de::Error::missing_field(".tag"))
                 };
-                match tag {
-                    "remove_password" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(LinkPassword::RemovePassword)
-                    }
+                let value = match tag {
+                    "remove_password" => LinkPassword::RemovePassword,
                     "set_password" => {
                         match map.next_key()? {
-                            Some("set_password") => Ok(LinkPassword::SetPassword(map.next_value()?)),
-                            None => Err(de::Error::missing_field("set_password")),
-                            _ => Err(de::Error::unknown_field(tag, VARIANTS))
+                            Some("set_password") => LinkPassword::SetPassword(map.next_value()?),
+                            None => return Err(de::Error::missing_field("set_password")),
+                            _ => return Err(de::Error::unknown_field(tag, VARIANTS))
                         }
                     }
-                    _ => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(LinkPassword::Other)
-                    }
-                }
+                    _ => LinkPassword::Other,
+                };
+                crate::eat_json_fields(&mut map)?;
+                Ok(value)
             }
         }
         const VARIANTS: &[&str] = &["remove_password",
@@ -8528,30 +8292,26 @@ impl<'de> ::serde::de::Deserialize<'de> for ListFileMembersContinueError {
                     Some(".tag") => map.next_value()?,
                     _ => return Err(de::Error::missing_field(".tag"))
                 };
-                match tag {
+                let value = match tag {
                     "user_error" => {
                         match map.next_key()? {
-                            Some("user_error") => Ok(ListFileMembersContinueError::UserError(map.next_value()?)),
-                            None => Err(de::Error::missing_field("user_error")),
-                            _ => Err(de::Error::unknown_field(tag, VARIANTS))
+                            Some("user_error") => ListFileMembersContinueError::UserError(map.next_value()?),
+                            None => return Err(de::Error::missing_field("user_error")),
+                            _ => return Err(de::Error::unknown_field(tag, VARIANTS))
                         }
                     }
                     "access_error" => {
                         match map.next_key()? {
-                            Some("access_error") => Ok(ListFileMembersContinueError::AccessError(map.next_value()?)),
-                            None => Err(de::Error::missing_field("access_error")),
-                            _ => Err(de::Error::unknown_field(tag, VARIANTS))
+                            Some("access_error") => ListFileMembersContinueError::AccessError(map.next_value()?),
+                            None => return Err(de::Error::missing_field("access_error")),
+                            _ => return Err(de::Error::unknown_field(tag, VARIANTS))
                         }
                     }
-                    "invalid_cursor" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(ListFileMembersContinueError::InvalidCursor)
-                    }
-                    _ => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(ListFileMembersContinueError::Other)
-                    }
-                }
+                    "invalid_cursor" => ListFileMembersContinueError::InvalidCursor,
+                    _ => ListFileMembersContinueError::Other,
+                };
+                crate::eat_json_fields(&mut map)?;
+                Ok(value)
             }
         }
         const VARIANTS: &[&str] = &["user_error",
@@ -8741,26 +8501,25 @@ impl<'de> ::serde::de::Deserialize<'de> for ListFileMembersError {
                     Some(".tag") => map.next_value()?,
                     _ => return Err(de::Error::missing_field(".tag"))
                 };
-                match tag {
+                let value = match tag {
                     "user_error" => {
                         match map.next_key()? {
-                            Some("user_error") => Ok(ListFileMembersError::UserError(map.next_value()?)),
-                            None => Err(de::Error::missing_field("user_error")),
-                            _ => Err(de::Error::unknown_field(tag, VARIANTS))
+                            Some("user_error") => ListFileMembersError::UserError(map.next_value()?),
+                            None => return Err(de::Error::missing_field("user_error")),
+                            _ => return Err(de::Error::unknown_field(tag, VARIANTS))
                         }
                     }
                     "access_error" => {
                         match map.next_key()? {
-                            Some("access_error") => Ok(ListFileMembersError::AccessError(map.next_value()?)),
-                            None => Err(de::Error::missing_field("access_error")),
-                            _ => Err(de::Error::unknown_field(tag, VARIANTS))
+                            Some("access_error") => ListFileMembersError::AccessError(map.next_value()?),
+                            None => return Err(de::Error::missing_field("access_error")),
+                            _ => return Err(de::Error::unknown_field(tag, VARIANTS))
                         }
                     }
-                    _ => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(ListFileMembersError::Other)
-                    }
-                }
+                    _ => ListFileMembersError::Other,
+                };
+                crate::eat_json_fields(&mut map)?;
+                Ok(value)
             }
         }
         const VARIANTS: &[&str] = &["user_error",
@@ -8841,20 +8600,19 @@ impl<'de> ::serde::de::Deserialize<'de> for ListFileMembersIndividualResult {
                     Some(".tag") => map.next_value()?,
                     _ => return Err(de::Error::missing_field(".tag"))
                 };
-                match tag {
-                    "result" => Ok(ListFileMembersIndividualResult::Result(ListFileMembersCountResult::internal_deserialize(map)?)),
+                let value = match tag {
+                    "result" => ListFileMembersIndividualResult::Result(ListFileMembersCountResult::internal_deserialize(&mut map)?),
                     "access_error" => {
                         match map.next_key()? {
-                            Some("access_error") => Ok(ListFileMembersIndividualResult::AccessError(map.next_value()?)),
-                            None => Err(de::Error::missing_field("access_error")),
-                            _ => Err(de::Error::unknown_field(tag, VARIANTS))
+                            Some("access_error") => ListFileMembersIndividualResult::AccessError(map.next_value()?),
+                            None => return Err(de::Error::missing_field("access_error")),
+                            _ => return Err(de::Error::unknown_field(tag, VARIANTS))
                         }
                     }
-                    _ => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(ListFileMembersIndividualResult::Other)
-                    }
-                }
+                    _ => ListFileMembersIndividualResult::Other,
+                };
+                crate::eat_json_fields(&mut map)?;
+                Ok(value)
             }
         }
         const VARIANTS: &[&str] = &["result",
@@ -9114,23 +8872,19 @@ impl<'de> ::serde::de::Deserialize<'de> for ListFilesContinueError {
                     Some(".tag") => map.next_value()?,
                     _ => return Err(de::Error::missing_field(".tag"))
                 };
-                match tag {
+                let value = match tag {
                     "user_error" => {
                         match map.next_key()? {
-                            Some("user_error") => Ok(ListFilesContinueError::UserError(map.next_value()?)),
-                            None => Err(de::Error::missing_field("user_error")),
-                            _ => Err(de::Error::unknown_field(tag, VARIANTS))
+                            Some("user_error") => ListFilesContinueError::UserError(map.next_value()?),
+                            None => return Err(de::Error::missing_field("user_error")),
+                            _ => return Err(de::Error::unknown_field(tag, VARIANTS))
                         }
                     }
-                    "invalid_cursor" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(ListFilesContinueError::InvalidCursor)
-                    }
-                    _ => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(ListFilesContinueError::Other)
-                    }
-                }
+                    "invalid_cursor" => ListFilesContinueError::InvalidCursor,
+                    _ => ListFilesContinueError::Other,
+                };
+                crate::eat_json_fields(&mut map)?;
+                Ok(value)
             }
         }
         const VARIANTS: &[&str] = &["user_error",
@@ -9536,23 +9290,19 @@ impl<'de> ::serde::de::Deserialize<'de> for ListFolderMembersContinueError {
                     Some(".tag") => map.next_value()?,
                     _ => return Err(de::Error::missing_field(".tag"))
                 };
-                match tag {
+                let value = match tag {
                     "access_error" => {
                         match map.next_key()? {
-                            Some("access_error") => Ok(ListFolderMembersContinueError::AccessError(map.next_value()?)),
-                            None => Err(de::Error::missing_field("access_error")),
-                            _ => Err(de::Error::unknown_field(tag, VARIANTS))
+                            Some("access_error") => ListFolderMembersContinueError::AccessError(map.next_value()?),
+                            None => return Err(de::Error::missing_field("access_error")),
+                            _ => return Err(de::Error::unknown_field(tag, VARIANTS))
                         }
                     }
-                    "invalid_cursor" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(ListFolderMembersContinueError::InvalidCursor)
-                    }
-                    _ => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(ListFolderMembersContinueError::Other)
-                    }
-                }
+                    "invalid_cursor" => ListFolderMembersContinueError::InvalidCursor,
+                    _ => ListFolderMembersContinueError::Other,
+                };
+                crate::eat_json_fields(&mut map)?;
+                Ok(value)
             }
         }
         const VARIANTS: &[&str] = &["access_error",
@@ -9931,16 +9681,12 @@ impl<'de> ::serde::de::Deserialize<'de> for ListFoldersContinueError {
                     Some(".tag") => map.next_value()?,
                     _ => return Err(de::Error::missing_field(".tag"))
                 };
-                match tag {
-                    "invalid_cursor" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(ListFoldersContinueError::InvalidCursor)
-                    }
-                    _ => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(ListFoldersContinueError::Other)
-                    }
-                }
+                let value = match tag {
+                    "invalid_cursor" => ListFoldersContinueError::InvalidCursor,
+                    _ => ListFoldersContinueError::Other,
+                };
+                crate::eat_json_fields(&mut map)?;
+                Ok(value)
             }
         }
         const VARIANTS: &[&str] = &["invalid_cursor",
@@ -10239,23 +9985,19 @@ impl<'de> ::serde::de::Deserialize<'de> for ListSharedLinksError {
                     Some(".tag") => map.next_value()?,
                     _ => return Err(de::Error::missing_field(".tag"))
                 };
-                match tag {
+                let value = match tag {
                     "path" => {
                         match map.next_key()? {
-                            Some("path") => Ok(ListSharedLinksError::Path(map.next_value()?)),
-                            None => Err(de::Error::missing_field("path")),
-                            _ => Err(de::Error::unknown_field(tag, VARIANTS))
+                            Some("path") => ListSharedLinksError::Path(map.next_value()?),
+                            None => return Err(de::Error::missing_field("path")),
+                            _ => return Err(de::Error::unknown_field(tag, VARIANTS))
                         }
                     }
-                    "reset" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(ListSharedLinksError::Reset)
-                    }
-                    _ => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(ListSharedLinksError::Other)
-                    }
-                }
+                    "reset" => ListSharedLinksError::Reset,
+                    _ => ListSharedLinksError::Other,
+                };
+                crate::eat_json_fields(&mut map)?;
+                Ok(value)
             }
         }
         const VARIANTS: &[&str] = &["path",
@@ -10590,36 +10332,17 @@ impl<'de> ::serde::de::Deserialize<'de> for MemberAction {
                     Some(".tag") => map.next_value()?,
                     _ => return Err(de::Error::missing_field(".tag"))
                 };
-                match tag {
-                    "leave_a_copy" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(MemberAction::LeaveACopy)
-                    }
-                    "make_editor" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(MemberAction::MakeEditor)
-                    }
-                    "make_owner" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(MemberAction::MakeOwner)
-                    }
-                    "make_viewer" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(MemberAction::MakeViewer)
-                    }
-                    "make_viewer_no_comment" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(MemberAction::MakeViewerNoComment)
-                    }
-                    "remove" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(MemberAction::Remove)
-                    }
-                    _ => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(MemberAction::Other)
-                    }
-                }
+                let value = match tag {
+                    "leave_a_copy" => MemberAction::LeaveACopy,
+                    "make_editor" => MemberAction::MakeEditor,
+                    "make_owner" => MemberAction::MakeOwner,
+                    "make_viewer" => MemberAction::MakeViewer,
+                    "make_viewer_no_comment" => MemberAction::MakeViewerNoComment,
+                    "remove" => MemberAction::Remove,
+                    _ => MemberAction::Other,
+                };
+                crate::eat_json_fields(&mut map)?;
+                Ok(value)
             }
         }
         const VARIANTS: &[&str] = &["leave_a_copy",
@@ -10830,20 +10553,13 @@ impl<'de> ::serde::de::Deserialize<'de> for MemberPolicy {
                     Some(".tag") => map.next_value()?,
                     _ => return Err(de::Error::missing_field(".tag"))
                 };
-                match tag {
-                    "team" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(MemberPolicy::Team)
-                    }
-                    "anyone" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(MemberPolicy::Anyone)
-                    }
-                    _ => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(MemberPolicy::Other)
-                    }
-                }
+                let value = match tag {
+                    "team" => MemberPolicy::Team,
+                    "anyone" => MemberPolicy::Anyone,
+                    _ => MemberPolicy::Other,
+                };
+                crate::eat_json_fields(&mut map)?;
+                Ok(value)
             }
         }
         const VARIANTS: &[&str] = &["team",
@@ -10903,26 +10619,25 @@ impl<'de> ::serde::de::Deserialize<'de> for MemberSelector {
                     Some(".tag") => map.next_value()?,
                     _ => return Err(de::Error::missing_field(".tag"))
                 };
-                match tag {
+                let value = match tag {
                     "dropbox_id" => {
                         match map.next_key()? {
-                            Some("dropbox_id") => Ok(MemberSelector::DropboxId(map.next_value()?)),
-                            None => Err(de::Error::missing_field("dropbox_id")),
-                            _ => Err(de::Error::unknown_field(tag, VARIANTS))
+                            Some("dropbox_id") => MemberSelector::DropboxId(map.next_value()?),
+                            None => return Err(de::Error::missing_field("dropbox_id")),
+                            _ => return Err(de::Error::unknown_field(tag, VARIANTS))
                         }
                     }
                     "email" => {
                         match map.next_key()? {
-                            Some("email") => Ok(MemberSelector::Email(map.next_value()?)),
-                            None => Err(de::Error::missing_field("email")),
-                            _ => Err(de::Error::unknown_field(tag, VARIANTS))
+                            Some("email") => MemberSelector::Email(map.next_value()?),
+                            None => return Err(de::Error::missing_field("email")),
+                            _ => return Err(de::Error::unknown_field(tag, VARIANTS))
                         }
                     }
-                    _ => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(MemberSelector::Other)
-                    }
-                }
+                    _ => MemberSelector::Other,
+                };
+                crate::eat_json_fields(&mut map)?;
+                Ok(value)
             }
         }
         const VARIANTS: &[&str] = &["dropbox_id",
@@ -11259,35 +10974,22 @@ impl<'de> ::serde::de::Deserialize<'de> for ModifySharedLinkSettingsError {
                     Some(".tag") => map.next_value()?,
                     _ => return Err(de::Error::missing_field(".tag"))
                 };
-                match tag {
-                    "shared_link_not_found" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(ModifySharedLinkSettingsError::SharedLinkNotFound)
-                    }
-                    "shared_link_access_denied" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(ModifySharedLinkSettingsError::SharedLinkAccessDenied)
-                    }
-                    "unsupported_link_type" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(ModifySharedLinkSettingsError::UnsupportedLinkType)
-                    }
+                let value = match tag {
+                    "shared_link_not_found" => ModifySharedLinkSettingsError::SharedLinkNotFound,
+                    "shared_link_access_denied" => ModifySharedLinkSettingsError::SharedLinkAccessDenied,
+                    "unsupported_link_type" => ModifySharedLinkSettingsError::UnsupportedLinkType,
                     "settings_error" => {
                         match map.next_key()? {
-                            Some("settings_error") => Ok(ModifySharedLinkSettingsError::SettingsError(map.next_value()?)),
-                            None => Err(de::Error::missing_field("settings_error")),
-                            _ => Err(de::Error::unknown_field(tag, VARIANTS))
+                            Some("settings_error") => ModifySharedLinkSettingsError::SettingsError(map.next_value()?),
+                            None => return Err(de::Error::missing_field("settings_error")),
+                            _ => return Err(de::Error::unknown_field(tag, VARIANTS))
                         }
                     }
-                    "email_not_verified" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(ModifySharedLinkSettingsError::EmailNotVerified)
-                    }
-                    _ => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(ModifySharedLinkSettingsError::Other)
-                    }
-                }
+                    "email_not_verified" => ModifySharedLinkSettingsError::EmailNotVerified,
+                    _ => ModifySharedLinkSettingsError::Other,
+                };
+                crate::eat_json_fields(&mut map)?;
+                Ok(value)
             }
         }
         const VARIANTS: &[&str] = &["shared_link_not_found",
@@ -11486,36 +11188,23 @@ impl<'de> ::serde::de::Deserialize<'de> for MountFolderError {
                     Some(".tag") => map.next_value()?,
                     _ => return Err(de::Error::missing_field(".tag"))
                 };
-                match tag {
+                let value = match tag {
                     "access_error" => {
                         match map.next_key()? {
-                            Some("access_error") => Ok(MountFolderError::AccessError(map.next_value()?)),
-                            None => Err(de::Error::missing_field("access_error")),
-                            _ => Err(de::Error::unknown_field(tag, VARIANTS))
+                            Some("access_error") => MountFolderError::AccessError(map.next_value()?),
+                            None => return Err(de::Error::missing_field("access_error")),
+                            _ => return Err(de::Error::unknown_field(tag, VARIANTS))
                         }
                     }
-                    "inside_shared_folder" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(MountFolderError::InsideSharedFolder)
-                    }
-                    "insufficient_quota" => Ok(MountFolderError::InsufficientQuota(InsufficientQuotaAmounts::internal_deserialize(map)?)),
-                    "already_mounted" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(MountFolderError::AlreadyMounted)
-                    }
-                    "no_permission" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(MountFolderError::NoPermission)
-                    }
-                    "not_mountable" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(MountFolderError::NotMountable)
-                    }
-                    _ => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(MountFolderError::Other)
-                    }
-                }
+                    "inside_shared_folder" => MountFolderError::InsideSharedFolder,
+                    "insufficient_quota" => MountFolderError::InsufficientQuota(InsufficientQuotaAmounts::internal_deserialize(&mut map)?),
+                    "already_mounted" => MountFolderError::AlreadyMounted,
+                    "no_permission" => MountFolderError::NoPermission,
+                    "not_mountable" => MountFolderError::NotMountable,
+                    _ => MountFolderError::Other,
+                };
+                crate::eat_json_fields(&mut map)?;
+                Ok(value)
             }
         }
         const VARIANTS: &[&str] = &["access_error",
@@ -11894,17 +11583,13 @@ impl<'de> ::serde::de::Deserialize<'de> for PendingUploadMode {
                     Some(".tag") => map.next_value()?,
                     _ => return Err(de::Error::missing_field(".tag"))
                 };
-                match tag {
-                    "file" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(PendingUploadMode::File)
-                    }
-                    "folder" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(PendingUploadMode::Folder)
-                    }
-                    _ => Err(de::Error::unknown_variant(tag, VARIANTS))
-                }
+                let value = match tag {
+                    "file" => PendingUploadMode::File,
+                    "folder" => PendingUploadMode::Folder,
+                    _ => return Err(de::Error::unknown_variant(tag, VARIANTS))
+                };
+                crate::eat_json_fields(&mut map)?;
+                Ok(value)
             }
         }
         const VARIANTS: &[&str] = &["file",
@@ -11987,69 +11672,26 @@ impl<'de> ::serde::de::Deserialize<'de> for PermissionDeniedReason {
                     Some(".tag") => map.next_value()?,
                     _ => return Err(de::Error::missing_field(".tag"))
                 };
-                match tag {
-                    "user_not_same_team_as_owner" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(PermissionDeniedReason::UserNotSameTeamAsOwner)
-                    }
-                    "user_not_allowed_by_owner" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(PermissionDeniedReason::UserNotAllowedByOwner)
-                    }
-                    "target_is_indirect_member" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(PermissionDeniedReason::TargetIsIndirectMember)
-                    }
-                    "target_is_owner" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(PermissionDeniedReason::TargetIsOwner)
-                    }
-                    "target_is_self" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(PermissionDeniedReason::TargetIsSelf)
-                    }
-                    "target_not_active" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(PermissionDeniedReason::TargetNotActive)
-                    }
-                    "folder_is_limited_team_folder" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(PermissionDeniedReason::FolderIsLimitedTeamFolder)
-                    }
-                    "owner_not_on_team" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(PermissionDeniedReason::OwnerNotOnTeam)
-                    }
-                    "permission_denied" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(PermissionDeniedReason::PermissionDenied)
-                    }
-                    "restricted_by_team" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(PermissionDeniedReason::RestrictedByTeam)
-                    }
-                    "user_account_type" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(PermissionDeniedReason::UserAccountType)
-                    }
-                    "user_not_on_team" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(PermissionDeniedReason::UserNotOnTeam)
-                    }
-                    "folder_is_inside_shared_folder" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(PermissionDeniedReason::FolderIsInsideSharedFolder)
-                    }
-                    "restricted_by_parent_folder" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(PermissionDeniedReason::RestrictedByParentFolder)
-                    }
-                    "insufficient_plan" => Ok(PermissionDeniedReason::InsufficientPlan(InsufficientPlan::internal_deserialize(map)?)),
-                    _ => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(PermissionDeniedReason::Other)
-                    }
-                }
+                let value = match tag {
+                    "user_not_same_team_as_owner" => PermissionDeniedReason::UserNotSameTeamAsOwner,
+                    "user_not_allowed_by_owner" => PermissionDeniedReason::UserNotAllowedByOwner,
+                    "target_is_indirect_member" => PermissionDeniedReason::TargetIsIndirectMember,
+                    "target_is_owner" => PermissionDeniedReason::TargetIsOwner,
+                    "target_is_self" => PermissionDeniedReason::TargetIsSelf,
+                    "target_not_active" => PermissionDeniedReason::TargetNotActive,
+                    "folder_is_limited_team_folder" => PermissionDeniedReason::FolderIsLimitedTeamFolder,
+                    "owner_not_on_team" => PermissionDeniedReason::OwnerNotOnTeam,
+                    "permission_denied" => PermissionDeniedReason::PermissionDenied,
+                    "restricted_by_team" => PermissionDeniedReason::RestrictedByTeam,
+                    "user_account_type" => PermissionDeniedReason::UserAccountType,
+                    "user_not_on_team" => PermissionDeniedReason::UserNotOnTeam,
+                    "folder_is_inside_shared_folder" => PermissionDeniedReason::FolderIsInsideSharedFolder,
+                    "restricted_by_parent_folder" => PermissionDeniedReason::RestrictedByParentFolder,
+                    "insufficient_plan" => PermissionDeniedReason::InsufficientPlan(InsufficientPlan::internal_deserialize(&mut map)?),
+                    _ => PermissionDeniedReason::Other,
+                };
+                crate::eat_json_fields(&mut map)?;
+                Ok(value)
             }
         }
         const VARIANTS: &[&str] = &["user_not_same_team_as_owner",
@@ -12292,27 +11934,20 @@ impl<'de> ::serde::de::Deserialize<'de> for RelinquishFileMembershipError {
                     Some(".tag") => map.next_value()?,
                     _ => return Err(de::Error::missing_field(".tag"))
                 };
-                match tag {
+                let value = match tag {
                     "access_error" => {
                         match map.next_key()? {
-                            Some("access_error") => Ok(RelinquishFileMembershipError::AccessError(map.next_value()?)),
-                            None => Err(de::Error::missing_field("access_error")),
-                            _ => Err(de::Error::unknown_field(tag, VARIANTS))
+                            Some("access_error") => RelinquishFileMembershipError::AccessError(map.next_value()?),
+                            None => return Err(de::Error::missing_field("access_error")),
+                            _ => return Err(de::Error::unknown_field(tag, VARIANTS))
                         }
                     }
-                    "group_access" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(RelinquishFileMembershipError::GroupAccess)
-                    }
-                    "no_permission" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(RelinquishFileMembershipError::NoPermission)
-                    }
-                    _ => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(RelinquishFileMembershipError::Other)
-                    }
-                }
+                    "group_access" => RelinquishFileMembershipError::GroupAccess,
+                    "no_permission" => RelinquishFileMembershipError::NoPermission,
+                    _ => RelinquishFileMembershipError::Other,
+                };
+                crate::eat_json_fields(&mut map)?;
+                Ok(value)
             }
         }
         const VARIANTS: &[&str] = &["access_error",
@@ -12520,43 +12155,24 @@ impl<'de> ::serde::de::Deserialize<'de> for RelinquishFolderMembershipError {
                     Some(".tag") => map.next_value()?,
                     _ => return Err(de::Error::missing_field(".tag"))
                 };
-                match tag {
+                let value = match tag {
                     "access_error" => {
                         match map.next_key()? {
-                            Some("access_error") => Ok(RelinquishFolderMembershipError::AccessError(map.next_value()?)),
-                            None => Err(de::Error::missing_field("access_error")),
-                            _ => Err(de::Error::unknown_field(tag, VARIANTS))
+                            Some("access_error") => RelinquishFolderMembershipError::AccessError(map.next_value()?),
+                            None => return Err(de::Error::missing_field("access_error")),
+                            _ => return Err(de::Error::unknown_field(tag, VARIANTS))
                         }
                     }
-                    "folder_owner" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(RelinquishFolderMembershipError::FolderOwner)
-                    }
-                    "mounted" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(RelinquishFolderMembershipError::Mounted)
-                    }
-                    "group_access" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(RelinquishFolderMembershipError::GroupAccess)
-                    }
-                    "team_folder" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(RelinquishFolderMembershipError::TeamFolder)
-                    }
-                    "no_permission" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(RelinquishFolderMembershipError::NoPermission)
-                    }
-                    "no_explicit_access" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(RelinquishFolderMembershipError::NoExplicitAccess)
-                    }
-                    _ => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(RelinquishFolderMembershipError::Other)
-                    }
-                }
+                    "folder_owner" => RelinquishFolderMembershipError::FolderOwner,
+                    "mounted" => RelinquishFolderMembershipError::Mounted,
+                    "group_access" => RelinquishFolderMembershipError::GroupAccess,
+                    "team_folder" => RelinquishFolderMembershipError::TeamFolder,
+                    "no_permission" => RelinquishFolderMembershipError::NoPermission,
+                    "no_explicit_access" => RelinquishFolderMembershipError::NoExplicitAccess,
+                    _ => RelinquishFolderMembershipError::Other,
+                };
+                crate::eat_json_fields(&mut map)?;
+                Ok(value)
             }
         }
         const VARIANTS: &[&str] = &["access_error",
@@ -12783,27 +12399,26 @@ impl<'de> ::serde::de::Deserialize<'de> for RemoveFileMemberError {
                     Some(".tag") => map.next_value()?,
                     _ => return Err(de::Error::missing_field(".tag"))
                 };
-                match tag {
+                let value = match tag {
                     "user_error" => {
                         match map.next_key()? {
-                            Some("user_error") => Ok(RemoveFileMemberError::UserError(map.next_value()?)),
-                            None => Err(de::Error::missing_field("user_error")),
-                            _ => Err(de::Error::unknown_field(tag, VARIANTS))
+                            Some("user_error") => RemoveFileMemberError::UserError(map.next_value()?),
+                            None => return Err(de::Error::missing_field("user_error")),
+                            _ => return Err(de::Error::unknown_field(tag, VARIANTS))
                         }
                     }
                     "access_error" => {
                         match map.next_key()? {
-                            Some("access_error") => Ok(RemoveFileMemberError::AccessError(map.next_value()?)),
-                            None => Err(de::Error::missing_field("access_error")),
-                            _ => Err(de::Error::unknown_field(tag, VARIANTS))
+                            Some("access_error") => RemoveFileMemberError::AccessError(map.next_value()?),
+                            None => return Err(de::Error::missing_field("access_error")),
+                            _ => return Err(de::Error::unknown_field(tag, VARIANTS))
                         }
                     }
-                    "no_explicit_access" => Ok(RemoveFileMemberError::NoExplicitAccess(MemberAccessLevelResult::internal_deserialize(map)?)),
-                    _ => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(RemoveFileMemberError::Other)
-                    }
-                }
+                    "no_explicit_access" => RemoveFileMemberError::NoExplicitAccess(MemberAccessLevelResult::internal_deserialize(&mut map)?),
+                    _ => RemoveFileMemberError::Other,
+                };
+                crate::eat_json_fields(&mut map)?;
+                Ok(value)
             }
         }
         const VARIANTS: &[&str] = &["user_error",
@@ -13025,46 +12640,30 @@ impl<'de> ::serde::de::Deserialize<'de> for RemoveFolderMemberError {
                     Some(".tag") => map.next_value()?,
                     _ => return Err(de::Error::missing_field(".tag"))
                 };
-                match tag {
+                let value = match tag {
                     "access_error" => {
                         match map.next_key()? {
-                            Some("access_error") => Ok(RemoveFolderMemberError::AccessError(map.next_value()?)),
-                            None => Err(de::Error::missing_field("access_error")),
-                            _ => Err(de::Error::unknown_field(tag, VARIANTS))
+                            Some("access_error") => RemoveFolderMemberError::AccessError(map.next_value()?),
+                            None => return Err(de::Error::missing_field("access_error")),
+                            _ => return Err(de::Error::unknown_field(tag, VARIANTS))
                         }
                     }
                     "member_error" => {
                         match map.next_key()? {
-                            Some("member_error") => Ok(RemoveFolderMemberError::MemberError(map.next_value()?)),
-                            None => Err(de::Error::missing_field("member_error")),
-                            _ => Err(de::Error::unknown_field(tag, VARIANTS))
+                            Some("member_error") => RemoveFolderMemberError::MemberError(map.next_value()?),
+                            None => return Err(de::Error::missing_field("member_error")),
+                            _ => return Err(de::Error::unknown_field(tag, VARIANTS))
                         }
                     }
-                    "folder_owner" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(RemoveFolderMemberError::FolderOwner)
-                    }
-                    "group_access" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(RemoveFolderMemberError::GroupAccess)
-                    }
-                    "team_folder" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(RemoveFolderMemberError::TeamFolder)
-                    }
-                    "no_permission" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(RemoveFolderMemberError::NoPermission)
-                    }
-                    "too_many_files" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(RemoveFolderMemberError::TooManyFiles)
-                    }
-                    _ => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(RemoveFolderMemberError::Other)
-                    }
-                }
+                    "folder_owner" => RemoveFolderMemberError::FolderOwner,
+                    "group_access" => RemoveFolderMemberError::GroupAccess,
+                    "team_folder" => RemoveFolderMemberError::TeamFolder,
+                    "no_permission" => RemoveFolderMemberError::NoPermission,
+                    "too_many_files" => RemoveFolderMemberError::TooManyFiles,
+                    _ => RemoveFolderMemberError::Other,
+                };
+                crate::eat_json_fields(&mut map)?;
+                Ok(value)
             }
         }
         const VARIANTS: &[&str] = &["access_error",
@@ -13183,21 +12782,20 @@ impl<'de> ::serde::de::Deserialize<'de> for RemoveMemberJobStatus {
                     Some(".tag") => map.next_value()?,
                     _ => return Err(de::Error::missing_field(".tag"))
                 };
-                match tag {
-                    "in_progress" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(RemoveMemberJobStatus::InProgress)
-                    }
-                    "complete" => Ok(RemoveMemberJobStatus::Complete(MemberAccessLevelResult::internal_deserialize(map)?)),
+                let value = match tag {
+                    "in_progress" => RemoveMemberJobStatus::InProgress,
+                    "complete" => RemoveMemberJobStatus::Complete(MemberAccessLevelResult::internal_deserialize(&mut map)?),
                     "failed" => {
                         match map.next_key()? {
-                            Some("failed") => Ok(RemoveMemberJobStatus::Failed(map.next_value()?)),
-                            None => Err(de::Error::missing_field("failed")),
-                            _ => Err(de::Error::unknown_field(tag, VARIANTS))
+                            Some("failed") => RemoveMemberJobStatus::Failed(map.next_value()?),
+                            None => return Err(de::Error::missing_field("failed")),
+                            _ => return Err(de::Error::unknown_field(tag, VARIANTS))
                         }
                     }
-                    _ => Err(de::Error::unknown_variant(tag, VARIANTS))
-                }
+                    _ => return Err(de::Error::unknown_variant(tag, VARIANTS))
+                };
+                crate::eat_json_fields(&mut map)?;
+                Ok(value)
             }
         }
         const VARIANTS: &[&str] = &["in_progress",
@@ -13266,24 +12864,14 @@ impl<'de> ::serde::de::Deserialize<'de> for RequestedLinkAccessLevel {
                     Some(".tag") => map.next_value()?,
                     _ => return Err(de::Error::missing_field(".tag"))
                 };
-                match tag {
-                    "viewer" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(RequestedLinkAccessLevel::Viewer)
-                    }
-                    "editor" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(RequestedLinkAccessLevel::Editor)
-                    }
-                    "max" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(RequestedLinkAccessLevel::Max)
-                    }
-                    _ => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(RequestedLinkAccessLevel::Other)
-                    }
-                }
+                let value = match tag {
+                    "viewer" => RequestedLinkAccessLevel::Viewer,
+                    "editor" => RequestedLinkAccessLevel::Editor,
+                    "max" => RequestedLinkAccessLevel::Max,
+                    _ => RequestedLinkAccessLevel::Other,
+                };
+                crate::eat_json_fields(&mut map)?;
+                Ok(value)
             }
         }
         const VARIANTS: &[&str] = &["viewer",
@@ -13351,21 +12939,14 @@ impl<'de> ::serde::de::Deserialize<'de> for RequestedVisibility {
                     Some(".tag") => map.next_value()?,
                     _ => return Err(de::Error::missing_field(".tag"))
                 };
-                match tag {
-                    "public" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(RequestedVisibility::Public)
-                    }
-                    "team_only" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(RequestedVisibility::TeamOnly)
-                    }
-                    "password" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(RequestedVisibility::Password)
-                    }
-                    _ => Err(de::Error::unknown_variant(tag, VARIANTS))
-                }
+                let value = match tag {
+                    "public" => RequestedVisibility::Public,
+                    "team_only" => RequestedVisibility::TeamOnly,
+                    "password" => RequestedVisibility::Password,
+                    _ => return Err(de::Error::unknown_variant(tag, VARIANTS))
+                };
+                crate::eat_json_fields(&mut map)?;
+                Ok(value)
             }
         }
         const VARIANTS: &[&str] = &["public",
@@ -13440,32 +13021,16 @@ impl<'de> ::serde::de::Deserialize<'de> for ResolvedVisibility {
                     Some(".tag") => map.next_value()?,
                     _ => return Err(de::Error::missing_field(".tag"))
                 };
-                match tag {
-                    "public" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(ResolvedVisibility::Public)
-                    }
-                    "team_only" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(ResolvedVisibility::TeamOnly)
-                    }
-                    "password" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(ResolvedVisibility::Password)
-                    }
-                    "team_and_password" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(ResolvedVisibility::TeamAndPassword)
-                    }
-                    "shared_folder_only" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(ResolvedVisibility::SharedFolderOnly)
-                    }
-                    _ => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(ResolvedVisibility::Other)
-                    }
-                }
+                let value = match tag {
+                    "public" => ResolvedVisibility::Public,
+                    "team_only" => ResolvedVisibility::TeamOnly,
+                    "password" => ResolvedVisibility::Password,
+                    "team_and_password" => ResolvedVisibility::TeamAndPassword,
+                    "shared_folder_only" => ResolvedVisibility::SharedFolderOnly,
+                    _ => ResolvedVisibility::Other,
+                };
+                crate::eat_json_fields(&mut map)?;
+                Ok(value)
             }
         }
         const VARIANTS: &[&str] = &["public",
@@ -13639,28 +13204,15 @@ impl<'de> ::serde::de::Deserialize<'de> for RevokeSharedLinkError {
                     Some(".tag") => map.next_value()?,
                     _ => return Err(de::Error::missing_field(".tag"))
                 };
-                match tag {
-                    "shared_link_not_found" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(RevokeSharedLinkError::SharedLinkNotFound)
-                    }
-                    "shared_link_access_denied" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(RevokeSharedLinkError::SharedLinkAccessDenied)
-                    }
-                    "unsupported_link_type" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(RevokeSharedLinkError::UnsupportedLinkType)
-                    }
-                    "shared_link_malformed" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(RevokeSharedLinkError::SharedLinkMalformed)
-                    }
-                    _ => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(RevokeSharedLinkError::Other)
-                    }
-                }
+                let value = match tag {
+                    "shared_link_not_found" => RevokeSharedLinkError::SharedLinkNotFound,
+                    "shared_link_access_denied" => RevokeSharedLinkError::SharedLinkAccessDenied,
+                    "unsupported_link_type" => RevokeSharedLinkError::UnsupportedLinkType,
+                    "shared_link_malformed" => RevokeSharedLinkError::SharedLinkMalformed,
+                    _ => RevokeSharedLinkError::Other,
+                };
+                crate::eat_json_fields(&mut map)?;
+                Ok(value)
             }
         }
         const VARIANTS: &[&str] = &["shared_link_not_found",
@@ -13855,23 +13407,19 @@ impl<'de> ::serde::de::Deserialize<'de> for SetAccessInheritanceError {
                     Some(".tag") => map.next_value()?,
                     _ => return Err(de::Error::missing_field(".tag"))
                 };
-                match tag {
+                let value = match tag {
                     "access_error" => {
                         match map.next_key()? {
-                            Some("access_error") => Ok(SetAccessInheritanceError::AccessError(map.next_value()?)),
-                            None => Err(de::Error::missing_field("access_error")),
-                            _ => Err(de::Error::unknown_field(tag, VARIANTS))
+                            Some("access_error") => SetAccessInheritanceError::AccessError(map.next_value()?),
+                            None => return Err(de::Error::missing_field("access_error")),
+                            _ => return Err(de::Error::unknown_field(tag, VARIANTS))
                         }
                     }
-                    "no_permission" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(SetAccessInheritanceError::NoPermission)
-                    }
-                    _ => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(SetAccessInheritanceError::Other)
-                    }
-                }
+                    "no_permission" => SetAccessInheritanceError::NoPermission,
+                    _ => SetAccessInheritanceError::Other,
+                };
+                crate::eat_json_fields(&mut map)?;
+                Ok(value)
             }
         }
         const VARIANTS: &[&str] = &["access_error",
@@ -14397,35 +13945,22 @@ impl<'de> ::serde::de::Deserialize<'de> for ShareFolderError {
                     Some(".tag") => map.next_value()?,
                     _ => return Err(de::Error::missing_field(".tag"))
                 };
-                match tag {
-                    "email_unverified" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(ShareFolderError::EmailUnverified)
-                    }
+                let value = match tag {
+                    "email_unverified" => ShareFolderError::EmailUnverified,
                     "bad_path" => {
                         match map.next_key()? {
-                            Some("bad_path") => Ok(ShareFolderError::BadPath(map.next_value()?)),
-                            None => Err(de::Error::missing_field("bad_path")),
-                            _ => Err(de::Error::unknown_field(tag, VARIANTS))
+                            Some("bad_path") => ShareFolderError::BadPath(map.next_value()?),
+                            None => return Err(de::Error::missing_field("bad_path")),
+                            _ => return Err(de::Error::unknown_field(tag, VARIANTS))
                         }
                     }
-                    "team_policy_disallows_member_policy" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(ShareFolderError::TeamPolicyDisallowsMemberPolicy)
-                    }
-                    "disallowed_shared_link_policy" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(ShareFolderError::DisallowedSharedLinkPolicy)
-                    }
-                    "no_permission" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(ShareFolderError::NoPermission)
-                    }
-                    _ => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(ShareFolderError::Other)
-                    }
-                }
+                    "team_policy_disallows_member_policy" => ShareFolderError::TeamPolicyDisallowsMemberPolicy,
+                    "disallowed_shared_link_policy" => ShareFolderError::DisallowedSharedLinkPolicy,
+                    "no_permission" => ShareFolderError::NoPermission,
+                    _ => ShareFolderError::Other,
+                };
+                crate::eat_json_fields(&mut map)?;
+                Ok(value)
             }
         }
         const VARIANTS: &[&str] = &["email_unverified",
@@ -14532,31 +14067,21 @@ impl<'de> ::serde::de::Deserialize<'de> for ShareFolderErrorBase {
                     Some(".tag") => map.next_value()?,
                     _ => return Err(de::Error::missing_field(".tag"))
                 };
-                match tag {
-                    "email_unverified" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(ShareFolderErrorBase::EmailUnverified)
-                    }
+                let value = match tag {
+                    "email_unverified" => ShareFolderErrorBase::EmailUnverified,
                     "bad_path" => {
                         match map.next_key()? {
-                            Some("bad_path") => Ok(ShareFolderErrorBase::BadPath(map.next_value()?)),
-                            None => Err(de::Error::missing_field("bad_path")),
-                            _ => Err(de::Error::unknown_field(tag, VARIANTS))
+                            Some("bad_path") => ShareFolderErrorBase::BadPath(map.next_value()?),
+                            None => return Err(de::Error::missing_field("bad_path")),
+                            _ => return Err(de::Error::unknown_field(tag, VARIANTS))
                         }
                     }
-                    "team_policy_disallows_member_policy" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(ShareFolderErrorBase::TeamPolicyDisallowsMemberPolicy)
-                    }
-                    "disallowed_shared_link_policy" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(ShareFolderErrorBase::DisallowedSharedLinkPolicy)
-                    }
-                    _ => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(ShareFolderErrorBase::Other)
-                    }
-                }
+                    "team_policy_disallows_member_policy" => ShareFolderErrorBase::TeamPolicyDisallowsMemberPolicy,
+                    "disallowed_shared_link_policy" => ShareFolderErrorBase::DisallowedSharedLinkPolicy,
+                    _ => ShareFolderErrorBase::Other,
+                };
+                crate::eat_json_fields(&mut map)?;
+                Ok(value)
             }
         }
         const VARIANTS: &[&str] = &["email_unverified",
@@ -14627,21 +14152,20 @@ impl<'de> ::serde::de::Deserialize<'de> for ShareFolderJobStatus {
                     Some(".tag") => map.next_value()?,
                     _ => return Err(de::Error::missing_field(".tag"))
                 };
-                match tag {
-                    "in_progress" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(ShareFolderJobStatus::InProgress)
-                    }
-                    "complete" => Ok(ShareFolderJobStatus::Complete(SharedFolderMetadata::internal_deserialize(map)?)),
+                let value = match tag {
+                    "in_progress" => ShareFolderJobStatus::InProgress,
+                    "complete" => ShareFolderJobStatus::Complete(SharedFolderMetadata::internal_deserialize(&mut map)?),
                     "failed" => {
                         match map.next_key()? {
-                            Some("failed") => Ok(ShareFolderJobStatus::Failed(map.next_value()?)),
-                            None => Err(de::Error::missing_field("failed")),
-                            _ => Err(de::Error::unknown_field(tag, VARIANTS))
+                            Some("failed") => ShareFolderJobStatus::Failed(map.next_value()?),
+                            None => return Err(de::Error::missing_field("failed")),
+                            _ => return Err(de::Error::unknown_field(tag, VARIANTS))
                         }
                     }
-                    _ => Err(de::Error::unknown_variant(tag, VARIANTS))
-                }
+                    _ => return Err(de::Error::unknown_variant(tag, VARIANTS))
+                };
+                crate::eat_json_fields(&mut map)?;
+                Ok(value)
             }
         }
         const VARIANTS: &[&str] = &["in_progress",
@@ -14703,17 +14227,19 @@ impl<'de> ::serde::de::Deserialize<'de> for ShareFolderLaunch {
                     Some(".tag") => map.next_value()?,
                     _ => return Err(de::Error::missing_field(".tag"))
                 };
-                match tag {
+                let value = match tag {
                     "async_job_id" => {
                         match map.next_key()? {
-                            Some("async_job_id") => Ok(ShareFolderLaunch::AsyncJobId(map.next_value()?)),
-                            None => Err(de::Error::missing_field("async_job_id")),
-                            _ => Err(de::Error::unknown_field(tag, VARIANTS))
+                            Some("async_job_id") => ShareFolderLaunch::AsyncJobId(map.next_value()?),
+                            None => return Err(de::Error::missing_field("async_job_id")),
+                            _ => return Err(de::Error::unknown_field(tag, VARIANTS))
                         }
                     }
-                    "complete" => Ok(ShareFolderLaunch::Complete(SharedFolderMetadata::internal_deserialize(map)?)),
-                    _ => Err(de::Error::unknown_variant(tag, VARIANTS))
-                }
+                    "complete" => ShareFolderLaunch::Complete(SharedFolderMetadata::internal_deserialize(&mut map)?),
+                    _ => return Err(de::Error::unknown_variant(tag, VARIANTS))
+                };
+                crate::eat_json_fields(&mut map)?;
+                Ok(value)
             }
         }
         const VARIANTS: &[&str] = &["async_job_id",
@@ -14798,69 +14324,26 @@ impl<'de> ::serde::de::Deserialize<'de> for SharePathError {
                     Some(".tag") => map.next_value()?,
                     _ => return Err(de::Error::missing_field(".tag"))
                 };
-                match tag {
-                    "is_file" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(SharePathError::IsFile)
-                    }
-                    "inside_shared_folder" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(SharePathError::InsideSharedFolder)
-                    }
-                    "contains_shared_folder" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(SharePathError::ContainsSharedFolder)
-                    }
-                    "contains_app_folder" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(SharePathError::ContainsAppFolder)
-                    }
-                    "contains_team_folder" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(SharePathError::ContainsTeamFolder)
-                    }
-                    "is_app_folder" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(SharePathError::IsAppFolder)
-                    }
-                    "inside_app_folder" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(SharePathError::InsideAppFolder)
-                    }
-                    "is_public_folder" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(SharePathError::IsPublicFolder)
-                    }
-                    "inside_public_folder" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(SharePathError::InsidePublicFolder)
-                    }
-                    "already_shared" => Ok(SharePathError::AlreadyShared(SharedFolderMetadata::internal_deserialize(map)?)),
-                    "invalid_path" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(SharePathError::InvalidPath)
-                    }
-                    "is_osx_package" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(SharePathError::IsOsxPackage)
-                    }
-                    "inside_osx_package" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(SharePathError::InsideOsxPackage)
-                    }
-                    "is_vault" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(SharePathError::IsVault)
-                    }
-                    "is_family" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(SharePathError::IsFamily)
-                    }
-                    _ => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(SharePathError::Other)
-                    }
-                }
+                let value = match tag {
+                    "is_file" => SharePathError::IsFile,
+                    "inside_shared_folder" => SharePathError::InsideSharedFolder,
+                    "contains_shared_folder" => SharePathError::ContainsSharedFolder,
+                    "contains_app_folder" => SharePathError::ContainsAppFolder,
+                    "contains_team_folder" => SharePathError::ContainsTeamFolder,
+                    "is_app_folder" => SharePathError::IsAppFolder,
+                    "inside_app_folder" => SharePathError::InsideAppFolder,
+                    "is_public_folder" => SharePathError::IsPublicFolder,
+                    "inside_public_folder" => SharePathError::InsidePublicFolder,
+                    "already_shared" => SharePathError::AlreadyShared(SharedFolderMetadata::internal_deserialize(&mut map)?),
+                    "invalid_path" => SharePathError::InvalidPath,
+                    "is_osx_package" => SharePathError::IsOsxPackage,
+                    "inside_osx_package" => SharePathError::InsideOsxPackage,
+                    "is_vault" => SharePathError::IsVault,
+                    "is_family" => SharePathError::IsFamily,
+                    _ => SharePathError::Other,
+                };
+                crate::eat_json_fields(&mut map)?;
+                Ok(value)
             }
         }
         const VARIANTS: &[&str] = &["is_file",
@@ -15940,28 +15423,15 @@ impl<'de> ::serde::de::Deserialize<'de> for SharedFolderAccessError {
                     Some(".tag") => map.next_value()?,
                     _ => return Err(de::Error::missing_field(".tag"))
                 };
-                match tag {
-                    "invalid_id" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(SharedFolderAccessError::InvalidId)
-                    }
-                    "not_a_member" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(SharedFolderAccessError::NotAMember)
-                    }
-                    "email_unverified" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(SharedFolderAccessError::EmailUnverified)
-                    }
-                    "unmounted" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(SharedFolderAccessError::Unmounted)
-                    }
-                    _ => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(SharedFolderAccessError::Other)
-                    }
-                }
+                let value = match tag {
+                    "invalid_id" => SharedFolderAccessError::InvalidId,
+                    "not_a_member" => SharedFolderAccessError::NotAMember,
+                    "email_unverified" => SharedFolderAccessError::EmailUnverified,
+                    "unmounted" => SharedFolderAccessError::Unmounted,
+                    _ => SharedFolderAccessError::Other,
+                };
+                crate::eat_json_fields(&mut map)?;
+                Ok(value)
             }
         }
         const VARIANTS: &[&str] = &["invalid_id",
@@ -16051,21 +15521,14 @@ impl<'de> ::serde::de::Deserialize<'de> for SharedFolderMemberError {
                     Some(".tag") => map.next_value()?,
                     _ => return Err(de::Error::missing_field(".tag"))
                 };
-                match tag {
-                    "invalid_dropbox_id" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(SharedFolderMemberError::InvalidDropboxId)
-                    }
-                    "not_a_member" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(SharedFolderMemberError::NotAMember)
-                    }
-                    "no_explicit_access" => Ok(SharedFolderMemberError::NoExplicitAccess(MemberAccessLevelResult::internal_deserialize(map)?)),
-                    _ => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(SharedFolderMemberError::Other)
-                    }
-                }
+                let value = match tag {
+                    "invalid_dropbox_id" => SharedFolderMemberError::InvalidDropboxId,
+                    "not_a_member" => SharedFolderMemberError::NotAMember,
+                    "no_explicit_access" => SharedFolderMemberError::NoExplicitAccess(MemberAccessLevelResult::internal_deserialize(&mut map)?),
+                    _ => SharedFolderMemberError::Other,
+                };
+                crate::eat_json_fields(&mut map)?;
+                Ok(value)
             }
         }
         const VARIANTS: &[&str] = &["invalid_dropbox_id",
@@ -16851,32 +16314,16 @@ impl<'de> ::serde::de::Deserialize<'de> for SharedLinkAccessFailureReason {
                     Some(".tag") => map.next_value()?,
                     _ => return Err(de::Error::missing_field(".tag"))
                 };
-                match tag {
-                    "login_required" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(SharedLinkAccessFailureReason::LoginRequired)
-                    }
-                    "email_verify_required" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(SharedLinkAccessFailureReason::EmailVerifyRequired)
-                    }
-                    "password_required" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(SharedLinkAccessFailureReason::PasswordRequired)
-                    }
-                    "team_only" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(SharedLinkAccessFailureReason::TeamOnly)
-                    }
-                    "owner_only" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(SharedLinkAccessFailureReason::OwnerOnly)
-                    }
-                    _ => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(SharedLinkAccessFailureReason::Other)
-                    }
-                }
+                let value = match tag {
+                    "login_required" => SharedLinkAccessFailureReason::LoginRequired,
+                    "email_verify_required" => SharedLinkAccessFailureReason::EmailVerifyRequired,
+                    "password_required" => SharedLinkAccessFailureReason::PasswordRequired,
+                    "team_only" => SharedLinkAccessFailureReason::TeamOnly,
+                    "owner_only" => SharedLinkAccessFailureReason::OwnerOnly,
+                    _ => SharedLinkAccessFailureReason::Other,
+                };
+                crate::eat_json_fields(&mut map)?;
+                Ok(value)
             }
         }
         const VARIANTS: &[&str] = &["login_required",
@@ -16954,19 +16401,18 @@ impl<'de> ::serde::de::Deserialize<'de> for SharedLinkAlreadyExistsMetadata {
                     Some(".tag") => map.next_value()?,
                     _ => return Err(de::Error::missing_field(".tag"))
                 };
-                match tag {
+                let value = match tag {
                     "metadata" => {
                         match map.next_key()? {
-                            Some("metadata") => Ok(SharedLinkAlreadyExistsMetadata::Metadata(map.next_value()?)),
-                            None => Err(de::Error::missing_field("metadata")),
-                            _ => Err(de::Error::unknown_field(tag, VARIANTS))
+                            Some("metadata") => SharedLinkAlreadyExistsMetadata::Metadata(map.next_value()?),
+                            None => return Err(de::Error::missing_field("metadata")),
+                            _ => return Err(de::Error::unknown_field(tag, VARIANTS))
                         }
                     }
-                    _ => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(SharedLinkAlreadyExistsMetadata::Other)
-                    }
-                }
+                    _ => SharedLinkAlreadyExistsMetadata::Other,
+                };
+                crate::eat_json_fields(&mut map)?;
+                Ok(value)
             }
         }
         const VARIANTS: &[&str] = &["metadata",
@@ -17021,24 +16467,14 @@ impl<'de> ::serde::de::Deserialize<'de> for SharedLinkError {
                     Some(".tag") => map.next_value()?,
                     _ => return Err(de::Error::missing_field(".tag"))
                 };
-                match tag {
-                    "shared_link_not_found" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(SharedLinkError::SharedLinkNotFound)
-                    }
-                    "shared_link_access_denied" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(SharedLinkError::SharedLinkAccessDenied)
-                    }
-                    "unsupported_link_type" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(SharedLinkError::UnsupportedLinkType)
-                    }
-                    _ => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(SharedLinkError::Other)
-                    }
-                }
+                let value = match tag {
+                    "shared_link_not_found" => SharedLinkError::SharedLinkNotFound,
+                    "shared_link_access_denied" => SharedLinkError::SharedLinkAccessDenied,
+                    "unsupported_link_type" => SharedLinkError::UnsupportedLinkType,
+                    _ => SharedLinkError::Other,
+                };
+                crate::eat_json_fields(&mut map)?;
+                Ok(value)
             }
         }
         const VARIANTS: &[&str] = &["shared_link_not_found",
@@ -17202,24 +16638,14 @@ impl<'de> ::serde::de::Deserialize<'de> for SharedLinkPolicy {
                     Some(".tag") => map.next_value()?,
                     _ => return Err(de::Error::missing_field(".tag"))
                 };
-                match tag {
-                    "anyone" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(SharedLinkPolicy::Anyone)
-                    }
-                    "team" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(SharedLinkPolicy::Team)
-                    }
-                    "members" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(SharedLinkPolicy::Members)
-                    }
-                    _ => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(SharedLinkPolicy::Other)
-                    }
-                }
+                let value = match tag {
+                    "anyone" => SharedLinkPolicy::Anyone,
+                    "team" => SharedLinkPolicy::Team,
+                    "members" => SharedLinkPolicy::Members,
+                    _ => SharedLinkPolicy::Other,
+                };
+                crate::eat_json_fields(&mut map)?;
+                Ok(value)
             }
         }
         const VARIANTS: &[&str] = &["anyone",
@@ -17452,17 +16878,13 @@ impl<'de> ::serde::de::Deserialize<'de> for SharedLinkSettingsError {
                     Some(".tag") => map.next_value()?,
                     _ => return Err(de::Error::missing_field(".tag"))
                 };
-                match tag {
-                    "invalid_settings" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(SharedLinkSettingsError::InvalidSettings)
-                    }
-                    "not_authorized" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(SharedLinkSettingsError::NotAuthorized)
-                    }
-                    _ => Err(de::Error::unknown_variant(tag, VARIANTS))
-                }
+                let value = match tag {
+                    "invalid_settings" => SharedLinkSettingsError::InvalidSettings,
+                    "not_authorized" => SharedLinkSettingsError::NotAuthorized,
+                    _ => return Err(de::Error::unknown_variant(tag, VARIANTS))
+                };
+                crate::eat_json_fields(&mut map)?;
+                Ok(value)
             }
         }
         const VARIANTS: &[&str] = &["invalid_settings",
@@ -17535,32 +16957,16 @@ impl<'de> ::serde::de::Deserialize<'de> for SharingFileAccessError {
                     Some(".tag") => map.next_value()?,
                     _ => return Err(de::Error::missing_field(".tag"))
                 };
-                match tag {
-                    "no_permission" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(SharingFileAccessError::NoPermission)
-                    }
-                    "invalid_file" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(SharingFileAccessError::InvalidFile)
-                    }
-                    "is_folder" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(SharingFileAccessError::IsFolder)
-                    }
-                    "inside_public_folder" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(SharingFileAccessError::InsidePublicFolder)
-                    }
-                    "inside_osx_package" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(SharingFileAccessError::InsideOsxPackage)
-                    }
-                    _ => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(SharingFileAccessError::Other)
-                    }
-                }
+                let value = match tag {
+                    "no_permission" => SharingFileAccessError::NoPermission,
+                    "invalid_file" => SharingFileAccessError::InvalidFile,
+                    "is_folder" => SharingFileAccessError::IsFolder,
+                    "inside_public_folder" => SharingFileAccessError::InsidePublicFolder,
+                    "inside_osx_package" => SharingFileAccessError::InsideOsxPackage,
+                    _ => SharingFileAccessError::Other,
+                };
+                crate::eat_json_fields(&mut map)?;
+                Ok(value)
             }
         }
         const VARIANTS: &[&str] = &["no_permission",
@@ -17657,16 +17063,12 @@ impl<'de> ::serde::de::Deserialize<'de> for SharingUserError {
                     Some(".tag") => map.next_value()?,
                     _ => return Err(de::Error::missing_field(".tag"))
                 };
-                match tag {
-                    "email_unverified" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(SharingUserError::EmailUnverified)
-                    }
-                    _ => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(SharingUserError::Other)
-                    }
-                }
+                let value = match tag {
+                    "email_unverified" => SharingUserError::EmailUnverified,
+                    _ => SharingUserError::Other,
+                };
+                crate::eat_json_fields(&mut map)?;
+                Ok(value)
             }
         }
         const VARIANTS: &[&str] = &["email_unverified",
@@ -17964,43 +17366,24 @@ impl<'de> ::serde::de::Deserialize<'de> for TransferFolderError {
                     Some(".tag") => map.next_value()?,
                     _ => return Err(de::Error::missing_field(".tag"))
                 };
-                match tag {
+                let value = match tag {
                     "access_error" => {
                         match map.next_key()? {
-                            Some("access_error") => Ok(TransferFolderError::AccessError(map.next_value()?)),
-                            None => Err(de::Error::missing_field("access_error")),
-                            _ => Err(de::Error::unknown_field(tag, VARIANTS))
+                            Some("access_error") => TransferFolderError::AccessError(map.next_value()?),
+                            None => return Err(de::Error::missing_field("access_error")),
+                            _ => return Err(de::Error::unknown_field(tag, VARIANTS))
                         }
                     }
-                    "invalid_dropbox_id" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(TransferFolderError::InvalidDropboxId)
-                    }
-                    "new_owner_not_a_member" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(TransferFolderError::NewOwnerNotAMember)
-                    }
-                    "new_owner_unmounted" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(TransferFolderError::NewOwnerUnmounted)
-                    }
-                    "new_owner_email_unverified" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(TransferFolderError::NewOwnerEmailUnverified)
-                    }
-                    "team_folder" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(TransferFolderError::TeamFolder)
-                    }
-                    "no_permission" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(TransferFolderError::NoPermission)
-                    }
-                    _ => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(TransferFolderError::Other)
-                    }
-                }
+                    "invalid_dropbox_id" => TransferFolderError::InvalidDropboxId,
+                    "new_owner_not_a_member" => TransferFolderError::NewOwnerNotAMember,
+                    "new_owner_unmounted" => TransferFolderError::NewOwnerUnmounted,
+                    "new_owner_email_unverified" => TransferFolderError::NewOwnerEmailUnverified,
+                    "team_folder" => TransferFolderError::TeamFolder,
+                    "no_permission" => TransferFolderError::NoPermission,
+                    _ => TransferFolderError::Other,
+                };
+                crate::eat_json_fields(&mut map)?;
+                Ok(value)
             }
         }
         const VARIANTS: &[&str] = &["access_error",
@@ -18209,27 +17592,20 @@ impl<'de> ::serde::de::Deserialize<'de> for UnmountFolderError {
                     Some(".tag") => map.next_value()?,
                     _ => return Err(de::Error::missing_field(".tag"))
                 };
-                match tag {
+                let value = match tag {
                     "access_error" => {
                         match map.next_key()? {
-                            Some("access_error") => Ok(UnmountFolderError::AccessError(map.next_value()?)),
-                            None => Err(de::Error::missing_field("access_error")),
-                            _ => Err(de::Error::unknown_field(tag, VARIANTS))
+                            Some("access_error") => UnmountFolderError::AccessError(map.next_value()?),
+                            None => return Err(de::Error::missing_field("access_error")),
+                            _ => return Err(de::Error::unknown_field(tag, VARIANTS))
                         }
                     }
-                    "no_permission" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(UnmountFolderError::NoPermission)
-                    }
-                    "not_unmountable" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(UnmountFolderError::NotUnmountable)
-                    }
-                    _ => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(UnmountFolderError::Other)
-                    }
-                }
+                    "no_permission" => UnmountFolderError::NoPermission,
+                    "not_unmountable" => UnmountFolderError::NotUnmountable,
+                    _ => UnmountFolderError::Other,
+                };
+                crate::eat_json_fields(&mut map)?;
+                Ok(value)
             }
         }
         const VARIANTS: &[&str] = &["access_error",
@@ -18406,26 +17782,25 @@ impl<'de> ::serde::de::Deserialize<'de> for UnshareFileError {
                     Some(".tag") => map.next_value()?,
                     _ => return Err(de::Error::missing_field(".tag"))
                 };
-                match tag {
+                let value = match tag {
                     "user_error" => {
                         match map.next_key()? {
-                            Some("user_error") => Ok(UnshareFileError::UserError(map.next_value()?)),
-                            None => Err(de::Error::missing_field("user_error")),
-                            _ => Err(de::Error::unknown_field(tag, VARIANTS))
+                            Some("user_error") => UnshareFileError::UserError(map.next_value()?),
+                            None => return Err(de::Error::missing_field("user_error")),
+                            _ => return Err(de::Error::unknown_field(tag, VARIANTS))
                         }
                     }
                     "access_error" => {
                         match map.next_key()? {
-                            Some("access_error") => Ok(UnshareFileError::AccessError(map.next_value()?)),
-                            None => Err(de::Error::missing_field("access_error")),
-                            _ => Err(de::Error::unknown_field(tag, VARIANTS))
+                            Some("access_error") => UnshareFileError::AccessError(map.next_value()?),
+                            None => return Err(de::Error::missing_field("access_error")),
+                            _ => return Err(de::Error::unknown_field(tag, VARIANTS))
                         }
                     }
-                    _ => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(UnshareFileError::Other)
-                    }
-                }
+                    _ => UnshareFileError::Other,
+                };
+                crate::eat_json_fields(&mut map)?;
+                Ok(value)
             }
         }
         const VARIANTS: &[&str] = &["user_error",
@@ -18619,31 +17994,21 @@ impl<'de> ::serde::de::Deserialize<'de> for UnshareFolderError {
                     Some(".tag") => map.next_value()?,
                     _ => return Err(de::Error::missing_field(".tag"))
                 };
-                match tag {
+                let value = match tag {
                     "access_error" => {
                         match map.next_key()? {
-                            Some("access_error") => Ok(UnshareFolderError::AccessError(map.next_value()?)),
-                            None => Err(de::Error::missing_field("access_error")),
-                            _ => Err(de::Error::unknown_field(tag, VARIANTS))
+                            Some("access_error") => UnshareFolderError::AccessError(map.next_value()?),
+                            None => return Err(de::Error::missing_field("access_error")),
+                            _ => return Err(de::Error::unknown_field(tag, VARIANTS))
                         }
                     }
-                    "team_folder" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(UnshareFolderError::TeamFolder)
-                    }
-                    "no_permission" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(UnshareFolderError::NoPermission)
-                    }
-                    "too_many_files" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(UnshareFolderError::TooManyFiles)
-                    }
-                    _ => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(UnshareFolderError::Other)
-                    }
-                }
+                    "team_folder" => UnshareFolderError::TeamFolder,
+                    "no_permission" => UnshareFolderError::NoPermission,
+                    "too_many_files" => UnshareFolderError::TooManyFiles,
+                    _ => UnshareFolderError::Other,
+                };
+                crate::eat_json_fields(&mut map)?;
+                Ok(value)
             }
         }
         const VARIANTS: &[&str] = &["access_error",
@@ -18983,41 +18348,34 @@ impl<'de> ::serde::de::Deserialize<'de> for UpdateFolderMemberError {
                     Some(".tag") => map.next_value()?,
                     _ => return Err(de::Error::missing_field(".tag"))
                 };
-                match tag {
+                let value = match tag {
                     "access_error" => {
                         match map.next_key()? {
-                            Some("access_error") => Ok(UpdateFolderMemberError::AccessError(map.next_value()?)),
-                            None => Err(de::Error::missing_field("access_error")),
-                            _ => Err(de::Error::unknown_field(tag, VARIANTS))
+                            Some("access_error") => UpdateFolderMemberError::AccessError(map.next_value()?),
+                            None => return Err(de::Error::missing_field("access_error")),
+                            _ => return Err(de::Error::unknown_field(tag, VARIANTS))
                         }
                     }
                     "member_error" => {
                         match map.next_key()? {
-                            Some("member_error") => Ok(UpdateFolderMemberError::MemberError(map.next_value()?)),
-                            None => Err(de::Error::missing_field("member_error")),
-                            _ => Err(de::Error::unknown_field(tag, VARIANTS))
+                            Some("member_error") => UpdateFolderMemberError::MemberError(map.next_value()?),
+                            None => return Err(de::Error::missing_field("member_error")),
+                            _ => return Err(de::Error::unknown_field(tag, VARIANTS))
                         }
                     }
                     "no_explicit_access" => {
                         match map.next_key()? {
-                            Some("no_explicit_access") => Ok(UpdateFolderMemberError::NoExplicitAccess(map.next_value()?)),
-                            None => Err(de::Error::missing_field("no_explicit_access")),
-                            _ => Err(de::Error::unknown_field(tag, VARIANTS))
+                            Some("no_explicit_access") => UpdateFolderMemberError::NoExplicitAccess(map.next_value()?),
+                            None => return Err(de::Error::missing_field("no_explicit_access")),
+                            _ => return Err(de::Error::unknown_field(tag, VARIANTS))
                         }
                     }
-                    "insufficient_plan" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(UpdateFolderMemberError::InsufficientPlan)
-                    }
-                    "no_permission" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(UpdateFolderMemberError::NoPermission)
-                    }
-                    _ => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(UpdateFolderMemberError::Other)
-                    }
-                }
+                    "insufficient_plan" => UpdateFolderMemberError::InsufficientPlan,
+                    "no_permission" => UpdateFolderMemberError::NoPermission,
+                    _ => UpdateFolderMemberError::Other,
+                };
+                crate::eat_json_fields(&mut map)?;
+                Ok(value)
             }
         }
         const VARIANTS: &[&str] = &["access_error",
@@ -19336,39 +18694,23 @@ impl<'de> ::serde::de::Deserialize<'de> for UpdateFolderPolicyError {
                     Some(".tag") => map.next_value()?,
                     _ => return Err(de::Error::missing_field(".tag"))
                 };
-                match tag {
+                let value = match tag {
                     "access_error" => {
                         match map.next_key()? {
-                            Some("access_error") => Ok(UpdateFolderPolicyError::AccessError(map.next_value()?)),
-                            None => Err(de::Error::missing_field("access_error")),
-                            _ => Err(de::Error::unknown_field(tag, VARIANTS))
+                            Some("access_error") => UpdateFolderPolicyError::AccessError(map.next_value()?),
+                            None => return Err(de::Error::missing_field("access_error")),
+                            _ => return Err(de::Error::unknown_field(tag, VARIANTS))
                         }
                     }
-                    "not_on_team" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(UpdateFolderPolicyError::NotOnTeam)
-                    }
-                    "team_policy_disallows_member_policy" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(UpdateFolderPolicyError::TeamPolicyDisallowsMemberPolicy)
-                    }
-                    "disallowed_shared_link_policy" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(UpdateFolderPolicyError::DisallowedSharedLinkPolicy)
-                    }
-                    "no_permission" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(UpdateFolderPolicyError::NoPermission)
-                    }
-                    "team_folder" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(UpdateFolderPolicyError::TeamFolder)
-                    }
-                    _ => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(UpdateFolderPolicyError::Other)
-                    }
-                }
+                    "not_on_team" => UpdateFolderPolicyError::NotOnTeam,
+                    "team_policy_disallows_member_policy" => UpdateFolderPolicyError::TeamPolicyDisallowsMemberPolicy,
+                    "disallowed_shared_link_policy" => UpdateFolderPolicyError::DisallowedSharedLinkPolicy,
+                    "no_permission" => UpdateFolderPolicyError::NoPermission,
+                    "team_folder" => UpdateFolderPolicyError::TeamFolder,
+                    _ => UpdateFolderPolicyError::Other,
+                };
+                crate::eat_json_fields(&mut map)?;
+                Ok(value)
             }
         }
         const VARIANTS: &[&str] = &["access_error",
@@ -19987,20 +19329,13 @@ impl<'de> ::serde::de::Deserialize<'de> for ViewerInfoPolicy {
                     Some(".tag") => map.next_value()?,
                     _ => return Err(de::Error::missing_field(".tag"))
                 };
-                match tag {
-                    "enabled" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(ViewerInfoPolicy::Enabled)
-                    }
-                    "disabled" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(ViewerInfoPolicy::Disabled)
-                    }
-                    _ => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(ViewerInfoPolicy::Other)
-                    }
-                }
+                let value = match tag {
+                    "enabled" => ViewerInfoPolicy::Enabled,
+                    "disabled" => ViewerInfoPolicy::Disabled,
+                    _ => ViewerInfoPolicy::Other,
+                };
+                crate::eat_json_fields(&mut map)?;
+                Ok(value)
             }
         }
         const VARIANTS: &[&str] = &["enabled",
@@ -20068,32 +19403,16 @@ impl<'de> ::serde::de::Deserialize<'de> for Visibility {
                     Some(".tag") => map.next_value()?,
                     _ => return Err(de::Error::missing_field(".tag"))
                 };
-                match tag {
-                    "public" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(Visibility::Public)
-                    }
-                    "team_only" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(Visibility::TeamOnly)
-                    }
-                    "password" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(Visibility::Password)
-                    }
-                    "team_and_password" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(Visibility::TeamAndPassword)
-                    }
-                    "shared_folder_only" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(Visibility::SharedFolderOnly)
-                    }
-                    _ => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(Visibility::Other)
-                    }
-                }
+                let value = match tag {
+                    "public" => Visibility::Public,
+                    "team_only" => Visibility::TeamOnly,
+                    "password" => Visibility::Password,
+                    "team_and_password" => Visibility::TeamAndPassword,
+                    "shared_folder_only" => Visibility::SharedFolderOnly,
+                    _ => Visibility::Other,
+                };
+                crate::eat_json_fields(&mut map)?;
+                Ok(value)
             }
         }
         const VARIANTS: &[&str] = &["public",

--- a/src/generated/team.rs
+++ b/src/generated/team.rs
@@ -1476,69 +1476,68 @@ impl<'de> ::serde::de::Deserialize<'de> for AddSecondaryEmailResult {
                     Some(".tag") => map.next_value()?,
                     _ => return Err(de::Error::missing_field(".tag"))
                 };
-                match tag {
-                    "success" => Ok(AddSecondaryEmailResult::Success(SecondaryEmail::internal_deserialize(map)?)),
+                let value = match tag {
+                    "success" => AddSecondaryEmailResult::Success(SecondaryEmail::internal_deserialize(&mut map)?),
                     "unavailable" => {
                         match map.next_key()? {
-                            Some("unavailable") => Ok(AddSecondaryEmailResult::Unavailable(map.next_value()?)),
-                            None => Err(de::Error::missing_field("unavailable")),
-                            _ => Err(de::Error::unknown_field(tag, VARIANTS))
+                            Some("unavailable") => AddSecondaryEmailResult::Unavailable(map.next_value()?),
+                            None => return Err(de::Error::missing_field("unavailable")),
+                            _ => return Err(de::Error::unknown_field(tag, VARIANTS))
                         }
                     }
                     "already_pending" => {
                         match map.next_key()? {
-                            Some("already_pending") => Ok(AddSecondaryEmailResult::AlreadyPending(map.next_value()?)),
-                            None => Err(de::Error::missing_field("already_pending")),
-                            _ => Err(de::Error::unknown_field(tag, VARIANTS))
+                            Some("already_pending") => AddSecondaryEmailResult::AlreadyPending(map.next_value()?),
+                            None => return Err(de::Error::missing_field("already_pending")),
+                            _ => return Err(de::Error::unknown_field(tag, VARIANTS))
                         }
                     }
                     "already_owned_by_user" => {
                         match map.next_key()? {
-                            Some("already_owned_by_user") => Ok(AddSecondaryEmailResult::AlreadyOwnedByUser(map.next_value()?)),
-                            None => Err(de::Error::missing_field("already_owned_by_user")),
-                            _ => Err(de::Error::unknown_field(tag, VARIANTS))
+                            Some("already_owned_by_user") => AddSecondaryEmailResult::AlreadyOwnedByUser(map.next_value()?),
+                            None => return Err(de::Error::missing_field("already_owned_by_user")),
+                            _ => return Err(de::Error::unknown_field(tag, VARIANTS))
                         }
                     }
                     "reached_limit" => {
                         match map.next_key()? {
-                            Some("reached_limit") => Ok(AddSecondaryEmailResult::ReachedLimit(map.next_value()?)),
-                            None => Err(de::Error::missing_field("reached_limit")),
-                            _ => Err(de::Error::unknown_field(tag, VARIANTS))
+                            Some("reached_limit") => AddSecondaryEmailResult::ReachedLimit(map.next_value()?),
+                            None => return Err(de::Error::missing_field("reached_limit")),
+                            _ => return Err(de::Error::unknown_field(tag, VARIANTS))
                         }
                     }
                     "transient_error" => {
                         match map.next_key()? {
-                            Some("transient_error") => Ok(AddSecondaryEmailResult::TransientError(map.next_value()?)),
-                            None => Err(de::Error::missing_field("transient_error")),
-                            _ => Err(de::Error::unknown_field(tag, VARIANTS))
+                            Some("transient_error") => AddSecondaryEmailResult::TransientError(map.next_value()?),
+                            None => return Err(de::Error::missing_field("transient_error")),
+                            _ => return Err(de::Error::unknown_field(tag, VARIANTS))
                         }
                     }
                     "too_many_updates" => {
                         match map.next_key()? {
-                            Some("too_many_updates") => Ok(AddSecondaryEmailResult::TooManyUpdates(map.next_value()?)),
-                            None => Err(de::Error::missing_field("too_many_updates")),
-                            _ => Err(de::Error::unknown_field(tag, VARIANTS))
+                            Some("too_many_updates") => AddSecondaryEmailResult::TooManyUpdates(map.next_value()?),
+                            None => return Err(de::Error::missing_field("too_many_updates")),
+                            _ => return Err(de::Error::unknown_field(tag, VARIANTS))
                         }
                     }
                     "unknown_error" => {
                         match map.next_key()? {
-                            Some("unknown_error") => Ok(AddSecondaryEmailResult::UnknownError(map.next_value()?)),
-                            None => Err(de::Error::missing_field("unknown_error")),
-                            _ => Err(de::Error::unknown_field(tag, VARIANTS))
+                            Some("unknown_error") => AddSecondaryEmailResult::UnknownError(map.next_value()?),
+                            None => return Err(de::Error::missing_field("unknown_error")),
+                            _ => return Err(de::Error::unknown_field(tag, VARIANTS))
                         }
                     }
                     "rate_limited" => {
                         match map.next_key()? {
-                            Some("rate_limited") => Ok(AddSecondaryEmailResult::RateLimited(map.next_value()?)),
-                            None => Err(de::Error::missing_field("rate_limited")),
-                            _ => Err(de::Error::unknown_field(tag, VARIANTS))
+                            Some("rate_limited") => AddSecondaryEmailResult::RateLimited(map.next_value()?),
+                            None => return Err(de::Error::missing_field("rate_limited")),
+                            _ => return Err(de::Error::unknown_field(tag, VARIANTS))
                         }
                     }
-                    _ => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(AddSecondaryEmailResult::Other)
-                    }
-                }
+                    _ => AddSecondaryEmailResult::Other,
+                };
+                crate::eat_json_fields(&mut map)?;
+                Ok(value)
             }
         }
         const VARIANTS: &[&str] = &["success",
@@ -1746,20 +1745,13 @@ impl<'de> ::serde::de::Deserialize<'de> for AddSecondaryEmailsError {
                     Some(".tag") => map.next_value()?,
                     _ => return Err(de::Error::missing_field(".tag"))
                 };
-                match tag {
-                    "secondary_emails_disabled" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(AddSecondaryEmailsError::SecondaryEmailsDisabled)
-                    }
-                    "too_many_emails" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(AddSecondaryEmailsError::TooManyEmails)
-                    }
-                    _ => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(AddSecondaryEmailsError::Other)
-                    }
-                }
+                let value = match tag {
+                    "secondary_emails_disabled" => AddSecondaryEmailsError::SecondaryEmailsDisabled,
+                    "too_many_emails" => AddSecondaryEmailsError::TooManyEmails,
+                    _ => AddSecondaryEmailsError::Other,
+                };
+                crate::eat_json_fields(&mut map)?;
+                Ok(value)
             }
         }
         const VARIANTS: &[&str] = &["secondary_emails_disabled",
@@ -1922,25 +1914,15 @@ impl<'de> ::serde::de::Deserialize<'de> for AdminTier {
                     Some(".tag") => map.next_value()?,
                     _ => return Err(de::Error::missing_field(".tag"))
                 };
-                match tag {
-                    "team_admin" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(AdminTier::TeamAdmin)
-                    }
-                    "user_management_admin" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(AdminTier::UserManagementAdmin)
-                    }
-                    "support_admin" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(AdminTier::SupportAdmin)
-                    }
-                    "member_only" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(AdminTier::MemberOnly)
-                    }
-                    _ => Err(de::Error::unknown_variant(tag, VARIANTS))
-                }
+                let value = match tag {
+                    "team_admin" => AdminTier::TeamAdmin,
+                    "user_management_admin" => AdminTier::UserManagementAdmin,
+                    "support_admin" => AdminTier::SupportAdmin,
+                    "member_only" => AdminTier::MemberOnly,
+                    _ => return Err(de::Error::unknown_variant(tag, VARIANTS))
+                };
+                crate::eat_json_fields(&mut map)?;
+                Ok(value)
             }
         }
         const VARIANTS: &[&str] = &["team_admin",
@@ -2273,33 +2255,32 @@ impl<'de> ::serde::de::Deserialize<'de> for BaseTeamFolderError {
                     Some(".tag") => map.next_value()?,
                     _ => return Err(de::Error::missing_field(".tag"))
                 };
-                match tag {
+                let value = match tag {
                     "access_error" => {
                         match map.next_key()? {
-                            Some("access_error") => Ok(BaseTeamFolderError::AccessError(map.next_value()?)),
-                            None => Err(de::Error::missing_field("access_error")),
-                            _ => Err(de::Error::unknown_field(tag, VARIANTS))
+                            Some("access_error") => BaseTeamFolderError::AccessError(map.next_value()?),
+                            None => return Err(de::Error::missing_field("access_error")),
+                            _ => return Err(de::Error::unknown_field(tag, VARIANTS))
                         }
                     }
                     "status_error" => {
                         match map.next_key()? {
-                            Some("status_error") => Ok(BaseTeamFolderError::StatusError(map.next_value()?)),
-                            None => Err(de::Error::missing_field("status_error")),
-                            _ => Err(de::Error::unknown_field(tag, VARIANTS))
+                            Some("status_error") => BaseTeamFolderError::StatusError(map.next_value()?),
+                            None => return Err(de::Error::missing_field("status_error")),
+                            _ => return Err(de::Error::unknown_field(tag, VARIANTS))
                         }
                     }
                     "team_shared_dropbox_error" => {
                         match map.next_key()? {
-                            Some("team_shared_dropbox_error") => Ok(BaseTeamFolderError::TeamSharedDropboxError(map.next_value()?)),
-                            None => Err(de::Error::missing_field("team_shared_dropbox_error")),
-                            _ => Err(de::Error::unknown_field(tag, VARIANTS))
+                            Some("team_shared_dropbox_error") => BaseTeamFolderError::TeamSharedDropboxError(map.next_value()?),
+                            None => return Err(de::Error::missing_field("team_shared_dropbox_error")),
+                            _ => return Err(de::Error::unknown_field(tag, VARIANTS))
                         }
                     }
-                    _ => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(BaseTeamFolderError::Other)
-                    }
-                }
+                    _ => BaseTeamFolderError::Other,
+                };
+                crate::eat_json_fields(&mut map)?;
+                Ok(value)
             }
         }
         const VARIANTS: &[&str] = &["access_error",
@@ -2389,16 +2370,12 @@ impl<'de> ::serde::de::Deserialize<'de> for CustomQuotaError {
                     Some(".tag") => map.next_value()?,
                     _ => return Err(de::Error::missing_field(".tag"))
                 };
-                match tag {
-                    "too_many_users" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(CustomQuotaError::TooManyUsers)
-                    }
-                    _ => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(CustomQuotaError::Other)
-                    }
-                }
+                let value = match tag {
+                    "too_many_users" => CustomQuotaError::TooManyUsers,
+                    _ => CustomQuotaError::Other,
+                };
+                crate::eat_json_fields(&mut map)?;
+                Ok(value)
             }
         }
         const VARIANTS: &[&str] = &["too_many_users",
@@ -2463,20 +2440,19 @@ impl<'de> ::serde::de::Deserialize<'de> for CustomQuotaResult {
                     Some(".tag") => map.next_value()?,
                     _ => return Err(de::Error::missing_field(".tag"))
                 };
-                match tag {
-                    "success" => Ok(CustomQuotaResult::Success(UserCustomQuotaResult::internal_deserialize(map)?)),
+                let value = match tag {
+                    "success" => CustomQuotaResult::Success(UserCustomQuotaResult::internal_deserialize(&mut map)?),
                     "invalid_user" => {
                         match map.next_key()? {
-                            Some("invalid_user") => Ok(CustomQuotaResult::InvalidUser(map.next_value()?)),
-                            None => Err(de::Error::missing_field("invalid_user")),
-                            _ => Err(de::Error::unknown_field(tag, VARIANTS))
+                            Some("invalid_user") => CustomQuotaResult::InvalidUser(map.next_value()?),
+                            None => return Err(de::Error::missing_field("invalid_user")),
+                            _ => return Err(de::Error::unknown_field(tag, VARIANTS))
                         }
                     }
-                    _ => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(CustomQuotaResult::Other)
-                    }
-                }
+                    _ => CustomQuotaResult::Other,
+                };
+                crate::eat_json_fields(&mut map)?;
+                Ok(value)
             }
         }
         const VARIANTS: &[&str] = &["success",
@@ -2790,33 +2766,32 @@ impl<'de> ::serde::de::Deserialize<'de> for DeleteSecondaryEmailResult {
                     Some(".tag") => map.next_value()?,
                     _ => return Err(de::Error::missing_field(".tag"))
                 };
-                match tag {
+                let value = match tag {
                     "success" => {
                         match map.next_key()? {
-                            Some("success") => Ok(DeleteSecondaryEmailResult::Success(map.next_value()?)),
-                            None => Err(de::Error::missing_field("success")),
-                            _ => Err(de::Error::unknown_field(tag, VARIANTS))
+                            Some("success") => DeleteSecondaryEmailResult::Success(map.next_value()?),
+                            None => return Err(de::Error::missing_field("success")),
+                            _ => return Err(de::Error::unknown_field(tag, VARIANTS))
                         }
                     }
                     "not_found" => {
                         match map.next_key()? {
-                            Some("not_found") => Ok(DeleteSecondaryEmailResult::NotFound(map.next_value()?)),
-                            None => Err(de::Error::missing_field("not_found")),
-                            _ => Err(de::Error::unknown_field(tag, VARIANTS))
+                            Some("not_found") => DeleteSecondaryEmailResult::NotFound(map.next_value()?),
+                            None => return Err(de::Error::missing_field("not_found")),
+                            _ => return Err(de::Error::unknown_field(tag, VARIANTS))
                         }
                     }
                     "cannot_remove_primary" => {
                         match map.next_key()? {
-                            Some("cannot_remove_primary") => Ok(DeleteSecondaryEmailResult::CannotRemovePrimary(map.next_value()?)),
-                            None => Err(de::Error::missing_field("cannot_remove_primary")),
-                            _ => Err(de::Error::unknown_field(tag, VARIANTS))
+                            Some("cannot_remove_primary") => DeleteSecondaryEmailResult::CannotRemovePrimary(map.next_value()?),
+                            None => return Err(de::Error::missing_field("cannot_remove_primary")),
+                            _ => return Err(de::Error::unknown_field(tag, VARIANTS))
                         }
                     }
-                    _ => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(DeleteSecondaryEmailResult::Other)
-                    }
-                }
+                    _ => DeleteSecondaryEmailResult::Other,
+                };
+                crate::eat_json_fields(&mut map)?;
+                Ok(value)
             }
         }
         const VARIANTS: &[&str] = &["success",
@@ -3301,24 +3276,14 @@ impl<'de> ::serde::de::Deserialize<'de> for DesktopPlatform {
                     Some(".tag") => map.next_value()?,
                     _ => return Err(de::Error::missing_field(".tag"))
                 };
-                match tag {
-                    "windows" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(DesktopPlatform::Windows)
-                    }
-                    "mac" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(DesktopPlatform::Mac)
-                    }
-                    "linux" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(DesktopPlatform::Linux)
-                    }
-                    _ => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(DesktopPlatform::Other)
-                    }
-                }
+                let value = match tag {
+                    "windows" => DesktopPlatform::Windows,
+                    "mac" => DesktopPlatform::Mac,
+                    "linux" => DesktopPlatform::Linux,
+                    _ => DesktopPlatform::Other,
+                };
+                crate::eat_json_fields(&mut map)?;
+                Ok(value)
             }
         }
         const VARIANTS: &[&str] = &["windows",
@@ -4005,16 +3970,12 @@ impl<'de> ::serde::de::Deserialize<'de> for ExcludedUsersListContinueError {
                     Some(".tag") => map.next_value()?,
                     _ => return Err(de::Error::missing_field(".tag"))
                 };
-                match tag {
-                    "invalid_cursor" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(ExcludedUsersListContinueError::InvalidCursor)
-                    }
-                    _ => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(ExcludedUsersListContinueError::Other)
-                    }
-                }
+                let value = match tag {
+                    "invalid_cursor" => ExcludedUsersListContinueError::InvalidCursor,
+                    _ => ExcludedUsersListContinueError::Other,
+                };
+                crate::eat_json_fields(&mut map)?;
+                Ok(value)
             }
         }
         const VARIANTS: &[&str] = &["invalid_cursor",
@@ -4077,16 +4038,12 @@ impl<'de> ::serde::de::Deserialize<'de> for ExcludedUsersListError {
                     Some(".tag") => map.next_value()?,
                     _ => return Err(de::Error::missing_field(".tag"))
                 };
-                match tag {
-                    "list_error" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(ExcludedUsersListError::ListError)
-                    }
-                    _ => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(ExcludedUsersListError::Other)
-                    }
-                }
+                let value = match tag {
+                    "list_error" => ExcludedUsersListError::ListError,
+                    _ => ExcludedUsersListError::Other,
+                };
+                crate::eat_json_fields(&mut map)?;
+                Ok(value)
             }
         }
         const VARIANTS: &[&str] = &["list_error",
@@ -4365,20 +4322,13 @@ impl<'de> ::serde::de::Deserialize<'de> for ExcludedUsersUpdateError {
                     Some(".tag") => map.next_value()?,
                     _ => return Err(de::Error::missing_field(".tag"))
                 };
-                match tag {
-                    "users_not_in_team" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(ExcludedUsersUpdateError::UsersNotInTeam)
-                    }
-                    "too_many_users" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(ExcludedUsersUpdateError::TooManyUsers)
-                    }
-                    _ => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(ExcludedUsersUpdateError::Other)
-                    }
-                }
+                let value = match tag {
+                    "users_not_in_team" => ExcludedUsersUpdateError::UsersNotInTeam,
+                    "too_many_users" => ExcludedUsersUpdateError::TooManyUsers,
+                    _ => ExcludedUsersUpdateError::Other,
+                };
+                crate::eat_json_fields(&mut map)?;
+                Ok(value)
             }
         }
         const VARIANTS: &[&str] = &["users_not_in_team",
@@ -4540,16 +4490,12 @@ impl<'de> ::serde::de::Deserialize<'de> for ExcludedUsersUpdateStatus {
                     Some(".tag") => map.next_value()?,
                     _ => return Err(de::Error::missing_field(".tag"))
                 };
-                match tag {
-                    "success" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(ExcludedUsersUpdateStatus::Success)
-                    }
-                    _ => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(ExcludedUsersUpdateStatus::Other)
-                    }
-                }
+                let value = match tag {
+                    "success" => ExcludedUsersUpdateStatus::Success,
+                    _ => ExcludedUsersUpdateStatus::Other,
+                };
+                crate::eat_json_fields(&mut map)?;
+                Ok(value)
             }
         }
         const VARIANTS: &[&str] = &["success",
@@ -4606,28 +4552,15 @@ impl<'de> ::serde::de::Deserialize<'de> for Feature {
                     Some(".tag") => map.next_value()?,
                     _ => return Err(de::Error::missing_field(".tag"))
                 };
-                match tag {
-                    "upload_api_rate_limit" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(Feature::UploadApiRateLimit)
-                    }
-                    "has_team_shared_dropbox" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(Feature::HasTeamSharedDropbox)
-                    }
-                    "has_team_file_events" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(Feature::HasTeamFileEvents)
-                    }
-                    "has_team_selective_sync" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(Feature::HasTeamSelectiveSync)
-                    }
-                    _ => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(Feature::Other)
-                    }
-                }
+                let value = match tag {
+                    "upload_api_rate_limit" => Feature::UploadApiRateLimit,
+                    "has_team_shared_dropbox" => Feature::HasTeamSharedDropbox,
+                    "has_team_file_events" => Feature::HasTeamFileEvents,
+                    "has_team_selective_sync" => Feature::HasTeamSelectiveSync,
+                    _ => Feature::Other,
+                };
+                crate::eat_json_fields(&mut map)?;
+                Ok(value)
             }
         }
         const VARIANTS: &[&str] = &["upload_api_rate_limit",
@@ -4702,40 +4635,39 @@ impl<'de> ::serde::de::Deserialize<'de> for FeatureValue {
                     Some(".tag") => map.next_value()?,
                     _ => return Err(de::Error::missing_field(".tag"))
                 };
-                match tag {
+                let value = match tag {
                     "upload_api_rate_limit" => {
                         match map.next_key()? {
-                            Some("upload_api_rate_limit") => Ok(FeatureValue::UploadApiRateLimit(map.next_value()?)),
-                            None => Err(de::Error::missing_field("upload_api_rate_limit")),
-                            _ => Err(de::Error::unknown_field(tag, VARIANTS))
+                            Some("upload_api_rate_limit") => FeatureValue::UploadApiRateLimit(map.next_value()?),
+                            None => return Err(de::Error::missing_field("upload_api_rate_limit")),
+                            _ => return Err(de::Error::unknown_field(tag, VARIANTS))
                         }
                     }
                     "has_team_shared_dropbox" => {
                         match map.next_key()? {
-                            Some("has_team_shared_dropbox") => Ok(FeatureValue::HasTeamSharedDropbox(map.next_value()?)),
-                            None => Err(de::Error::missing_field("has_team_shared_dropbox")),
-                            _ => Err(de::Error::unknown_field(tag, VARIANTS))
+                            Some("has_team_shared_dropbox") => FeatureValue::HasTeamSharedDropbox(map.next_value()?),
+                            None => return Err(de::Error::missing_field("has_team_shared_dropbox")),
+                            _ => return Err(de::Error::unknown_field(tag, VARIANTS))
                         }
                     }
                     "has_team_file_events" => {
                         match map.next_key()? {
-                            Some("has_team_file_events") => Ok(FeatureValue::HasTeamFileEvents(map.next_value()?)),
-                            None => Err(de::Error::missing_field("has_team_file_events")),
-                            _ => Err(de::Error::unknown_field(tag, VARIANTS))
+                            Some("has_team_file_events") => FeatureValue::HasTeamFileEvents(map.next_value()?),
+                            None => return Err(de::Error::missing_field("has_team_file_events")),
+                            _ => return Err(de::Error::unknown_field(tag, VARIANTS))
                         }
                     }
                     "has_team_selective_sync" => {
                         match map.next_key()? {
-                            Some("has_team_selective_sync") => Ok(FeatureValue::HasTeamSelectiveSync(map.next_value()?)),
-                            None => Err(de::Error::missing_field("has_team_selective_sync")),
-                            _ => Err(de::Error::unknown_field(tag, VARIANTS))
+                            Some("has_team_selective_sync") => FeatureValue::HasTeamSelectiveSync(map.next_value()?),
+                            None => return Err(de::Error::missing_field("has_team_selective_sync")),
+                            _ => return Err(de::Error::unknown_field(tag, VARIANTS))
                         }
                     }
-                    _ => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(FeatureValue::Other)
-                    }
-                }
+                    _ => FeatureValue::Other,
+                };
+                crate::eat_json_fields(&mut map)?;
+                Ok(value)
             }
         }
         const VARIANTS: &[&str] = &["upload_api_rate_limit",
@@ -4902,16 +4834,12 @@ impl<'de> ::serde::de::Deserialize<'de> for FeaturesGetValuesBatchError {
                     Some(".tag") => map.next_value()?,
                     _ => return Err(de::Error::missing_field(".tag"))
                 };
-                match tag {
-                    "empty_features_list" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(FeaturesGetValuesBatchError::EmptyFeaturesList)
-                    }
-                    _ => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(FeaturesGetValuesBatchError::Other)
-                    }
-                }
+                let value = match tag {
+                    "empty_features_list" => FeaturesGetValuesBatchError::EmptyFeaturesList,
+                    _ => FeaturesGetValuesBatchError::Other,
+                };
+                crate::eat_json_fields(&mut map)?;
+                Ok(value)
             }
         }
         const VARIANTS: &[&str] = &["empty_features_list",
@@ -5818,17 +5746,13 @@ impl<'de> ::serde::de::Deserialize<'de> for GroupAccessType {
                     Some(".tag") => map.next_value()?,
                     _ => return Err(de::Error::missing_field(".tag"))
                 };
-                match tag {
-                    "member" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(GroupAccessType::Member)
-                    }
-                    "owner" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(GroupAccessType::Owner)
-                    }
-                    _ => Err(de::Error::unknown_variant(tag, VARIANTS))
-                }
+                let value = match tag {
+                    "member" => GroupAccessType::Member,
+                    "owner" => GroupAccessType::Owner,
+                    _ => return Err(de::Error::unknown_variant(tag, VARIANTS))
+                };
+                crate::eat_json_fields(&mut map)?;
+                Ok(value)
             }
         }
         const VARIANTS: &[&str] = &["member",
@@ -6036,28 +5960,15 @@ impl<'de> ::serde::de::Deserialize<'de> for GroupCreateError {
                     Some(".tag") => map.next_value()?,
                     _ => return Err(de::Error::missing_field(".tag"))
                 };
-                match tag {
-                    "group_name_already_used" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(GroupCreateError::GroupNameAlreadyUsed)
-                    }
-                    "group_name_invalid" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(GroupCreateError::GroupNameInvalid)
-                    }
-                    "external_id_already_in_use" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(GroupCreateError::ExternalIdAlreadyInUse)
-                    }
-                    "system_managed_group_disallowed" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(GroupCreateError::SystemManagedGroupDisallowed)
-                    }
-                    _ => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(GroupCreateError::Other)
-                    }
-                }
+                let value = match tag {
+                    "group_name_already_used" => GroupCreateError::GroupNameAlreadyUsed,
+                    "group_name_invalid" => GroupCreateError::GroupNameInvalid,
+                    "external_id_already_in_use" => GroupCreateError::ExternalIdAlreadyInUse,
+                    "system_managed_group_disallowed" => GroupCreateError::SystemManagedGroupDisallowed,
+                    _ => GroupCreateError::Other,
+                };
+                crate::eat_json_fields(&mut map)?;
+                Ok(value)
             }
         }
         const VARIANTS: &[&str] = &["group_name_already_used",
@@ -6147,24 +6058,14 @@ impl<'de> ::serde::de::Deserialize<'de> for GroupDeleteError {
                     Some(".tag") => map.next_value()?,
                     _ => return Err(de::Error::missing_field(".tag"))
                 };
-                match tag {
-                    "group_not_found" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(GroupDeleteError::GroupNotFound)
-                    }
-                    "system_managed_group_disallowed" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(GroupDeleteError::SystemManagedGroupDisallowed)
-                    }
-                    "group_already_deleted" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(GroupDeleteError::GroupAlreadyDeleted)
-                    }
-                    _ => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(GroupDeleteError::Other)
-                    }
-                }
+                let value = match tag {
+                    "group_not_found" => GroupDeleteError::GroupNotFound,
+                    "system_managed_group_disallowed" => GroupDeleteError::SystemManagedGroupDisallowed,
+                    "group_already_deleted" => GroupDeleteError::GroupAlreadyDeleted,
+                    _ => GroupDeleteError::Other,
+                };
+                crate::eat_json_fields(&mut map)?;
+                Ok(value)
             }
         }
         const VARIANTS: &[&str] = &["group_not_found",
@@ -6643,24 +6544,14 @@ impl<'de> ::serde::de::Deserialize<'de> for GroupMemberSelectorError {
                     Some(".tag") => map.next_value()?,
                     _ => return Err(de::Error::missing_field(".tag"))
                 };
-                match tag {
-                    "group_not_found" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(GroupMemberSelectorError::GroupNotFound)
-                    }
-                    "system_managed_group_disallowed" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(GroupMemberSelectorError::SystemManagedGroupDisallowed)
-                    }
-                    "member_not_in_group" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(GroupMemberSelectorError::MemberNotInGroup)
-                    }
-                    _ => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(GroupMemberSelectorError::Other)
-                    }
-                }
+                let value = match tag {
+                    "group_not_found" => GroupMemberSelectorError::GroupNotFound,
+                    "system_managed_group_disallowed" => GroupMemberSelectorError::SystemManagedGroupDisallowed,
+                    "member_not_in_group" => GroupMemberSelectorError::MemberNotInGroup,
+                    _ => GroupMemberSelectorError::Other,
+                };
+                crate::eat_json_fields(&mut map)?;
+                Ok(value)
             }
         }
         const VARIANTS: &[&str] = &["group_not_found",
@@ -6744,28 +6635,15 @@ impl<'de> ::serde::de::Deserialize<'de> for GroupMemberSetAccessTypeError {
                     Some(".tag") => map.next_value()?,
                     _ => return Err(de::Error::missing_field(".tag"))
                 };
-                match tag {
-                    "group_not_found" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(GroupMemberSetAccessTypeError::GroupNotFound)
-                    }
-                    "system_managed_group_disallowed" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(GroupMemberSetAccessTypeError::SystemManagedGroupDisallowed)
-                    }
-                    "member_not_in_group" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(GroupMemberSetAccessTypeError::MemberNotInGroup)
-                    }
-                    "user_cannot_be_manager_of_company_managed_group" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(GroupMemberSetAccessTypeError::UserCannotBeManagerOfCompanyManagedGroup)
-                    }
-                    _ => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(GroupMemberSetAccessTypeError::Other)
-                    }
-                }
+                let value = match tag {
+                    "group_not_found" => GroupMemberSetAccessTypeError::GroupNotFound,
+                    "system_managed_group_disallowed" => GroupMemberSetAccessTypeError::SystemManagedGroupDisallowed,
+                    "member_not_in_group" => GroupMemberSetAccessTypeError::MemberNotInGroup,
+                    "user_cannot_be_manager_of_company_managed_group" => GroupMemberSetAccessTypeError::UserCannotBeManagerOfCompanyManagedGroup,
+                    _ => GroupMemberSetAccessTypeError::Other,
+                };
+                crate::eat_json_fields(&mut map)?;
+                Ok(value)
             }
         }
         const VARIANTS: &[&str] = &["group_not_found",
@@ -6992,53 +6870,37 @@ impl<'de> ::serde::de::Deserialize<'de> for GroupMembersAddError {
                     Some(".tag") => map.next_value()?,
                     _ => return Err(de::Error::missing_field(".tag"))
                 };
-                match tag {
-                    "group_not_found" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(GroupMembersAddError::GroupNotFound)
-                    }
-                    "system_managed_group_disallowed" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(GroupMembersAddError::SystemManagedGroupDisallowed)
-                    }
-                    "duplicate_user" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(GroupMembersAddError::DuplicateUser)
-                    }
-                    "group_not_in_team" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(GroupMembersAddError::GroupNotInTeam)
-                    }
+                let value = match tag {
+                    "group_not_found" => GroupMembersAddError::GroupNotFound,
+                    "system_managed_group_disallowed" => GroupMembersAddError::SystemManagedGroupDisallowed,
+                    "duplicate_user" => GroupMembersAddError::DuplicateUser,
+                    "group_not_in_team" => GroupMembersAddError::GroupNotInTeam,
                     "members_not_in_team" => {
                         match map.next_key()? {
-                            Some("members_not_in_team") => Ok(GroupMembersAddError::MembersNotInTeam(map.next_value()?)),
-                            None => Err(de::Error::missing_field("members_not_in_team")),
-                            _ => Err(de::Error::unknown_field(tag, VARIANTS))
+                            Some("members_not_in_team") => GroupMembersAddError::MembersNotInTeam(map.next_value()?),
+                            None => return Err(de::Error::missing_field("members_not_in_team")),
+                            _ => return Err(de::Error::unknown_field(tag, VARIANTS))
                         }
                     }
                     "users_not_found" => {
                         match map.next_key()? {
-                            Some("users_not_found") => Ok(GroupMembersAddError::UsersNotFound(map.next_value()?)),
-                            None => Err(de::Error::missing_field("users_not_found")),
-                            _ => Err(de::Error::unknown_field(tag, VARIANTS))
+                            Some("users_not_found") => GroupMembersAddError::UsersNotFound(map.next_value()?),
+                            None => return Err(de::Error::missing_field("users_not_found")),
+                            _ => return Err(de::Error::unknown_field(tag, VARIANTS))
                         }
                     }
-                    "user_must_be_active_to_be_owner" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(GroupMembersAddError::UserMustBeActiveToBeOwner)
-                    }
+                    "user_must_be_active_to_be_owner" => GroupMembersAddError::UserMustBeActiveToBeOwner,
                     "user_cannot_be_manager_of_company_managed_group" => {
                         match map.next_key()? {
-                            Some("user_cannot_be_manager_of_company_managed_group") => Ok(GroupMembersAddError::UserCannotBeManagerOfCompanyManagedGroup(map.next_value()?)),
-                            None => Err(de::Error::missing_field("user_cannot_be_manager_of_company_managed_group")),
-                            _ => Err(de::Error::unknown_field(tag, VARIANTS))
+                            Some("user_cannot_be_manager_of_company_managed_group") => GroupMembersAddError::UserCannotBeManagerOfCompanyManagedGroup(map.next_value()?),
+                            None => return Err(de::Error::missing_field("user_cannot_be_manager_of_company_managed_group")),
+                            _ => return Err(de::Error::unknown_field(tag, VARIANTS))
                         }
                     }
-                    _ => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(GroupMembersAddError::Other)
-                    }
-                }
+                    _ => GroupMembersAddError::Other,
+                };
+                crate::eat_json_fields(&mut map)?;
+                Ok(value)
             }
         }
         const VARIANTS: &[&str] = &["group_not_found",
@@ -7399,42 +7261,29 @@ impl<'de> ::serde::de::Deserialize<'de> for GroupMembersRemoveError {
                     Some(".tag") => map.next_value()?,
                     _ => return Err(de::Error::missing_field(".tag"))
                 };
-                match tag {
-                    "group_not_found" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(GroupMembersRemoveError::GroupNotFound)
-                    }
-                    "system_managed_group_disallowed" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(GroupMembersRemoveError::SystemManagedGroupDisallowed)
-                    }
-                    "member_not_in_group" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(GroupMembersRemoveError::MemberNotInGroup)
-                    }
-                    "group_not_in_team" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(GroupMembersRemoveError::GroupNotInTeam)
-                    }
+                let value = match tag {
+                    "group_not_found" => GroupMembersRemoveError::GroupNotFound,
+                    "system_managed_group_disallowed" => GroupMembersRemoveError::SystemManagedGroupDisallowed,
+                    "member_not_in_group" => GroupMembersRemoveError::MemberNotInGroup,
+                    "group_not_in_team" => GroupMembersRemoveError::GroupNotInTeam,
                     "members_not_in_team" => {
                         match map.next_key()? {
-                            Some("members_not_in_team") => Ok(GroupMembersRemoveError::MembersNotInTeam(map.next_value()?)),
-                            None => Err(de::Error::missing_field("members_not_in_team")),
-                            _ => Err(de::Error::unknown_field(tag, VARIANTS))
+                            Some("members_not_in_team") => GroupMembersRemoveError::MembersNotInTeam(map.next_value()?),
+                            None => return Err(de::Error::missing_field("members_not_in_team")),
+                            _ => return Err(de::Error::unknown_field(tag, VARIANTS))
                         }
                     }
                     "users_not_found" => {
                         match map.next_key()? {
-                            Some("users_not_found") => Ok(GroupMembersRemoveError::UsersNotFound(map.next_value()?)),
-                            None => Err(de::Error::missing_field("users_not_found")),
-                            _ => Err(de::Error::unknown_field(tag, VARIANTS))
+                            Some("users_not_found") => GroupMembersRemoveError::UsersNotFound(map.next_value()?),
+                            None => return Err(de::Error::missing_field("users_not_found")),
+                            _ => return Err(de::Error::unknown_field(tag, VARIANTS))
                         }
                     }
-                    _ => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(GroupMembersRemoveError::Other)
-                    }
-                }
+                    _ => GroupMembersRemoveError::Other,
+                };
+                crate::eat_json_fields(&mut map)?;
+                Ok(value)
             }
         }
         const VARIANTS: &[&str] = &["group_not_found",
@@ -7648,24 +7497,14 @@ impl<'de> ::serde::de::Deserialize<'de> for GroupMembersSelectorError {
                     Some(".tag") => map.next_value()?,
                     _ => return Err(de::Error::missing_field(".tag"))
                 };
-                match tag {
-                    "group_not_found" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(GroupMembersSelectorError::GroupNotFound)
-                    }
-                    "system_managed_group_disallowed" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(GroupMembersSelectorError::SystemManagedGroupDisallowed)
-                    }
-                    "member_not_in_group" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(GroupMembersSelectorError::MemberNotInGroup)
-                    }
-                    _ => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(GroupMembersSelectorError::Other)
-                    }
-                }
+                let value = match tag {
+                    "group_not_found" => GroupMembersSelectorError::GroupNotFound,
+                    "system_managed_group_disallowed" => GroupMembersSelectorError::SystemManagedGroupDisallowed,
+                    "member_not_in_group" => GroupMembersSelectorError::MemberNotInGroup,
+                    _ => GroupMembersSelectorError::Other,
+                };
+                crate::eat_json_fields(&mut map)?;
+                Ok(value)
             }
         }
         const VARIANTS: &[&str] = &["group_not_found",
@@ -7878,23 +7717,25 @@ impl<'de> ::serde::de::Deserialize<'de> for GroupSelector {
                     Some(".tag") => map.next_value()?,
                     _ => return Err(de::Error::missing_field(".tag"))
                 };
-                match tag {
+                let value = match tag {
                     "group_id" => {
                         match map.next_key()? {
-                            Some("group_id") => Ok(GroupSelector::GroupId(map.next_value()?)),
-                            None => Err(de::Error::missing_field("group_id")),
-                            _ => Err(de::Error::unknown_field(tag, VARIANTS))
+                            Some("group_id") => GroupSelector::GroupId(map.next_value()?),
+                            None => return Err(de::Error::missing_field("group_id")),
+                            _ => return Err(de::Error::unknown_field(tag, VARIANTS))
                         }
                     }
                     "group_external_id" => {
                         match map.next_key()? {
-                            Some("group_external_id") => Ok(GroupSelector::GroupExternalId(map.next_value()?)),
-                            None => Err(de::Error::missing_field("group_external_id")),
-                            _ => Err(de::Error::unknown_field(tag, VARIANTS))
+                            Some("group_external_id") => GroupSelector::GroupExternalId(map.next_value()?),
+                            None => return Err(de::Error::missing_field("group_external_id")),
+                            _ => return Err(de::Error::unknown_field(tag, VARIANTS))
                         }
                     }
-                    _ => Err(de::Error::unknown_variant(tag, VARIANTS))
-                }
+                    _ => return Err(de::Error::unknown_variant(tag, VARIANTS))
+                };
+                crate::eat_json_fields(&mut map)?;
+                Ok(value)
             }
         }
         const VARIANTS: &[&str] = &["group_id",
@@ -7952,16 +7793,12 @@ impl<'de> ::serde::de::Deserialize<'de> for GroupSelectorError {
                     Some(".tag") => map.next_value()?,
                     _ => return Err(de::Error::missing_field(".tag"))
                 };
-                match tag {
-                    "group_not_found" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(GroupSelectorError::GroupNotFound)
-                    }
-                    _ => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(GroupSelectorError::Other)
-                    }
-                }
+                let value = match tag {
+                    "group_not_found" => GroupSelectorError::GroupNotFound,
+                    _ => GroupSelectorError::Other,
+                };
+                crate::eat_json_fields(&mut map)?;
+                Ok(value)
             }
         }
         const VARIANTS: &[&str] = &["group_not_found",
@@ -8027,20 +7864,13 @@ impl<'de> ::serde::de::Deserialize<'de> for GroupSelectorWithTeamGroupError {
                     Some(".tag") => map.next_value()?,
                     _ => return Err(de::Error::missing_field(".tag"))
                 };
-                match tag {
-                    "group_not_found" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(GroupSelectorWithTeamGroupError::GroupNotFound)
-                    }
-                    "system_managed_group_disallowed" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(GroupSelectorWithTeamGroupError::SystemManagedGroupDisallowed)
-                    }
-                    _ => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(GroupSelectorWithTeamGroupError::Other)
-                    }
-                }
+                let value = match tag {
+                    "group_not_found" => GroupSelectorWithTeamGroupError::GroupNotFound,
+                    "system_managed_group_disallowed" => GroupSelectorWithTeamGroupError::SystemManagedGroupDisallowed,
+                    _ => GroupSelectorWithTeamGroupError::Other,
+                };
+                crate::eat_json_fields(&mut map)?;
+                Ok(value)
             }
         }
         const VARIANTS: &[&str] = &["group_not_found",
@@ -8289,32 +8119,16 @@ impl<'de> ::serde::de::Deserialize<'de> for GroupUpdateError {
                     Some(".tag") => map.next_value()?,
                     _ => return Err(de::Error::missing_field(".tag"))
                 };
-                match tag {
-                    "group_not_found" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(GroupUpdateError::GroupNotFound)
-                    }
-                    "system_managed_group_disallowed" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(GroupUpdateError::SystemManagedGroupDisallowed)
-                    }
-                    "group_name_already_used" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(GroupUpdateError::GroupNameAlreadyUsed)
-                    }
-                    "group_name_invalid" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(GroupUpdateError::GroupNameInvalid)
-                    }
-                    "external_id_already_in_use" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(GroupUpdateError::ExternalIdAlreadyInUse)
-                    }
-                    _ => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(GroupUpdateError::Other)
-                    }
-                }
+                let value = match tag {
+                    "group_not_found" => GroupUpdateError::GroupNotFound,
+                    "system_managed_group_disallowed" => GroupUpdateError::SystemManagedGroupDisallowed,
+                    "group_name_already_used" => GroupUpdateError::GroupNameAlreadyUsed,
+                    "group_name_invalid" => GroupUpdateError::GroupNameInvalid,
+                    "external_id_already_in_use" => GroupUpdateError::ExternalIdAlreadyInUse,
+                    _ => GroupUpdateError::Other,
+                };
+                crate::eat_json_fields(&mut map)?;
+                Ok(value)
             }
         }
         const VARIANTS: &[&str] = &["group_not_found",
@@ -8408,16 +8222,12 @@ impl<'de> ::serde::de::Deserialize<'de> for GroupsGetInfoError {
                     Some(".tag") => map.next_value()?,
                     _ => return Err(de::Error::missing_field(".tag"))
                 };
-                match tag {
-                    "group_not_on_team" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(GroupsGetInfoError::GroupNotOnTeam)
-                    }
-                    _ => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(GroupsGetInfoError::Other)
-                    }
-                }
+                let value = match tag {
+                    "group_not_on_team" => GroupsGetInfoError::GroupNotOnTeam,
+                    _ => GroupsGetInfoError::Other,
+                };
+                crate::eat_json_fields(&mut map)?;
+                Ok(value)
             }
         }
         const VARIANTS: &[&str] = &["group_not_on_team",
@@ -8479,17 +8289,19 @@ impl<'de> ::serde::de::Deserialize<'de> for GroupsGetInfoItem {
                     Some(".tag") => map.next_value()?,
                     _ => return Err(de::Error::missing_field(".tag"))
                 };
-                match tag {
+                let value = match tag {
                     "id_not_found" => {
                         match map.next_key()? {
-                            Some("id_not_found") => Ok(GroupsGetInfoItem::IdNotFound(map.next_value()?)),
-                            None => Err(de::Error::missing_field("id_not_found")),
-                            _ => Err(de::Error::unknown_field(tag, VARIANTS))
+                            Some("id_not_found") => GroupsGetInfoItem::IdNotFound(map.next_value()?),
+                            None => return Err(de::Error::missing_field("id_not_found")),
+                            _ => return Err(de::Error::unknown_field(tag, VARIANTS))
                         }
                     }
-                    "group_info" => Ok(GroupsGetInfoItem::GroupInfo(GroupFullInfo::internal_deserialize(map)?)),
-                    _ => Err(de::Error::unknown_variant(tag, VARIANTS))
-                }
+                    "group_info" => GroupsGetInfoItem::GroupInfo(GroupFullInfo::internal_deserialize(&mut map)?),
+                    _ => return Err(de::Error::unknown_variant(tag, VARIANTS))
+                };
+                crate::eat_json_fields(&mut map)?;
+                Ok(value)
             }
         }
         const VARIANTS: &[&str] = &["id_not_found",
@@ -8722,16 +8534,12 @@ impl<'de> ::serde::de::Deserialize<'de> for GroupsListContinueError {
                     Some(".tag") => map.next_value()?,
                     _ => return Err(de::Error::missing_field(".tag"))
                 };
-                match tag {
-                    "invalid_cursor" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(GroupsListContinueError::InvalidCursor)
-                    }
-                    _ => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(GroupsListContinueError::Other)
-                    }
-                }
+                let value = match tag {
+                    "invalid_cursor" => GroupsListContinueError::InvalidCursor,
+                    _ => GroupsListContinueError::Other,
+                };
+                crate::eat_json_fields(&mut map)?;
+                Ok(value)
             }
         }
         const VARIANTS: &[&str] = &["invalid_cursor",
@@ -9112,16 +8920,12 @@ impl<'de> ::serde::de::Deserialize<'de> for GroupsMembersListContinueError {
                     Some(".tag") => map.next_value()?,
                     _ => return Err(de::Error::missing_field(".tag"))
                 };
-                match tag {
-                    "invalid_cursor" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(GroupsMembersListContinueError::InvalidCursor)
-                    }
-                    _ => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(GroupsMembersListContinueError::Other)
-                    }
-                }
+                let value = match tag {
+                    "invalid_cursor" => GroupsMembersListContinueError::InvalidCursor,
+                    _ => GroupsMembersListContinueError::Other,
+                };
+                crate::eat_json_fields(&mut map)?;
+                Ok(value)
             }
         }
         const VARIANTS: &[&str] = &["invalid_cursor",
@@ -9305,24 +9109,14 @@ impl<'de> ::serde::de::Deserialize<'de> for GroupsPollError {
                     Some(".tag") => map.next_value()?,
                     _ => return Err(de::Error::missing_field(".tag"))
                 };
-                match tag {
-                    "invalid_async_job_id" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(GroupsPollError::InvalidAsyncJobId)
-                    }
-                    "internal_error" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(GroupsPollError::InternalError)
-                    }
-                    "access_denied" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(GroupsPollError::AccessDenied)
-                    }
-                    _ => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(GroupsPollError::Other)
-                    }
-                }
+                let value = match tag {
+                    "invalid_async_job_id" => GroupsPollError::InvalidAsyncJobId,
+                    "internal_error" => GroupsPollError::InternalError,
+                    "access_denied" => GroupsPollError::AccessDenied,
+                    _ => GroupsPollError::Other,
+                };
+                crate::eat_json_fields(&mut map)?;
+                Ok(value)
             }
         }
         const VARIANTS: &[&str] = &["invalid_async_job_id",
@@ -9399,23 +9193,25 @@ impl<'de> ::serde::de::Deserialize<'de> for GroupsSelector {
                     Some(".tag") => map.next_value()?,
                     _ => return Err(de::Error::missing_field(".tag"))
                 };
-                match tag {
+                let value = match tag {
                     "group_ids" => {
                         match map.next_key()? {
-                            Some("group_ids") => Ok(GroupsSelector::GroupIds(map.next_value()?)),
-                            None => Err(de::Error::missing_field("group_ids")),
-                            _ => Err(de::Error::unknown_field(tag, VARIANTS))
+                            Some("group_ids") => GroupsSelector::GroupIds(map.next_value()?),
+                            None => return Err(de::Error::missing_field("group_ids")),
+                            _ => return Err(de::Error::unknown_field(tag, VARIANTS))
                         }
                     }
                     "group_external_ids" => {
                         match map.next_key()? {
-                            Some("group_external_ids") => Ok(GroupsSelector::GroupExternalIds(map.next_value()?)),
-                            None => Err(de::Error::missing_field("group_external_ids")),
-                            _ => Err(de::Error::unknown_field(tag, VARIANTS))
+                            Some("group_external_ids") => GroupsSelector::GroupExternalIds(map.next_value()?),
+                            None => return Err(de::Error::missing_field("group_external_ids")),
+                            _ => return Err(de::Error::unknown_field(tag, VARIANTS))
                         }
                     }
-                    _ => Err(de::Error::unknown_variant(tag, VARIANTS))
-                }
+                    _ => return Err(de::Error::unknown_variant(tag, VARIANTS))
+                };
+                crate::eat_json_fields(&mut map)?;
+                Ok(value)
             }
         }
         const VARIANTS: &[&str] = &["group_ids",
@@ -9473,19 +9269,18 @@ impl<'de> ::serde::de::Deserialize<'de> for HasTeamFileEventsValue {
                     Some(".tag") => map.next_value()?,
                     _ => return Err(de::Error::missing_field(".tag"))
                 };
-                match tag {
+                let value = match tag {
                     "enabled" => {
                         match map.next_key()? {
-                            Some("enabled") => Ok(HasTeamFileEventsValue::Enabled(map.next_value()?)),
-                            None => Err(de::Error::missing_field("enabled")),
-                            _ => Err(de::Error::unknown_field(tag, VARIANTS))
+                            Some("enabled") => HasTeamFileEventsValue::Enabled(map.next_value()?),
+                            None => return Err(de::Error::missing_field("enabled")),
+                            _ => return Err(de::Error::unknown_field(tag, VARIANTS))
                         }
                     }
-                    _ => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(HasTeamFileEventsValue::Other)
-                    }
-                }
+                    _ => HasTeamFileEventsValue::Other,
+                };
+                crate::eat_json_fields(&mut map)?;
+                Ok(value)
             }
         }
         const VARIANTS: &[&str] = &["enabled",
@@ -9537,19 +9332,18 @@ impl<'de> ::serde::de::Deserialize<'de> for HasTeamSelectiveSyncValue {
                     Some(".tag") => map.next_value()?,
                     _ => return Err(de::Error::missing_field(".tag"))
                 };
-                match tag {
+                let value = match tag {
                     "has_team_selective_sync" => {
                         match map.next_key()? {
-                            Some("has_team_selective_sync") => Ok(HasTeamSelectiveSyncValue::HasTeamSelectiveSync(map.next_value()?)),
-                            None => Err(de::Error::missing_field("has_team_selective_sync")),
-                            _ => Err(de::Error::unknown_field(tag, VARIANTS))
+                            Some("has_team_selective_sync") => HasTeamSelectiveSyncValue::HasTeamSelectiveSync(map.next_value()?),
+                            None => return Err(de::Error::missing_field("has_team_selective_sync")),
+                            _ => return Err(de::Error::unknown_field(tag, VARIANTS))
                         }
                     }
-                    _ => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(HasTeamSelectiveSyncValue::Other)
-                    }
-                }
+                    _ => HasTeamSelectiveSyncValue::Other,
+                };
+                crate::eat_json_fields(&mut map)?;
+                Ok(value)
             }
         }
         const VARIANTS: &[&str] = &["has_team_selective_sync",
@@ -9601,19 +9395,18 @@ impl<'de> ::serde::de::Deserialize<'de> for HasTeamSharedDropboxValue {
                     Some(".tag") => map.next_value()?,
                     _ => return Err(de::Error::missing_field(".tag"))
                 };
-                match tag {
+                let value = match tag {
                     "has_team_shared_dropbox" => {
                         match map.next_key()? {
-                            Some("has_team_shared_dropbox") => Ok(HasTeamSharedDropboxValue::HasTeamSharedDropbox(map.next_value()?)),
-                            None => Err(de::Error::missing_field("has_team_shared_dropbox")),
-                            _ => Err(de::Error::unknown_field(tag, VARIANTS))
+                            Some("has_team_shared_dropbox") => HasTeamSharedDropboxValue::HasTeamSharedDropbox(map.next_value()?),
+                            None => return Err(de::Error::missing_field("has_team_shared_dropbox")),
+                            _ => return Err(de::Error::unknown_field(tag, VARIANTS))
                         }
                     }
-                    _ => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(HasTeamSharedDropboxValue::Other)
-                    }
-                }
+                    _ => HasTeamSharedDropboxValue::Other,
+                };
+                crate::eat_json_fields(&mut map)?;
+                Ok(value)
             }
         }
         const VARIANTS: &[&str] = &["has_team_shared_dropbox",
@@ -10184,36 +9977,17 @@ impl<'de> ::serde::de::Deserialize<'de> for LegalHoldStatus {
                     Some(".tag") => map.next_value()?,
                     _ => return Err(de::Error::missing_field(".tag"))
                 };
-                match tag {
-                    "active" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(LegalHoldStatus::Active)
-                    }
-                    "released" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(LegalHoldStatus::Released)
-                    }
-                    "activating" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(LegalHoldStatus::Activating)
-                    }
-                    "updating" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(LegalHoldStatus::Updating)
-                    }
-                    "exporting" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(LegalHoldStatus::Exporting)
-                    }
-                    "releasing" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(LegalHoldStatus::Releasing)
-                    }
-                    _ => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(LegalHoldStatus::Other)
-                    }
-                }
+                let value = match tag {
+                    "active" => LegalHoldStatus::Active,
+                    "released" => LegalHoldStatus::Released,
+                    "activating" => LegalHoldStatus::Activating,
+                    "updating" => LegalHoldStatus::Updating,
+                    "exporting" => LegalHoldStatus::Exporting,
+                    "releasing" => LegalHoldStatus::Releasing,
+                    _ => LegalHoldStatus::Other,
+                };
+                crate::eat_json_fields(&mut map)?;
+                Ok(value)
             }
         }
         const VARIANTS: &[&str] = &["active",
@@ -10300,20 +10074,13 @@ impl<'de> ::serde::de::Deserialize<'de> for LegalHoldsError {
                     Some(".tag") => map.next_value()?,
                     _ => return Err(de::Error::missing_field(".tag"))
                 };
-                match tag {
-                    "unknown_legal_hold_error" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(LegalHoldsError::UnknownLegalHoldError)
-                    }
-                    "insufficient_permissions" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(LegalHoldsError::InsufficientPermissions)
-                    }
-                    _ => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(LegalHoldsError::Other)
-                    }
-                }
+                let value = match tag {
+                    "unknown_legal_hold_error" => LegalHoldsError::UnknownLegalHoldError,
+                    "insufficient_permissions" => LegalHoldsError::InsufficientPermissions,
+                    _ => LegalHoldsError::Other,
+                };
+                crate::eat_json_fields(&mut map)?;
+                Ok(value)
             }
         }
         const VARIANTS: &[&str] = &["unknown_legal_hold_error",
@@ -10477,24 +10244,14 @@ impl<'de> ::serde::de::Deserialize<'de> for LegalHoldsGetPolicyError {
                     Some(".tag") => map.next_value()?,
                     _ => return Err(de::Error::missing_field(".tag"))
                 };
-                match tag {
-                    "unknown_legal_hold_error" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(LegalHoldsGetPolicyError::UnknownLegalHoldError)
-                    }
-                    "insufficient_permissions" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(LegalHoldsGetPolicyError::InsufficientPermissions)
-                    }
-                    "legal_hold_policy_not_found" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(LegalHoldsGetPolicyError::LegalHoldPolicyNotFound)
-                    }
-                    _ => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(LegalHoldsGetPolicyError::Other)
-                    }
-                }
+                let value = match tag {
+                    "unknown_legal_hold_error" => LegalHoldsGetPolicyError::UnknownLegalHoldError,
+                    "insufficient_permissions" => LegalHoldsGetPolicyError::InsufficientPermissions,
+                    "legal_hold_policy_not_found" => LegalHoldsGetPolicyError::LegalHoldPolicyNotFound,
+                    _ => LegalHoldsGetPolicyError::Other,
+                };
+                crate::eat_json_fields(&mut map)?;
+                Ok(value)
             }
         }
         const VARIANTS: &[&str] = &["unknown_legal_hold_error",
@@ -10900,24 +10657,14 @@ impl<'de> ::serde::de::Deserialize<'de> for LegalHoldsListHeldRevisionsContinueE
                     Some(".tag") => map.next_value()?,
                     _ => return Err(de::Error::missing_field(".tag"))
                 };
-                match tag {
-                    "unknown_legal_hold_error" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(LegalHoldsListHeldRevisionsContinueError::UnknownLegalHoldError)
-                    }
-                    "transient_error" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(LegalHoldsListHeldRevisionsContinueError::TransientError)
-                    }
-                    "reset" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(LegalHoldsListHeldRevisionsContinueError::Reset)
-                    }
-                    _ => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(LegalHoldsListHeldRevisionsContinueError::Other)
-                    }
-                }
+                let value = match tag {
+                    "unknown_legal_hold_error" => LegalHoldsListHeldRevisionsContinueError::UnknownLegalHoldError,
+                    "transient_error" => LegalHoldsListHeldRevisionsContinueError::TransientError,
+                    "reset" => LegalHoldsListHeldRevisionsContinueError::Reset,
+                    _ => LegalHoldsListHeldRevisionsContinueError::Other,
+                };
+                crate::eat_json_fields(&mut map)?;
+                Ok(value)
             }
         }
         const VARIANTS: &[&str] = &["unknown_legal_hold_error",
@@ -11002,32 +10749,16 @@ impl<'de> ::serde::de::Deserialize<'de> for LegalHoldsListHeldRevisionsError {
                     Some(".tag") => map.next_value()?,
                     _ => return Err(de::Error::missing_field(".tag"))
                 };
-                match tag {
-                    "unknown_legal_hold_error" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(LegalHoldsListHeldRevisionsError::UnknownLegalHoldError)
-                    }
-                    "insufficient_permissions" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(LegalHoldsListHeldRevisionsError::InsufficientPermissions)
-                    }
-                    "transient_error" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(LegalHoldsListHeldRevisionsError::TransientError)
-                    }
-                    "legal_hold_still_empty" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(LegalHoldsListHeldRevisionsError::LegalHoldStillEmpty)
-                    }
-                    "inactive_legal_hold" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(LegalHoldsListHeldRevisionsError::InactiveLegalHold)
-                    }
-                    _ => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(LegalHoldsListHeldRevisionsError::Other)
-                    }
-                }
+                let value = match tag {
+                    "unknown_legal_hold_error" => LegalHoldsListHeldRevisionsError::UnknownLegalHoldError,
+                    "insufficient_permissions" => LegalHoldsListHeldRevisionsError::InsufficientPermissions,
+                    "transient_error" => LegalHoldsListHeldRevisionsError::TransientError,
+                    "legal_hold_still_empty" => LegalHoldsListHeldRevisionsError::LegalHoldStillEmpty,
+                    "inactive_legal_hold" => LegalHoldsListHeldRevisionsError::InactiveLegalHold,
+                    _ => LegalHoldsListHeldRevisionsError::Other,
+                };
+                crate::eat_json_fields(&mut map)?;
+                Ok(value)
             }
         }
         const VARIANTS: &[&str] = &["unknown_legal_hold_error",
@@ -11211,24 +10942,14 @@ impl<'de> ::serde::de::Deserialize<'de> for LegalHoldsListPoliciesError {
                     Some(".tag") => map.next_value()?,
                     _ => return Err(de::Error::missing_field(".tag"))
                 };
-                match tag {
-                    "unknown_legal_hold_error" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(LegalHoldsListPoliciesError::UnknownLegalHoldError)
-                    }
-                    "insufficient_permissions" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(LegalHoldsListPoliciesError::InsufficientPermissions)
-                    }
-                    "transient_error" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(LegalHoldsListPoliciesError::TransientError)
-                    }
-                    _ => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(LegalHoldsListPoliciesError::Other)
-                    }
-                }
+                let value = match tag {
+                    "unknown_legal_hold_error" => LegalHoldsListPoliciesError::UnknownLegalHoldError,
+                    "insufficient_permissions" => LegalHoldsListPoliciesError::InsufficientPermissions,
+                    "transient_error" => LegalHoldsListPoliciesError::TransientError,
+                    _ => LegalHoldsListPoliciesError::Other,
+                };
+                crate::eat_json_fields(&mut map)?;
+                Ok(value)
             }
         }
         const VARIANTS: &[&str] = &["unknown_legal_hold_error",
@@ -11570,52 +11291,21 @@ impl<'de> ::serde::de::Deserialize<'de> for LegalHoldsPolicyCreateError {
                     Some(".tag") => map.next_value()?,
                     _ => return Err(de::Error::missing_field(".tag"))
                 };
-                match tag {
-                    "unknown_legal_hold_error" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(LegalHoldsPolicyCreateError::UnknownLegalHoldError)
-                    }
-                    "insufficient_permissions" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(LegalHoldsPolicyCreateError::InsufficientPermissions)
-                    }
-                    "start_date_is_later_than_end_date" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(LegalHoldsPolicyCreateError::StartDateIsLaterThanEndDate)
-                    }
-                    "empty_members_list" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(LegalHoldsPolicyCreateError::EmptyMembersList)
-                    }
-                    "invalid_members" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(LegalHoldsPolicyCreateError::InvalidMembers)
-                    }
-                    "number_of_users_on_hold_is_greater_than_hold_limitation" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(LegalHoldsPolicyCreateError::NumberOfUsersOnHoldIsGreaterThanHoldLimitation)
-                    }
-                    "transient_error" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(LegalHoldsPolicyCreateError::TransientError)
-                    }
-                    "name_must_be_unique" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(LegalHoldsPolicyCreateError::NameMustBeUnique)
-                    }
-                    "team_exceeded_legal_hold_quota" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(LegalHoldsPolicyCreateError::TeamExceededLegalHoldQuota)
-                    }
-                    "invalid_date" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(LegalHoldsPolicyCreateError::InvalidDate)
-                    }
-                    _ => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(LegalHoldsPolicyCreateError::Other)
-                    }
-                }
+                let value = match tag {
+                    "unknown_legal_hold_error" => LegalHoldsPolicyCreateError::UnknownLegalHoldError,
+                    "insufficient_permissions" => LegalHoldsPolicyCreateError::InsufficientPermissions,
+                    "start_date_is_later_than_end_date" => LegalHoldsPolicyCreateError::StartDateIsLaterThanEndDate,
+                    "empty_members_list" => LegalHoldsPolicyCreateError::EmptyMembersList,
+                    "invalid_members" => LegalHoldsPolicyCreateError::InvalidMembers,
+                    "number_of_users_on_hold_is_greater_than_hold_limitation" => LegalHoldsPolicyCreateError::NumberOfUsersOnHoldIsGreaterThanHoldLimitation,
+                    "transient_error" => LegalHoldsPolicyCreateError::TransientError,
+                    "name_must_be_unique" => LegalHoldsPolicyCreateError::NameMustBeUnique,
+                    "team_exceeded_legal_hold_quota" => LegalHoldsPolicyCreateError::TeamExceededLegalHoldQuota,
+                    "invalid_date" => LegalHoldsPolicyCreateError::InvalidDate,
+                    _ => LegalHoldsPolicyCreateError::Other,
+                };
+                crate::eat_json_fields(&mut map)?;
+                Ok(value)
             }
         }
         const VARIANTS: &[&str] = &["unknown_legal_hold_error",
@@ -11848,32 +11538,16 @@ impl<'de> ::serde::de::Deserialize<'de> for LegalHoldsPolicyReleaseError {
                     Some(".tag") => map.next_value()?,
                     _ => return Err(de::Error::missing_field(".tag"))
                 };
-                match tag {
-                    "unknown_legal_hold_error" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(LegalHoldsPolicyReleaseError::UnknownLegalHoldError)
-                    }
-                    "insufficient_permissions" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(LegalHoldsPolicyReleaseError::InsufficientPermissions)
-                    }
-                    "legal_hold_performing_another_operation" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(LegalHoldsPolicyReleaseError::LegalHoldPerformingAnotherOperation)
-                    }
-                    "legal_hold_already_releasing" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(LegalHoldsPolicyReleaseError::LegalHoldAlreadyReleasing)
-                    }
-                    "legal_hold_policy_not_found" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(LegalHoldsPolicyReleaseError::LegalHoldPolicyNotFound)
-                    }
-                    _ => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(LegalHoldsPolicyReleaseError::Other)
-                    }
-                }
+                let value = match tag {
+                    "unknown_legal_hold_error" => LegalHoldsPolicyReleaseError::UnknownLegalHoldError,
+                    "insufficient_permissions" => LegalHoldsPolicyReleaseError::InsufficientPermissions,
+                    "legal_hold_performing_another_operation" => LegalHoldsPolicyReleaseError::LegalHoldPerformingAnotherOperation,
+                    "legal_hold_already_releasing" => LegalHoldsPolicyReleaseError::LegalHoldAlreadyReleasing,
+                    "legal_hold_policy_not_found" => LegalHoldsPolicyReleaseError::LegalHoldPolicyNotFound,
+                    _ => LegalHoldsPolicyReleaseError::Other,
+                };
+                crate::eat_json_fields(&mut map)?;
+                Ok(value)
             }
         }
         const VARIANTS: &[&str] = &["unknown_legal_hold_error",
@@ -12129,52 +11803,21 @@ impl<'de> ::serde::de::Deserialize<'de> for LegalHoldsPolicyUpdateError {
                     Some(".tag") => map.next_value()?,
                     _ => return Err(de::Error::missing_field(".tag"))
                 };
-                match tag {
-                    "unknown_legal_hold_error" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(LegalHoldsPolicyUpdateError::UnknownLegalHoldError)
-                    }
-                    "insufficient_permissions" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(LegalHoldsPolicyUpdateError::InsufficientPermissions)
-                    }
-                    "transient_error" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(LegalHoldsPolicyUpdateError::TransientError)
-                    }
-                    "inactive_legal_hold" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(LegalHoldsPolicyUpdateError::InactiveLegalHold)
-                    }
-                    "legal_hold_performing_another_operation" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(LegalHoldsPolicyUpdateError::LegalHoldPerformingAnotherOperation)
-                    }
-                    "invalid_members" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(LegalHoldsPolicyUpdateError::InvalidMembers)
-                    }
-                    "number_of_users_on_hold_is_greater_than_hold_limitation" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(LegalHoldsPolicyUpdateError::NumberOfUsersOnHoldIsGreaterThanHoldLimitation)
-                    }
-                    "empty_members_list" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(LegalHoldsPolicyUpdateError::EmptyMembersList)
-                    }
-                    "name_must_be_unique" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(LegalHoldsPolicyUpdateError::NameMustBeUnique)
-                    }
-                    "legal_hold_policy_not_found" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(LegalHoldsPolicyUpdateError::LegalHoldPolicyNotFound)
-                    }
-                    _ => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(LegalHoldsPolicyUpdateError::Other)
-                    }
-                }
+                let value = match tag {
+                    "unknown_legal_hold_error" => LegalHoldsPolicyUpdateError::UnknownLegalHoldError,
+                    "insufficient_permissions" => LegalHoldsPolicyUpdateError::InsufficientPermissions,
+                    "transient_error" => LegalHoldsPolicyUpdateError::TransientError,
+                    "inactive_legal_hold" => LegalHoldsPolicyUpdateError::InactiveLegalHold,
+                    "legal_hold_performing_another_operation" => LegalHoldsPolicyUpdateError::LegalHoldPerformingAnotherOperation,
+                    "invalid_members" => LegalHoldsPolicyUpdateError::InvalidMembers,
+                    "number_of_users_on_hold_is_greater_than_hold_limitation" => LegalHoldsPolicyUpdateError::NumberOfUsersOnHoldIsGreaterThanHoldLimitation,
+                    "empty_members_list" => LegalHoldsPolicyUpdateError::EmptyMembersList,
+                    "name_must_be_unique" => LegalHoldsPolicyUpdateError::NameMustBeUnique,
+                    "legal_hold_policy_not_found" => LegalHoldsPolicyUpdateError::LegalHoldPolicyNotFound,
+                    _ => LegalHoldsPolicyUpdateError::Other,
+                };
+                crate::eat_json_fields(&mut map)?;
+                Ok(value)
             }
         }
         const VARIANTS: &[&str] = &["unknown_legal_hold_error",
@@ -12399,16 +12042,12 @@ impl<'de> ::serde::de::Deserialize<'de> for ListMemberAppsError {
                     Some(".tag") => map.next_value()?,
                     _ => return Err(de::Error::missing_field(".tag"))
                 };
-                match tag {
-                    "member_not_found" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(ListMemberAppsError::MemberNotFound)
-                    }
-                    _ => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(ListMemberAppsError::Other)
-                    }
-                }
+                let value = match tag {
+                    "member_not_found" => ListMemberAppsError::MemberNotFound,
+                    _ => ListMemberAppsError::Other,
+                };
+                crate::eat_json_fields(&mut map)?;
+                Ok(value)
             }
         }
         const VARIANTS: &[&str] = &["member_not_found",
@@ -12704,16 +12343,12 @@ impl<'de> ::serde::de::Deserialize<'de> for ListMemberDevicesError {
                     Some(".tag") => map.next_value()?,
                     _ => return Err(de::Error::missing_field(".tag"))
                 };
-                match tag {
-                    "member_not_found" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(ListMemberDevicesError::MemberNotFound)
-                    }
-                    _ => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(ListMemberDevicesError::Other)
-                    }
-                }
+                let value = match tag {
+                    "member_not_found" => ListMemberDevicesError::MemberNotFound,
+                    _ => ListMemberDevicesError::Other,
+                };
+                crate::eat_json_fields(&mut map)?;
+                Ok(value)
             }
         }
         const VARIANTS: &[&str] = &["member_not_found",
@@ -12992,16 +12627,12 @@ impl<'de> ::serde::de::Deserialize<'de> for ListMembersAppsError {
                     Some(".tag") => map.next_value()?,
                     _ => return Err(de::Error::missing_field(".tag"))
                 };
-                match tag {
-                    "reset" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(ListMembersAppsError::Reset)
-                    }
-                    _ => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(ListMembersAppsError::Other)
-                    }
-                }
+                let value = match tag {
+                    "reset" => ListMembersAppsError::Reset,
+                    _ => ListMembersAppsError::Other,
+                };
+                crate::eat_json_fields(&mut map)?;
+                Ok(value)
             }
         }
         const VARIANTS: &[&str] = &["reset",
@@ -13332,16 +12963,12 @@ impl<'de> ::serde::de::Deserialize<'de> for ListMembersDevicesError {
                     Some(".tag") => map.next_value()?,
                     _ => return Err(de::Error::missing_field(".tag"))
                 };
-                match tag {
-                    "reset" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(ListMembersDevicesError::Reset)
-                    }
-                    _ => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(ListMembersDevicesError::Other)
-                    }
-                }
+                let value = match tag {
+                    "reset" => ListMembersDevicesError::Reset,
+                    _ => ListMembersDevicesError::Other,
+                };
+                crate::eat_json_fields(&mut map)?;
+                Ok(value)
             }
         }
         const VARIANTS: &[&str] = &["reset",
@@ -13617,16 +13244,12 @@ impl<'de> ::serde::de::Deserialize<'de> for ListTeamAppsError {
                     Some(".tag") => map.next_value()?,
                     _ => return Err(de::Error::missing_field(".tag"))
                 };
-                match tag {
-                    "reset" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(ListTeamAppsError::Reset)
-                    }
-                    _ => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(ListTeamAppsError::Other)
-                    }
-                }
+                let value = match tag {
+                    "reset" => ListTeamAppsError::Reset,
+                    _ => ListTeamAppsError::Other,
+                };
+                crate::eat_json_fields(&mut map)?;
+                Ok(value)
             }
         }
         const VARIANTS: &[&str] = &["reset",
@@ -13957,16 +13580,12 @@ impl<'de> ::serde::de::Deserialize<'de> for ListTeamDevicesError {
                     Some(".tag") => map.next_value()?,
                     _ => return Err(de::Error::missing_field(".tag"))
                 };
-                match tag {
-                    "reset" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(ListTeamDevicesError::Reset)
-                    }
-                    _ => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(ListTeamDevicesError::Other)
-                    }
-                }
+                let value = match tag {
+                    "reset" => ListTeamDevicesError::Reset,
+                    _ => ListTeamDevicesError::Other,
+                };
+                crate::eat_json_fields(&mut map)?;
+                Ok(value)
             }
         }
         const VARIANTS: &[&str] = &["reset",
@@ -14493,80 +14112,82 @@ impl<'de> ::serde::de::Deserialize<'de> for MemberAddResult {
                     Some(".tag") => map.next_value()?,
                     _ => return Err(de::Error::missing_field(".tag"))
                 };
-                match tag {
-                    "success" => Ok(MemberAddResult::Success(TeamMemberInfo::internal_deserialize(map)?)),
+                let value = match tag {
+                    "success" => MemberAddResult::Success(TeamMemberInfo::internal_deserialize(&mut map)?),
                     "team_license_limit" => {
                         match map.next_key()? {
-                            Some("team_license_limit") => Ok(MemberAddResult::TeamLicenseLimit(map.next_value()?)),
-                            None => Err(de::Error::missing_field("team_license_limit")),
-                            _ => Err(de::Error::unknown_field(tag, VARIANTS))
+                            Some("team_license_limit") => MemberAddResult::TeamLicenseLimit(map.next_value()?),
+                            None => return Err(de::Error::missing_field("team_license_limit")),
+                            _ => return Err(de::Error::unknown_field(tag, VARIANTS))
                         }
                     }
                     "free_team_member_limit_reached" => {
                         match map.next_key()? {
-                            Some("free_team_member_limit_reached") => Ok(MemberAddResult::FreeTeamMemberLimitReached(map.next_value()?)),
-                            None => Err(de::Error::missing_field("free_team_member_limit_reached")),
-                            _ => Err(de::Error::unknown_field(tag, VARIANTS))
+                            Some("free_team_member_limit_reached") => MemberAddResult::FreeTeamMemberLimitReached(map.next_value()?),
+                            None => return Err(de::Error::missing_field("free_team_member_limit_reached")),
+                            _ => return Err(de::Error::unknown_field(tag, VARIANTS))
                         }
                     }
                     "user_already_on_team" => {
                         match map.next_key()? {
-                            Some("user_already_on_team") => Ok(MemberAddResult::UserAlreadyOnTeam(map.next_value()?)),
-                            None => Err(de::Error::missing_field("user_already_on_team")),
-                            _ => Err(de::Error::unknown_field(tag, VARIANTS))
+                            Some("user_already_on_team") => MemberAddResult::UserAlreadyOnTeam(map.next_value()?),
+                            None => return Err(de::Error::missing_field("user_already_on_team")),
+                            _ => return Err(de::Error::unknown_field(tag, VARIANTS))
                         }
                     }
                     "user_on_another_team" => {
                         match map.next_key()? {
-                            Some("user_on_another_team") => Ok(MemberAddResult::UserOnAnotherTeam(map.next_value()?)),
-                            None => Err(de::Error::missing_field("user_on_another_team")),
-                            _ => Err(de::Error::unknown_field(tag, VARIANTS))
+                            Some("user_on_another_team") => MemberAddResult::UserOnAnotherTeam(map.next_value()?),
+                            None => return Err(de::Error::missing_field("user_on_another_team")),
+                            _ => return Err(de::Error::unknown_field(tag, VARIANTS))
                         }
                     }
                     "user_already_paired" => {
                         match map.next_key()? {
-                            Some("user_already_paired") => Ok(MemberAddResult::UserAlreadyPaired(map.next_value()?)),
-                            None => Err(de::Error::missing_field("user_already_paired")),
-                            _ => Err(de::Error::unknown_field(tag, VARIANTS))
+                            Some("user_already_paired") => MemberAddResult::UserAlreadyPaired(map.next_value()?),
+                            None => return Err(de::Error::missing_field("user_already_paired")),
+                            _ => return Err(de::Error::unknown_field(tag, VARIANTS))
                         }
                     }
                     "user_migration_failed" => {
                         match map.next_key()? {
-                            Some("user_migration_failed") => Ok(MemberAddResult::UserMigrationFailed(map.next_value()?)),
-                            None => Err(de::Error::missing_field("user_migration_failed")),
-                            _ => Err(de::Error::unknown_field(tag, VARIANTS))
+                            Some("user_migration_failed") => MemberAddResult::UserMigrationFailed(map.next_value()?),
+                            None => return Err(de::Error::missing_field("user_migration_failed")),
+                            _ => return Err(de::Error::unknown_field(tag, VARIANTS))
                         }
                     }
                     "duplicate_external_member_id" => {
                         match map.next_key()? {
-                            Some("duplicate_external_member_id") => Ok(MemberAddResult::DuplicateExternalMemberId(map.next_value()?)),
-                            None => Err(de::Error::missing_field("duplicate_external_member_id")),
-                            _ => Err(de::Error::unknown_field(tag, VARIANTS))
+                            Some("duplicate_external_member_id") => MemberAddResult::DuplicateExternalMemberId(map.next_value()?),
+                            None => return Err(de::Error::missing_field("duplicate_external_member_id")),
+                            _ => return Err(de::Error::unknown_field(tag, VARIANTS))
                         }
                     }
                     "duplicate_member_persistent_id" => {
                         match map.next_key()? {
-                            Some("duplicate_member_persistent_id") => Ok(MemberAddResult::DuplicateMemberPersistentId(map.next_value()?)),
-                            None => Err(de::Error::missing_field("duplicate_member_persistent_id")),
-                            _ => Err(de::Error::unknown_field(tag, VARIANTS))
+                            Some("duplicate_member_persistent_id") => MemberAddResult::DuplicateMemberPersistentId(map.next_value()?),
+                            None => return Err(de::Error::missing_field("duplicate_member_persistent_id")),
+                            _ => return Err(de::Error::unknown_field(tag, VARIANTS))
                         }
                     }
                     "persistent_id_disabled" => {
                         match map.next_key()? {
-                            Some("persistent_id_disabled") => Ok(MemberAddResult::PersistentIdDisabled(map.next_value()?)),
-                            None => Err(de::Error::missing_field("persistent_id_disabled")),
-                            _ => Err(de::Error::unknown_field(tag, VARIANTS))
+                            Some("persistent_id_disabled") => MemberAddResult::PersistentIdDisabled(map.next_value()?),
+                            None => return Err(de::Error::missing_field("persistent_id_disabled")),
+                            _ => return Err(de::Error::unknown_field(tag, VARIANTS))
                         }
                     }
                     "user_creation_failed" => {
                         match map.next_key()? {
-                            Some("user_creation_failed") => Ok(MemberAddResult::UserCreationFailed(map.next_value()?)),
-                            None => Err(de::Error::missing_field("user_creation_failed")),
-                            _ => Err(de::Error::unknown_field(tag, VARIANTS))
+                            Some("user_creation_failed") => MemberAddResult::UserCreationFailed(map.next_value()?),
+                            None => return Err(de::Error::missing_field("user_creation_failed")),
+                            _ => return Err(de::Error::unknown_field(tag, VARIANTS))
                         }
                     }
-                    _ => Err(de::Error::unknown_variant(tag, VARIANTS))
-                }
+                    _ => return Err(de::Error::unknown_variant(tag, VARIANTS))
+                };
+                crate::eat_json_fields(&mut map)?;
+                Ok(value)
             }
         }
         const VARIANTS: &[&str] = &["success",
@@ -15276,17 +14897,13 @@ impl<'de> ::serde::de::Deserialize<'de> for MemberSelectorError {
                     Some(".tag") => map.next_value()?,
                     _ => return Err(de::Error::missing_field(".tag"))
                 };
-                match tag {
-                    "user_not_found" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(MemberSelectorError::UserNotFound)
-                    }
-                    "user_not_in_team" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(MemberSelectorError::UserNotInTeam)
-                    }
-                    _ => Err(de::Error::unknown_variant(tag, VARIANTS))
-                }
+                let value = match tag {
+                    "user_not_found" => MemberSelectorError::UserNotFound,
+                    "user_not_in_team" => MemberSelectorError::UserNotInTeam,
+                    _ => return Err(de::Error::unknown_variant(tag, VARIANTS))
+                };
+                crate::eat_json_fields(&mut map)?;
+                Ok(value)
             }
         }
         const VARIANTS: &[&str] = &["user_not_found",
@@ -15463,27 +15080,26 @@ impl<'de> ::serde::de::Deserialize<'de> for MembersAddJobStatus {
                     Some(".tag") => map.next_value()?,
                     _ => return Err(de::Error::missing_field(".tag"))
                 };
-                match tag {
-                    "in_progress" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(MembersAddJobStatus::InProgress)
-                    }
+                let value = match tag {
+                    "in_progress" => MembersAddJobStatus::InProgress,
                     "complete" => {
                         match map.next_key()? {
-                            Some("complete") => Ok(MembersAddJobStatus::Complete(map.next_value()?)),
-                            None => Err(de::Error::missing_field("complete")),
-                            _ => Err(de::Error::unknown_field(tag, VARIANTS))
+                            Some("complete") => MembersAddJobStatus::Complete(map.next_value()?),
+                            None => return Err(de::Error::missing_field("complete")),
+                            _ => return Err(de::Error::unknown_field(tag, VARIANTS))
                         }
                     }
                     "failed" => {
                         match map.next_key()? {
-                            Some("failed") => Ok(MembersAddJobStatus::Failed(map.next_value()?)),
-                            None => Err(de::Error::missing_field("failed")),
-                            _ => Err(de::Error::unknown_field(tag, VARIANTS))
+                            Some("failed") => MembersAddJobStatus::Failed(map.next_value()?),
+                            None => return Err(de::Error::missing_field("failed")),
+                            _ => return Err(de::Error::unknown_field(tag, VARIANTS))
                         }
                     }
-                    _ => Err(de::Error::unknown_variant(tag, VARIANTS))
-                }
+                    _ => return Err(de::Error::unknown_variant(tag, VARIANTS))
+                };
+                crate::eat_json_fields(&mut map)?;
+                Ok(value)
             }
         }
         const VARIANTS: &[&str] = &["in_progress",
@@ -15545,23 +15161,25 @@ impl<'de> ::serde::de::Deserialize<'de> for MembersAddLaunch {
                     Some(".tag") => map.next_value()?,
                     _ => return Err(de::Error::missing_field(".tag"))
                 };
-                match tag {
+                let value = match tag {
                     "async_job_id" => {
                         match map.next_key()? {
-                            Some("async_job_id") => Ok(MembersAddLaunch::AsyncJobId(map.next_value()?)),
-                            None => Err(de::Error::missing_field("async_job_id")),
-                            _ => Err(de::Error::unknown_field(tag, VARIANTS))
+                            Some("async_job_id") => MembersAddLaunch::AsyncJobId(map.next_value()?),
+                            None => return Err(de::Error::missing_field("async_job_id")),
+                            _ => return Err(de::Error::unknown_field(tag, VARIANTS))
                         }
                     }
                     "complete" => {
                         match map.next_key()? {
-                            Some("complete") => Ok(MembersAddLaunch::Complete(map.next_value()?)),
-                            None => Err(de::Error::missing_field("complete")),
-                            _ => Err(de::Error::unknown_field(tag, VARIANTS))
+                            Some("complete") => MembersAddLaunch::Complete(map.next_value()?),
+                            None => return Err(de::Error::missing_field("complete")),
+                            _ => return Err(de::Error::unknown_field(tag, VARIANTS))
                         }
                     }
-                    _ => Err(de::Error::unknown_variant(tag, VARIANTS))
-                }
+                    _ => return Err(de::Error::unknown_variant(tag, VARIANTS))
+                };
+                crate::eat_json_fields(&mut map)?;
+                Ok(value)
             }
         }
         const VARIANTS: &[&str] = &["async_job_id",
@@ -15941,20 +15559,13 @@ impl<'de> ::serde::de::Deserialize<'de> for MembersDeactivateError {
                     Some(".tag") => map.next_value()?,
                     _ => return Err(de::Error::missing_field(".tag"))
                 };
-                match tag {
-                    "user_not_found" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(MembersDeactivateError::UserNotFound)
-                    }
-                    "user_not_in_team" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(MembersDeactivateError::UserNotInTeam)
-                    }
-                    _ => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(MembersDeactivateError::Other)
-                    }
-                }
+                let value = match tag {
+                    "user_not_found" => MembersDeactivateError::UserNotFound,
+                    "user_not_in_team" => MembersDeactivateError::UserNotInTeam,
+                    _ => MembersDeactivateError::Other,
+                };
+                crate::eat_json_fields(&mut map)?;
+                Ok(value)
             }
         }
         const VARIANTS: &[&str] = &["user_not_found",
@@ -16119,24 +15730,14 @@ impl<'de> ::serde::de::Deserialize<'de> for MembersDeleteProfilePhotoError {
                     Some(".tag") => map.next_value()?,
                     _ => return Err(de::Error::missing_field(".tag"))
                 };
-                match tag {
-                    "user_not_found" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(MembersDeleteProfilePhotoError::UserNotFound)
-                    }
-                    "user_not_in_team" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(MembersDeleteProfilePhotoError::UserNotInTeam)
-                    }
-                    "set_profile_disallowed" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(MembersDeleteProfilePhotoError::SetProfileDisallowed)
-                    }
-                    _ => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(MembersDeleteProfilePhotoError::Other)
-                    }
-                }
+                let value = match tag {
+                    "user_not_found" => MembersDeleteProfilePhotoError::UserNotFound,
+                    "user_not_in_team" => MembersDeleteProfilePhotoError::UserNotInTeam,
+                    "set_profile_disallowed" => MembersDeleteProfilePhotoError::SetProfileDisallowed,
+                    _ => MembersDeleteProfilePhotoError::Other,
+                };
+                crate::eat_json_fields(&mut map)?;
+                Ok(value)
             }
         }
         const VARIANTS: &[&str] = &["user_not_found",
@@ -16358,17 +15959,19 @@ impl<'de> ::serde::de::Deserialize<'de> for MembersGetInfoItem {
                     Some(".tag") => map.next_value()?,
                     _ => return Err(de::Error::missing_field(".tag"))
                 };
-                match tag {
+                let value = match tag {
                     "id_not_found" => {
                         match map.next_key()? {
-                            Some("id_not_found") => Ok(MembersGetInfoItem::IdNotFound(map.next_value()?)),
-                            None => Err(de::Error::missing_field("id_not_found")),
-                            _ => Err(de::Error::unknown_field(tag, VARIANTS))
+                            Some("id_not_found") => MembersGetInfoItem::IdNotFound(map.next_value()?),
+                            None => return Err(de::Error::missing_field("id_not_found")),
+                            _ => return Err(de::Error::unknown_field(tag, VARIANTS))
                         }
                     }
-                    "member_info" => Ok(MembersGetInfoItem::MemberInfo(TeamMemberInfo::internal_deserialize(map)?)),
-                    _ => Err(de::Error::unknown_variant(tag, VARIANTS))
-                }
+                    "member_info" => MembersGetInfoItem::MemberInfo(TeamMemberInfo::internal_deserialize(&mut map)?),
+                    _ => return Err(de::Error::unknown_variant(tag, VARIANTS))
+                };
+                crate::eat_json_fields(&mut map)?;
+                Ok(value)
             }
         }
         const VARIANTS: &[&str] = &["id_not_found",
@@ -16725,16 +16328,12 @@ impl<'de> ::serde::de::Deserialize<'de> for MembersListContinueError {
                     Some(".tag") => map.next_value()?,
                     _ => return Err(de::Error::missing_field(".tag"))
                 };
-                match tag {
-                    "invalid_cursor" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(MembersListContinueError::InvalidCursor)
-                    }
-                    _ => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(MembersListContinueError::Other)
-                    }
-                }
+                let value = match tag {
+                    "invalid_cursor" => MembersListContinueError::InvalidCursor,
+                    _ => MembersListContinueError::Other,
+                };
+                crate::eat_json_fields(&mut map)?;
+                Ok(value)
             }
         }
         const VARIANTS: &[&str] = &["invalid_cursor",
@@ -17065,28 +16664,15 @@ impl<'de> ::serde::de::Deserialize<'de> for MembersRecoverError {
                     Some(".tag") => map.next_value()?,
                     _ => return Err(de::Error::missing_field(".tag"))
                 };
-                match tag {
-                    "user_not_found" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(MembersRecoverError::UserNotFound)
-                    }
-                    "user_unrecoverable" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(MembersRecoverError::UserUnrecoverable)
-                    }
-                    "user_not_in_team" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(MembersRecoverError::UserNotInTeam)
-                    }
-                    "team_license_limit" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(MembersRecoverError::TeamLicenseLimit)
-                    }
-                    _ => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(MembersRecoverError::Other)
-                    }
-                }
+                let value = match tag {
+                    "user_not_found" => MembersRecoverError::UserNotFound,
+                    "user_unrecoverable" => MembersRecoverError::UserUnrecoverable,
+                    "user_not_in_team" => MembersRecoverError::UserNotInTeam,
+                    "team_license_limit" => MembersRecoverError::TeamLicenseLimit,
+                    _ => MembersRecoverError::Other,
+                };
+                crate::eat_json_fields(&mut map)?;
+                Ok(value)
             }
         }
         const VARIANTS: &[&str] = &["user_not_found",
@@ -17408,100 +16994,33 @@ impl<'de> ::serde::de::Deserialize<'de> for MembersRemoveError {
                     Some(".tag") => map.next_value()?,
                     _ => return Err(de::Error::missing_field(".tag"))
                 };
-                match tag {
-                    "user_not_found" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(MembersRemoveError::UserNotFound)
-                    }
-                    "user_not_in_team" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(MembersRemoveError::UserNotInTeam)
-                    }
-                    "removed_and_transfer_dest_should_differ" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(MembersRemoveError::RemovedAndTransferDestShouldDiffer)
-                    }
-                    "removed_and_transfer_admin_should_differ" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(MembersRemoveError::RemovedAndTransferAdminShouldDiffer)
-                    }
-                    "transfer_dest_user_not_found" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(MembersRemoveError::TransferDestUserNotFound)
-                    }
-                    "transfer_dest_user_not_in_team" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(MembersRemoveError::TransferDestUserNotInTeam)
-                    }
-                    "transfer_admin_user_not_in_team" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(MembersRemoveError::TransferAdminUserNotInTeam)
-                    }
-                    "transfer_admin_user_not_found" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(MembersRemoveError::TransferAdminUserNotFound)
-                    }
-                    "unspecified_transfer_admin_id" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(MembersRemoveError::UnspecifiedTransferAdminId)
-                    }
-                    "transfer_admin_is_not_admin" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(MembersRemoveError::TransferAdminIsNotAdmin)
-                    }
-                    "recipient_not_verified" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(MembersRemoveError::RecipientNotVerified)
-                    }
-                    "remove_last_admin" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(MembersRemoveError::RemoveLastAdmin)
-                    }
-                    "cannot_keep_account_and_transfer" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(MembersRemoveError::CannotKeepAccountAndTransfer)
-                    }
-                    "cannot_keep_account_and_delete_data" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(MembersRemoveError::CannotKeepAccountAndDeleteData)
-                    }
-                    "email_address_too_long_to_be_disabled" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(MembersRemoveError::EmailAddressTooLongToBeDisabled)
-                    }
-                    "cannot_keep_invited_user_account" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(MembersRemoveError::CannotKeepInvitedUserAccount)
-                    }
-                    "cannot_retain_shares_when_data_wiped" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(MembersRemoveError::CannotRetainSharesWhenDataWiped)
-                    }
-                    "cannot_retain_shares_when_no_account_kept" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(MembersRemoveError::CannotRetainSharesWhenNoAccountKept)
-                    }
-                    "cannot_retain_shares_when_team_external_sharing_off" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(MembersRemoveError::CannotRetainSharesWhenTeamExternalSharingOff)
-                    }
-                    "cannot_keep_account" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(MembersRemoveError::CannotKeepAccount)
-                    }
-                    "cannot_keep_account_under_legal_hold" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(MembersRemoveError::CannotKeepAccountUnderLegalHold)
-                    }
-                    "cannot_keep_account_required_to_sign_tos" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(MembersRemoveError::CannotKeepAccountRequiredToSignTos)
-                    }
-                    _ => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(MembersRemoveError::Other)
-                    }
-                }
+                let value = match tag {
+                    "user_not_found" => MembersRemoveError::UserNotFound,
+                    "user_not_in_team" => MembersRemoveError::UserNotInTeam,
+                    "removed_and_transfer_dest_should_differ" => MembersRemoveError::RemovedAndTransferDestShouldDiffer,
+                    "removed_and_transfer_admin_should_differ" => MembersRemoveError::RemovedAndTransferAdminShouldDiffer,
+                    "transfer_dest_user_not_found" => MembersRemoveError::TransferDestUserNotFound,
+                    "transfer_dest_user_not_in_team" => MembersRemoveError::TransferDestUserNotInTeam,
+                    "transfer_admin_user_not_in_team" => MembersRemoveError::TransferAdminUserNotInTeam,
+                    "transfer_admin_user_not_found" => MembersRemoveError::TransferAdminUserNotFound,
+                    "unspecified_transfer_admin_id" => MembersRemoveError::UnspecifiedTransferAdminId,
+                    "transfer_admin_is_not_admin" => MembersRemoveError::TransferAdminIsNotAdmin,
+                    "recipient_not_verified" => MembersRemoveError::RecipientNotVerified,
+                    "remove_last_admin" => MembersRemoveError::RemoveLastAdmin,
+                    "cannot_keep_account_and_transfer" => MembersRemoveError::CannotKeepAccountAndTransfer,
+                    "cannot_keep_account_and_delete_data" => MembersRemoveError::CannotKeepAccountAndDeleteData,
+                    "email_address_too_long_to_be_disabled" => MembersRemoveError::EmailAddressTooLongToBeDisabled,
+                    "cannot_keep_invited_user_account" => MembersRemoveError::CannotKeepInvitedUserAccount,
+                    "cannot_retain_shares_when_data_wiped" => MembersRemoveError::CannotRetainSharesWhenDataWiped,
+                    "cannot_retain_shares_when_no_account_kept" => MembersRemoveError::CannotRetainSharesWhenNoAccountKept,
+                    "cannot_retain_shares_when_team_external_sharing_off" => MembersRemoveError::CannotRetainSharesWhenTeamExternalSharingOff,
+                    "cannot_keep_account" => MembersRemoveError::CannotKeepAccount,
+                    "cannot_keep_account_under_legal_hold" => MembersRemoveError::CannotKeepAccountUnderLegalHold,
+                    "cannot_keep_account_required_to_sign_tos" => MembersRemoveError::CannotKeepAccountRequiredToSignTos,
+                    _ => MembersRemoveError::Other,
+                };
+                crate::eat_json_fields(&mut map)?;
+                Ok(value)
             }
         }
         const VARIANTS: &[&str] = &["user_not_found",
@@ -17732,20 +17251,13 @@ impl<'de> ::serde::de::Deserialize<'de> for MembersSendWelcomeError {
                     Some(".tag") => map.next_value()?,
                     _ => return Err(de::Error::missing_field(".tag"))
                 };
-                match tag {
-                    "user_not_found" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(MembersSendWelcomeError::UserNotFound)
-                    }
-                    "user_not_in_team" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(MembersSendWelcomeError::UserNotInTeam)
-                    }
-                    _ => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(MembersSendWelcomeError::Other)
-                    }
-                }
+                let value = match tag {
+                    "user_not_found" => MembersSendWelcomeError::UserNotFound,
+                    "user_not_in_team" => MembersSendWelcomeError::UserNotInTeam,
+                    _ => MembersSendWelcomeError::Other,
+                };
+                crate::eat_json_fields(&mut map)?;
+                Ok(value)
             }
         }
         const VARIANTS: &[&str] = &["user_not_found",
@@ -17929,32 +17441,16 @@ impl<'de> ::serde::de::Deserialize<'de> for MembersSetPermissionsError {
                     Some(".tag") => map.next_value()?,
                     _ => return Err(de::Error::missing_field(".tag"))
                 };
-                match tag {
-                    "user_not_found" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(MembersSetPermissionsError::UserNotFound)
-                    }
-                    "last_admin" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(MembersSetPermissionsError::LastAdmin)
-                    }
-                    "user_not_in_team" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(MembersSetPermissionsError::UserNotInTeam)
-                    }
-                    "cannot_set_permissions" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(MembersSetPermissionsError::CannotSetPermissions)
-                    }
-                    "team_license_limit" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(MembersSetPermissionsError::TeamLicenseLimit)
-                    }
-                    _ => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(MembersSetPermissionsError::Other)
-                    }
-                }
+                let value = match tag {
+                    "user_not_found" => MembersSetPermissionsError::UserNotFound,
+                    "last_admin" => MembersSetPermissionsError::LastAdmin,
+                    "user_not_in_team" => MembersSetPermissionsError::UserNotInTeam,
+                    "cannot_set_permissions" => MembersSetPermissionsError::CannotSetPermissions,
+                    "team_license_limit" => MembersSetPermissionsError::TeamLicenseLimit,
+                    _ => MembersSetPermissionsError::Other,
+                };
+                crate::eat_json_fields(&mut map)?;
+                Ok(value)
             }
         }
         const VARIANTS: &[&str] = &["user_not_found",
@@ -18375,56 +17871,22 @@ impl<'de> ::serde::de::Deserialize<'de> for MembersSetProfileError {
                     Some(".tag") => map.next_value()?,
                     _ => return Err(de::Error::missing_field(".tag"))
                 };
-                match tag {
-                    "user_not_found" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(MembersSetProfileError::UserNotFound)
-                    }
-                    "user_not_in_team" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(MembersSetProfileError::UserNotInTeam)
-                    }
-                    "external_id_and_new_external_id_unsafe" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(MembersSetProfileError::ExternalIdAndNewExternalIdUnsafe)
-                    }
-                    "no_new_data_specified" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(MembersSetProfileError::NoNewDataSpecified)
-                    }
-                    "email_reserved_for_other_user" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(MembersSetProfileError::EmailReservedForOtherUser)
-                    }
-                    "external_id_used_by_other_user" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(MembersSetProfileError::ExternalIdUsedByOtherUser)
-                    }
-                    "set_profile_disallowed" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(MembersSetProfileError::SetProfileDisallowed)
-                    }
-                    "param_cannot_be_empty" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(MembersSetProfileError::ParamCannotBeEmpty)
-                    }
-                    "persistent_id_disabled" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(MembersSetProfileError::PersistentIdDisabled)
-                    }
-                    "persistent_id_used_by_other_user" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(MembersSetProfileError::PersistentIdUsedByOtherUser)
-                    }
-                    "directory_restricted_off" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(MembersSetProfileError::DirectoryRestrictedOff)
-                    }
-                    _ => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(MembersSetProfileError::Other)
-                    }
-                }
+                let value = match tag {
+                    "user_not_found" => MembersSetProfileError::UserNotFound,
+                    "user_not_in_team" => MembersSetProfileError::UserNotInTeam,
+                    "external_id_and_new_external_id_unsafe" => MembersSetProfileError::ExternalIdAndNewExternalIdUnsafe,
+                    "no_new_data_specified" => MembersSetProfileError::NoNewDataSpecified,
+                    "email_reserved_for_other_user" => MembersSetProfileError::EmailReservedForOtherUser,
+                    "external_id_used_by_other_user" => MembersSetProfileError::ExternalIdUsedByOtherUser,
+                    "set_profile_disallowed" => MembersSetProfileError::SetProfileDisallowed,
+                    "param_cannot_be_empty" => MembersSetProfileError::ParamCannotBeEmpty,
+                    "persistent_id_disabled" => MembersSetProfileError::PersistentIdDisabled,
+                    "persistent_id_used_by_other_user" => MembersSetProfileError::PersistentIdUsedByOtherUser,
+                    "directory_restricted_off" => MembersSetProfileError::DirectoryRestrictedOff,
+                    _ => MembersSetProfileError::Other,
+                };
+                crate::eat_json_fields(&mut map)?;
+                Ok(value)
             }
         }
         const VARIANTS: &[&str] = &["user_not_found",
@@ -18675,31 +18137,21 @@ impl<'de> ::serde::de::Deserialize<'de> for MembersSetProfilePhotoError {
                     Some(".tag") => map.next_value()?,
                     _ => return Err(de::Error::missing_field(".tag"))
                 };
-                match tag {
-                    "user_not_found" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(MembersSetProfilePhotoError::UserNotFound)
-                    }
-                    "user_not_in_team" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(MembersSetProfilePhotoError::UserNotInTeam)
-                    }
-                    "set_profile_disallowed" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(MembersSetProfilePhotoError::SetProfileDisallowed)
-                    }
+                let value = match tag {
+                    "user_not_found" => MembersSetProfilePhotoError::UserNotFound,
+                    "user_not_in_team" => MembersSetProfilePhotoError::UserNotInTeam,
+                    "set_profile_disallowed" => MembersSetProfilePhotoError::SetProfileDisallowed,
                     "photo_error" => {
                         match map.next_key()? {
-                            Some("photo_error") => Ok(MembersSetProfilePhotoError::PhotoError(map.next_value()?)),
-                            None => Err(de::Error::missing_field("photo_error")),
-                            _ => Err(de::Error::unknown_field(tag, VARIANTS))
+                            Some("photo_error") => MembersSetProfilePhotoError::PhotoError(map.next_value()?),
+                            None => return Err(de::Error::missing_field("photo_error")),
+                            _ => return Err(de::Error::unknown_field(tag, VARIANTS))
                         }
                     }
-                    _ => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(MembersSetProfilePhotoError::Other)
-                    }
-                }
+                    _ => MembersSetProfilePhotoError::Other,
+                };
+                crate::eat_json_fields(&mut map)?;
+                Ok(value)
             }
         }
         const VARIANTS: &[&str] = &["user_not_found",
@@ -18801,32 +18253,16 @@ impl<'de> ::serde::de::Deserialize<'de> for MembersSuspendError {
                     Some(".tag") => map.next_value()?,
                     _ => return Err(de::Error::missing_field(".tag"))
                 };
-                match tag {
-                    "user_not_found" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(MembersSuspendError::UserNotFound)
-                    }
-                    "user_not_in_team" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(MembersSuspendError::UserNotInTeam)
-                    }
-                    "suspend_inactive_user" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(MembersSuspendError::SuspendInactiveUser)
-                    }
-                    "suspend_last_admin" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(MembersSuspendError::SuspendLastAdmin)
-                    }
-                    "team_license_limit" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(MembersSuspendError::TeamLicenseLimit)
-                    }
-                    _ => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(MembersSuspendError::Other)
-                    }
-                }
+                let value = match tag {
+                    "user_not_found" => MembersSuspendError::UserNotFound,
+                    "user_not_in_team" => MembersSuspendError::UserNotInTeam,
+                    "suspend_inactive_user" => MembersSuspendError::SuspendInactiveUser,
+                    "suspend_last_admin" => MembersSuspendError::SuspendLastAdmin,
+                    "team_license_limit" => MembersSuspendError::TeamLicenseLimit,
+                    _ => MembersSuspendError::Other,
+                };
+                crate::eat_json_fields(&mut map)?;
+                Ok(value)
             }
         }
         const VARIANTS: &[&str] = &["user_not_found",
@@ -18941,56 +18377,22 @@ impl<'de> ::serde::de::Deserialize<'de> for MembersTransferFilesError {
                     Some(".tag") => map.next_value()?,
                     _ => return Err(de::Error::missing_field(".tag"))
                 };
-                match tag {
-                    "user_not_found" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(MembersTransferFilesError::UserNotFound)
-                    }
-                    "user_not_in_team" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(MembersTransferFilesError::UserNotInTeam)
-                    }
-                    "removed_and_transfer_dest_should_differ" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(MembersTransferFilesError::RemovedAndTransferDestShouldDiffer)
-                    }
-                    "removed_and_transfer_admin_should_differ" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(MembersTransferFilesError::RemovedAndTransferAdminShouldDiffer)
-                    }
-                    "transfer_dest_user_not_found" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(MembersTransferFilesError::TransferDestUserNotFound)
-                    }
-                    "transfer_dest_user_not_in_team" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(MembersTransferFilesError::TransferDestUserNotInTeam)
-                    }
-                    "transfer_admin_user_not_in_team" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(MembersTransferFilesError::TransferAdminUserNotInTeam)
-                    }
-                    "transfer_admin_user_not_found" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(MembersTransferFilesError::TransferAdminUserNotFound)
-                    }
-                    "unspecified_transfer_admin_id" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(MembersTransferFilesError::UnspecifiedTransferAdminId)
-                    }
-                    "transfer_admin_is_not_admin" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(MembersTransferFilesError::TransferAdminIsNotAdmin)
-                    }
-                    "recipient_not_verified" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(MembersTransferFilesError::RecipientNotVerified)
-                    }
-                    _ => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(MembersTransferFilesError::Other)
-                    }
-                }
+                let value = match tag {
+                    "user_not_found" => MembersTransferFilesError::UserNotFound,
+                    "user_not_in_team" => MembersTransferFilesError::UserNotInTeam,
+                    "removed_and_transfer_dest_should_differ" => MembersTransferFilesError::RemovedAndTransferDestShouldDiffer,
+                    "removed_and_transfer_admin_should_differ" => MembersTransferFilesError::RemovedAndTransferAdminShouldDiffer,
+                    "transfer_dest_user_not_found" => MembersTransferFilesError::TransferDestUserNotFound,
+                    "transfer_dest_user_not_in_team" => MembersTransferFilesError::TransferDestUserNotInTeam,
+                    "transfer_admin_user_not_in_team" => MembersTransferFilesError::TransferAdminUserNotInTeam,
+                    "transfer_admin_user_not_found" => MembersTransferFilesError::TransferAdminUserNotFound,
+                    "unspecified_transfer_admin_id" => MembersTransferFilesError::UnspecifiedTransferAdminId,
+                    "transfer_admin_is_not_admin" => MembersTransferFilesError::TransferAdminIsNotAdmin,
+                    "recipient_not_verified" => MembersTransferFilesError::RecipientNotVerified,
+                    _ => MembersTransferFilesError::Other,
+                };
+                crate::eat_json_fields(&mut map)?;
+                Ok(value)
             }
         }
         const VARIANTS: &[&str] = &["user_not_found",
@@ -19161,72 +18563,26 @@ impl<'de> ::serde::de::Deserialize<'de> for MembersTransferFormerMembersFilesErr
                     Some(".tag") => map.next_value()?,
                     _ => return Err(de::Error::missing_field(".tag"))
                 };
-                match tag {
-                    "user_not_found" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(MembersTransferFormerMembersFilesError::UserNotFound)
-                    }
-                    "user_not_in_team" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(MembersTransferFormerMembersFilesError::UserNotInTeam)
-                    }
-                    "removed_and_transfer_dest_should_differ" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(MembersTransferFormerMembersFilesError::RemovedAndTransferDestShouldDiffer)
-                    }
-                    "removed_and_transfer_admin_should_differ" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(MembersTransferFormerMembersFilesError::RemovedAndTransferAdminShouldDiffer)
-                    }
-                    "transfer_dest_user_not_found" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(MembersTransferFormerMembersFilesError::TransferDestUserNotFound)
-                    }
-                    "transfer_dest_user_not_in_team" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(MembersTransferFormerMembersFilesError::TransferDestUserNotInTeam)
-                    }
-                    "transfer_admin_user_not_in_team" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(MembersTransferFormerMembersFilesError::TransferAdminUserNotInTeam)
-                    }
-                    "transfer_admin_user_not_found" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(MembersTransferFormerMembersFilesError::TransferAdminUserNotFound)
-                    }
-                    "unspecified_transfer_admin_id" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(MembersTransferFormerMembersFilesError::UnspecifiedTransferAdminId)
-                    }
-                    "transfer_admin_is_not_admin" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(MembersTransferFormerMembersFilesError::TransferAdminIsNotAdmin)
-                    }
-                    "recipient_not_verified" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(MembersTransferFormerMembersFilesError::RecipientNotVerified)
-                    }
-                    "user_data_is_being_transferred" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(MembersTransferFormerMembersFilesError::UserDataIsBeingTransferred)
-                    }
-                    "user_not_removed" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(MembersTransferFormerMembersFilesError::UserNotRemoved)
-                    }
-                    "user_data_cannot_be_transferred" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(MembersTransferFormerMembersFilesError::UserDataCannotBeTransferred)
-                    }
-                    "user_data_already_transferred" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(MembersTransferFormerMembersFilesError::UserDataAlreadyTransferred)
-                    }
-                    _ => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(MembersTransferFormerMembersFilesError::Other)
-                    }
-                }
+                let value = match tag {
+                    "user_not_found" => MembersTransferFormerMembersFilesError::UserNotFound,
+                    "user_not_in_team" => MembersTransferFormerMembersFilesError::UserNotInTeam,
+                    "removed_and_transfer_dest_should_differ" => MembersTransferFormerMembersFilesError::RemovedAndTransferDestShouldDiffer,
+                    "removed_and_transfer_admin_should_differ" => MembersTransferFormerMembersFilesError::RemovedAndTransferAdminShouldDiffer,
+                    "transfer_dest_user_not_found" => MembersTransferFormerMembersFilesError::TransferDestUserNotFound,
+                    "transfer_dest_user_not_in_team" => MembersTransferFormerMembersFilesError::TransferDestUserNotInTeam,
+                    "transfer_admin_user_not_in_team" => MembersTransferFormerMembersFilesError::TransferAdminUserNotInTeam,
+                    "transfer_admin_user_not_found" => MembersTransferFormerMembersFilesError::TransferAdminUserNotFound,
+                    "unspecified_transfer_admin_id" => MembersTransferFormerMembersFilesError::UnspecifiedTransferAdminId,
+                    "transfer_admin_is_not_admin" => MembersTransferFormerMembersFilesError::TransferAdminIsNotAdmin,
+                    "recipient_not_verified" => MembersTransferFormerMembersFilesError::RecipientNotVerified,
+                    "user_data_is_being_transferred" => MembersTransferFormerMembersFilesError::UserDataIsBeingTransferred,
+                    "user_not_removed" => MembersTransferFormerMembersFilesError::UserNotRemoved,
+                    "user_data_cannot_be_transferred" => MembersTransferFormerMembersFilesError::UserDataCannotBeTransferred,
+                    "user_data_already_transferred" => MembersTransferFormerMembersFilesError::UserDataAlreadyTransferred,
+                    _ => MembersTransferFormerMembersFilesError::Other,
+                };
+                crate::eat_json_fields(&mut map)?;
+                Ok(value)
             }
         }
         const VARIANTS: &[&str] = &["user_not_found",
@@ -19499,28 +18855,15 @@ impl<'de> ::serde::de::Deserialize<'de> for MembersUnsuspendError {
                     Some(".tag") => map.next_value()?,
                     _ => return Err(de::Error::missing_field(".tag"))
                 };
-                match tag {
-                    "user_not_found" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(MembersUnsuspendError::UserNotFound)
-                    }
-                    "user_not_in_team" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(MembersUnsuspendError::UserNotInTeam)
-                    }
-                    "unsuspend_non_suspended_member" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(MembersUnsuspendError::UnsuspendNonSuspendedMember)
-                    }
-                    "team_license_limit" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(MembersUnsuspendError::TeamLicenseLimit)
-                    }
-                    _ => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(MembersUnsuspendError::Other)
-                    }
-                }
+                let value = match tag {
+                    "user_not_found" => MembersUnsuspendError::UserNotFound,
+                    "user_not_in_team" => MembersUnsuspendError::UserNotInTeam,
+                    "unsuspend_non_suspended_member" => MembersUnsuspendError::UnsuspendNonSuspendedMember,
+                    "team_license_limit" => MembersUnsuspendError::TeamLicenseLimit,
+                    _ => MembersUnsuspendError::Other,
+                };
+                crate::eat_json_fields(&mut map)?;
+                Ok(value)
             }
         }
         const VARIANTS: &[&str] = &["user_not_found",
@@ -19614,32 +18957,16 @@ impl<'de> ::serde::de::Deserialize<'de> for MobileClientPlatform {
                     Some(".tag") => map.next_value()?,
                     _ => return Err(de::Error::missing_field(".tag"))
                 };
-                match tag {
-                    "iphone" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(MobileClientPlatform::Iphone)
-                    }
-                    "ipad" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(MobileClientPlatform::Ipad)
-                    }
-                    "android" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(MobileClientPlatform::Android)
-                    }
-                    "windows_phone" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(MobileClientPlatform::WindowsPhone)
-                    }
-                    "blackberry" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(MobileClientPlatform::Blackberry)
-                    }
-                    _ => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(MobileClientPlatform::Other)
-                    }
-                }
+                let value = match tag {
+                    "iphone" => MobileClientPlatform::Iphone,
+                    "ipad" => MobileClientPlatform::Ipad,
+                    "android" => MobileClientPlatform::Android,
+                    "windows_phone" => MobileClientPlatform::WindowsPhone,
+                    "blackberry" => MobileClientPlatform::Blackberry,
+                    _ => MobileClientPlatform::Other,
+                };
+                crate::eat_json_fields(&mut map)?;
+                Ok(value)
             }
         }
         const VARIANTS: &[&str] = &["iphone",
@@ -20110,28 +19437,15 @@ impl<'de> ::serde::de::Deserialize<'de> for NamespaceType {
                     Some(".tag") => map.next_value()?,
                     _ => return Err(de::Error::missing_field(".tag"))
                 };
-                match tag {
-                    "app_folder" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(NamespaceType::AppFolder)
-                    }
-                    "shared_folder" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(NamespaceType::SharedFolder)
-                    }
-                    "team_folder" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(NamespaceType::TeamFolder)
-                    }
-                    "team_member_folder" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(NamespaceType::TeamMemberFolder)
-                    }
-                    _ => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(NamespaceType::Other)
-                    }
-                }
+                let value = match tag {
+                    "app_folder" => NamespaceType::AppFolder,
+                    "shared_folder" => NamespaceType::SharedFolder,
+                    "team_folder" => NamespaceType::TeamFolder,
+                    "team_member_folder" => NamespaceType::TeamMemberFolder,
+                    _ => NamespaceType::Other,
+                };
+                crate::eat_json_fields(&mut map)?;
+                Ok(value)
             }
         }
         const VARIANTS: &[&str] = &["app_folder",
@@ -20205,26 +19519,25 @@ impl<'de> ::serde::de::Deserialize<'de> for RemoveCustomQuotaResult {
                     Some(".tag") => map.next_value()?,
                     _ => return Err(de::Error::missing_field(".tag"))
                 };
-                match tag {
+                let value = match tag {
                     "success" => {
                         match map.next_key()? {
-                            Some("success") => Ok(RemoveCustomQuotaResult::Success(map.next_value()?)),
-                            None => Err(de::Error::missing_field("success")),
-                            _ => Err(de::Error::unknown_field(tag, VARIANTS))
+                            Some("success") => RemoveCustomQuotaResult::Success(map.next_value()?),
+                            None => return Err(de::Error::missing_field("success")),
+                            _ => return Err(de::Error::unknown_field(tag, VARIANTS))
                         }
                     }
                     "invalid_user" => {
                         match map.next_key()? {
-                            Some("invalid_user") => Ok(RemoveCustomQuotaResult::InvalidUser(map.next_value()?)),
-                            None => Err(de::Error::missing_field("invalid_user")),
-                            _ => Err(de::Error::unknown_field(tag, VARIANTS))
+                            Some("invalid_user") => RemoveCustomQuotaResult::InvalidUser(map.next_value()?),
+                            None => return Err(de::Error::missing_field("invalid_user")),
+                            _ => return Err(de::Error::unknown_field(tag, VARIANTS))
                         }
                     }
-                    _ => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(RemoveCustomQuotaResult::Other)
-                    }
-                }
+                    _ => RemoveCustomQuotaResult::Other,
+                };
+                crate::eat_json_fields(&mut map)?;
+                Ok(value)
             }
         }
         const VARIANTS: &[&str] = &["success",
@@ -20393,33 +19706,32 @@ impl<'de> ::serde::de::Deserialize<'de> for ResendSecondaryEmailResult {
                     Some(".tag") => map.next_value()?,
                     _ => return Err(de::Error::missing_field(".tag"))
                 };
-                match tag {
+                let value = match tag {
                     "success" => {
                         match map.next_key()? {
-                            Some("success") => Ok(ResendSecondaryEmailResult::Success(map.next_value()?)),
-                            None => Err(de::Error::missing_field("success")),
-                            _ => Err(de::Error::unknown_field(tag, VARIANTS))
+                            Some("success") => ResendSecondaryEmailResult::Success(map.next_value()?),
+                            None => return Err(de::Error::missing_field("success")),
+                            _ => return Err(de::Error::unknown_field(tag, VARIANTS))
                         }
                     }
                     "not_pending" => {
                         match map.next_key()? {
-                            Some("not_pending") => Ok(ResendSecondaryEmailResult::NotPending(map.next_value()?)),
-                            None => Err(de::Error::missing_field("not_pending")),
-                            _ => Err(de::Error::unknown_field(tag, VARIANTS))
+                            Some("not_pending") => ResendSecondaryEmailResult::NotPending(map.next_value()?),
+                            None => return Err(de::Error::missing_field("not_pending")),
+                            _ => return Err(de::Error::unknown_field(tag, VARIANTS))
                         }
                     }
                     "rate_limited" => {
                         match map.next_key()? {
-                            Some("rate_limited") => Ok(ResendSecondaryEmailResult::RateLimited(map.next_value()?)),
-                            None => Err(de::Error::missing_field("rate_limited")),
-                            _ => Err(de::Error::unknown_field(tag, VARIANTS))
+                            Some("rate_limited") => ResendSecondaryEmailResult::RateLimited(map.next_value()?),
+                            None => return Err(de::Error::missing_field("rate_limited")),
+                            _ => return Err(de::Error::unknown_field(tag, VARIANTS))
                         }
                     }
-                    _ => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(ResendSecondaryEmailResult::Other)
-                    }
-                }
+                    _ => ResendSecondaryEmailResult::Other,
+                };
+                crate::eat_json_fields(&mut map)?;
+                Ok(value)
             }
         }
         const VARIANTS: &[&str] = &["success",
@@ -20788,12 +20100,14 @@ impl<'de> ::serde::de::Deserialize<'de> for RevokeDeviceSessionArg {
                     Some(".tag") => map.next_value()?,
                     _ => return Err(de::Error::missing_field(".tag"))
                 };
-                match tag {
-                    "web_session" => Ok(RevokeDeviceSessionArg::WebSession(DeviceSessionArg::internal_deserialize(map)?)),
-                    "desktop_client" => Ok(RevokeDeviceSessionArg::DesktopClient(RevokeDesktopClientArg::internal_deserialize(map)?)),
-                    "mobile_client" => Ok(RevokeDeviceSessionArg::MobileClient(DeviceSessionArg::internal_deserialize(map)?)),
-                    _ => Err(de::Error::unknown_variant(tag, VARIANTS))
-                }
+                let value = match tag {
+                    "web_session" => RevokeDeviceSessionArg::WebSession(DeviceSessionArg::internal_deserialize(&mut map)?),
+                    "desktop_client" => RevokeDeviceSessionArg::DesktopClient(RevokeDesktopClientArg::internal_deserialize(&mut map)?),
+                    "mobile_client" => RevokeDeviceSessionArg::MobileClient(DeviceSessionArg::internal_deserialize(&mut map)?),
+                    _ => return Err(de::Error::unknown_variant(tag, VARIANTS))
+                };
+                crate::eat_json_fields(&mut map)?;
+                Ok(value)
             }
         }
         const VARIANTS: &[&str] = &["web_session",
@@ -21090,20 +20404,13 @@ impl<'de> ::serde::de::Deserialize<'de> for RevokeDeviceSessionError {
                     Some(".tag") => map.next_value()?,
                     _ => return Err(de::Error::missing_field(".tag"))
                 };
-                match tag {
-                    "device_session_not_found" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(RevokeDeviceSessionError::DeviceSessionNotFound)
-                    }
-                    "member_not_found" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(RevokeDeviceSessionError::MemberNotFound)
-                    }
-                    _ => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(RevokeDeviceSessionError::Other)
-                    }
-                }
+                let value = match tag {
+                    "device_session_not_found" => RevokeDeviceSessionError::DeviceSessionNotFound,
+                    "member_not_found" => RevokeDeviceSessionError::MemberNotFound,
+                    _ => RevokeDeviceSessionError::Other,
+                };
+                crate::eat_json_fields(&mut map)?;
+                Ok(value)
             }
         }
         const VARIANTS: &[&str] = &["device_session_not_found",
@@ -21639,24 +20946,14 @@ impl<'de> ::serde::de::Deserialize<'de> for RevokeLinkedAppError {
                     Some(".tag") => map.next_value()?,
                     _ => return Err(de::Error::missing_field(".tag"))
                 };
-                match tag {
-                    "app_not_found" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(RevokeLinkedAppError::AppNotFound)
-                    }
-                    "member_not_found" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(RevokeLinkedAppError::MemberNotFound)
-                    }
-                    "app_folder_removal_not_supported" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(RevokeLinkedAppError::AppFolderRemovalNotSupported)
-                    }
-                    _ => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(RevokeLinkedAppError::Other)
-                    }
-                }
+                let value = match tag {
+                    "app_not_found" => RevokeLinkedAppError::AppNotFound,
+                    "member_not_found" => RevokeLinkedAppError::MemberNotFound,
+                    "app_folder_removal_not_supported" => RevokeLinkedAppError::AppFolderRemovalNotSupported,
+                    _ => RevokeLinkedAppError::Other,
+                };
+                crate::eat_json_fields(&mut map)?;
+                Ok(value)
             }
         }
         const VARIANTS: &[&str] = &["app_not_found",
@@ -21935,20 +21232,13 @@ impl<'de> ::serde::de::Deserialize<'de> for SetCustomQuotaError {
                     Some(".tag") => map.next_value()?,
                     _ => return Err(de::Error::missing_field(".tag"))
                 };
-                match tag {
-                    "too_many_users" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(SetCustomQuotaError::TooManyUsers)
-                    }
-                    "some_users_are_excluded" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(SetCustomQuotaError::SomeUsersAreExcluded)
-                    }
-                    _ => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(SetCustomQuotaError::Other)
-                    }
-                }
+                let value = match tag {
+                    "too_many_users" => SetCustomQuotaError::TooManyUsers,
+                    "some_users_are_excluded" => SetCustomQuotaError::SomeUsersAreExcluded,
+                    _ => SetCustomQuotaError::Other,
+                };
+                crate::eat_json_fields(&mut map)?;
+                Ok(value)
             }
         }
         const VARIANTS: &[&str] = &["too_many_users",
@@ -22125,20 +21415,13 @@ impl<'de> ::serde::de::Deserialize<'de> for TeamFolderAccessError {
                     Some(".tag") => map.next_value()?,
                     _ => return Err(de::Error::missing_field(".tag"))
                 };
-                match tag {
-                    "invalid_team_folder_id" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(TeamFolderAccessError::InvalidTeamFolderId)
-                    }
-                    "no_access" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(TeamFolderAccessError::NoAccess)
-                    }
-                    _ => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(TeamFolderAccessError::Other)
-                    }
-                }
+                let value = match tag {
+                    "invalid_team_folder_id" => TeamFolderAccessError::InvalidTeamFolderId,
+                    "no_access" => TeamFolderAccessError::NoAccess,
+                    _ => TeamFolderAccessError::Other,
+                };
+                crate::eat_json_fields(&mut map)?;
+                Ok(value)
             }
         }
         const VARIANTS: &[&str] = &["invalid_team_folder_id",
@@ -22210,33 +21493,32 @@ impl<'de> ::serde::de::Deserialize<'de> for TeamFolderActivateError {
                     Some(".tag") => map.next_value()?,
                     _ => return Err(de::Error::missing_field(".tag"))
                 };
-                match tag {
+                let value = match tag {
                     "access_error" => {
                         match map.next_key()? {
-                            Some("access_error") => Ok(TeamFolderActivateError::AccessError(map.next_value()?)),
-                            None => Err(de::Error::missing_field("access_error")),
-                            _ => Err(de::Error::unknown_field(tag, VARIANTS))
+                            Some("access_error") => TeamFolderActivateError::AccessError(map.next_value()?),
+                            None => return Err(de::Error::missing_field("access_error")),
+                            _ => return Err(de::Error::unknown_field(tag, VARIANTS))
                         }
                     }
                     "status_error" => {
                         match map.next_key()? {
-                            Some("status_error") => Ok(TeamFolderActivateError::StatusError(map.next_value()?)),
-                            None => Err(de::Error::missing_field("status_error")),
-                            _ => Err(de::Error::unknown_field(tag, VARIANTS))
+                            Some("status_error") => TeamFolderActivateError::StatusError(map.next_value()?),
+                            None => return Err(de::Error::missing_field("status_error")),
+                            _ => return Err(de::Error::unknown_field(tag, VARIANTS))
                         }
                     }
                     "team_shared_dropbox_error" => {
                         match map.next_key()? {
-                            Some("team_shared_dropbox_error") => Ok(TeamFolderActivateError::TeamSharedDropboxError(map.next_value()?)),
-                            None => Err(de::Error::missing_field("team_shared_dropbox_error")),
-                            _ => Err(de::Error::unknown_field(tag, VARIANTS))
+                            Some("team_shared_dropbox_error") => TeamFolderActivateError::TeamSharedDropboxError(map.next_value()?),
+                            None => return Err(de::Error::missing_field("team_shared_dropbox_error")),
+                            _ => return Err(de::Error::unknown_field(tag, VARIANTS))
                         }
                     }
-                    _ => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(TeamFolderActivateError::Other)
-                    }
-                }
+                    _ => TeamFolderActivateError::Other,
+                };
+                crate::eat_json_fields(&mut map)?;
+                Ok(value)
             }
         }
         const VARIANTS: &[&str] = &["access_error",
@@ -22435,33 +21717,32 @@ impl<'de> ::serde::de::Deserialize<'de> for TeamFolderArchiveError {
                     Some(".tag") => map.next_value()?,
                     _ => return Err(de::Error::missing_field(".tag"))
                 };
-                match tag {
+                let value = match tag {
                     "access_error" => {
                         match map.next_key()? {
-                            Some("access_error") => Ok(TeamFolderArchiveError::AccessError(map.next_value()?)),
-                            None => Err(de::Error::missing_field("access_error")),
-                            _ => Err(de::Error::unknown_field(tag, VARIANTS))
+                            Some("access_error") => TeamFolderArchiveError::AccessError(map.next_value()?),
+                            None => return Err(de::Error::missing_field("access_error")),
+                            _ => return Err(de::Error::unknown_field(tag, VARIANTS))
                         }
                     }
                     "status_error" => {
                         match map.next_key()? {
-                            Some("status_error") => Ok(TeamFolderArchiveError::StatusError(map.next_value()?)),
-                            None => Err(de::Error::missing_field("status_error")),
-                            _ => Err(de::Error::unknown_field(tag, VARIANTS))
+                            Some("status_error") => TeamFolderArchiveError::StatusError(map.next_value()?),
+                            None => return Err(de::Error::missing_field("status_error")),
+                            _ => return Err(de::Error::unknown_field(tag, VARIANTS))
                         }
                     }
                     "team_shared_dropbox_error" => {
                         match map.next_key()? {
-                            Some("team_shared_dropbox_error") => Ok(TeamFolderArchiveError::TeamSharedDropboxError(map.next_value()?)),
-                            None => Err(de::Error::missing_field("team_shared_dropbox_error")),
-                            _ => Err(de::Error::unknown_field(tag, VARIANTS))
+                            Some("team_shared_dropbox_error") => TeamFolderArchiveError::TeamSharedDropboxError(map.next_value()?),
+                            None => return Err(de::Error::missing_field("team_shared_dropbox_error")),
+                            _ => return Err(de::Error::unknown_field(tag, VARIANTS))
                         }
                     }
-                    _ => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(TeamFolderArchiveError::Other)
-                    }
-                }
+                    _ => TeamFolderArchiveError::Other,
+                };
+                crate::eat_json_fields(&mut map)?;
+                Ok(value)
             }
         }
         const VARIANTS: &[&str] = &["access_error",
@@ -22551,21 +21832,20 @@ impl<'de> ::serde::de::Deserialize<'de> for TeamFolderArchiveJobStatus {
                     Some(".tag") => map.next_value()?,
                     _ => return Err(de::Error::missing_field(".tag"))
                 };
-                match tag {
-                    "in_progress" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(TeamFolderArchiveJobStatus::InProgress)
-                    }
-                    "complete" => Ok(TeamFolderArchiveJobStatus::Complete(TeamFolderMetadata::internal_deserialize(map)?)),
+                let value = match tag {
+                    "in_progress" => TeamFolderArchiveJobStatus::InProgress,
+                    "complete" => TeamFolderArchiveJobStatus::Complete(TeamFolderMetadata::internal_deserialize(&mut map)?),
                     "failed" => {
                         match map.next_key()? {
-                            Some("failed") => Ok(TeamFolderArchiveJobStatus::Failed(map.next_value()?)),
-                            None => Err(de::Error::missing_field("failed")),
-                            _ => Err(de::Error::unknown_field(tag, VARIANTS))
+                            Some("failed") => TeamFolderArchiveJobStatus::Failed(map.next_value()?),
+                            None => return Err(de::Error::missing_field("failed")),
+                            _ => return Err(de::Error::unknown_field(tag, VARIANTS))
                         }
                     }
-                    _ => Err(de::Error::unknown_variant(tag, VARIANTS))
-                }
+                    _ => return Err(de::Error::unknown_variant(tag, VARIANTS))
+                };
+                crate::eat_json_fields(&mut map)?;
+                Ok(value)
             }
         }
         const VARIANTS: &[&str] = &["in_progress",
@@ -22627,17 +21907,19 @@ impl<'de> ::serde::de::Deserialize<'de> for TeamFolderArchiveLaunch {
                     Some(".tag") => map.next_value()?,
                     _ => return Err(de::Error::missing_field(".tag"))
                 };
-                match tag {
+                let value = match tag {
                     "async_job_id" => {
                         match map.next_key()? {
-                            Some("async_job_id") => Ok(TeamFolderArchiveLaunch::AsyncJobId(map.next_value()?)),
-                            None => Err(de::Error::missing_field("async_job_id")),
-                            _ => Err(de::Error::unknown_field(tag, VARIANTS))
+                            Some("async_job_id") => TeamFolderArchiveLaunch::AsyncJobId(map.next_value()?),
+                            None => return Err(de::Error::missing_field("async_job_id")),
+                            _ => return Err(de::Error::unknown_field(tag, VARIANTS))
                         }
                     }
-                    "complete" => Ok(TeamFolderArchiveLaunch::Complete(TeamFolderMetadata::internal_deserialize(map)?)),
-                    _ => Err(de::Error::unknown_variant(tag, VARIANTS))
-                }
+                    "complete" => TeamFolderArchiveLaunch::Complete(TeamFolderMetadata::internal_deserialize(&mut map)?),
+                    _ => return Err(de::Error::unknown_variant(tag, VARIANTS))
+                };
+                crate::eat_json_fields(&mut map)?;
+                Ok(value)
             }
         }
         const VARIANTS: &[&str] = &["async_job_id",
@@ -22809,31 +22091,21 @@ impl<'de> ::serde::de::Deserialize<'de> for TeamFolderCreateError {
                     Some(".tag") => map.next_value()?,
                     _ => return Err(de::Error::missing_field(".tag"))
                 };
-                match tag {
-                    "invalid_folder_name" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(TeamFolderCreateError::InvalidFolderName)
-                    }
-                    "folder_name_already_used" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(TeamFolderCreateError::FolderNameAlreadyUsed)
-                    }
-                    "folder_name_reserved" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(TeamFolderCreateError::FolderNameReserved)
-                    }
+                let value = match tag {
+                    "invalid_folder_name" => TeamFolderCreateError::InvalidFolderName,
+                    "folder_name_already_used" => TeamFolderCreateError::FolderNameAlreadyUsed,
+                    "folder_name_reserved" => TeamFolderCreateError::FolderNameReserved,
                     "sync_settings_error" => {
                         match map.next_key()? {
-                            Some("sync_settings_error") => Ok(TeamFolderCreateError::SyncSettingsError(map.next_value()?)),
-                            None => Err(de::Error::missing_field("sync_settings_error")),
-                            _ => Err(de::Error::unknown_field(tag, VARIANTS))
+                            Some("sync_settings_error") => TeamFolderCreateError::SyncSettingsError(map.next_value()?),
+                            None => return Err(de::Error::missing_field("sync_settings_error")),
+                            _ => return Err(de::Error::unknown_field(tag, VARIANTS))
                         }
                     }
-                    _ => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(TeamFolderCreateError::Other)
-                    }
-                }
+                    _ => TeamFolderCreateError::Other,
+                };
+                crate::eat_json_fields(&mut map)?;
+                Ok(value)
             }
         }
         const VARIANTS: &[&str] = &["invalid_folder_name",
@@ -22925,17 +22197,19 @@ impl<'de> ::serde::de::Deserialize<'de> for TeamFolderGetInfoItem {
                     Some(".tag") => map.next_value()?,
                     _ => return Err(de::Error::missing_field(".tag"))
                 };
-                match tag {
+                let value = match tag {
                     "id_not_found" => {
                         match map.next_key()? {
-                            Some("id_not_found") => Ok(TeamFolderGetInfoItem::IdNotFound(map.next_value()?)),
-                            None => Err(de::Error::missing_field("id_not_found")),
-                            _ => Err(de::Error::unknown_field(tag, VARIANTS))
+                            Some("id_not_found") => TeamFolderGetInfoItem::IdNotFound(map.next_value()?),
+                            None => return Err(de::Error::missing_field("id_not_found")),
+                            _ => return Err(de::Error::unknown_field(tag, VARIANTS))
                         }
                     }
-                    "team_folder_metadata" => Ok(TeamFolderGetInfoItem::TeamFolderMetadata(TeamFolderMetadata::internal_deserialize(map)?)),
-                    _ => Err(de::Error::unknown_variant(tag, VARIANTS))
-                }
+                    "team_folder_metadata" => TeamFolderGetInfoItem::TeamFolderMetadata(TeamFolderMetadata::internal_deserialize(&mut map)?),
+                    _ => return Err(de::Error::unknown_variant(tag, VARIANTS))
+                };
+                crate::eat_json_fields(&mut map)?;
+                Ok(value)
             }
         }
         const VARIANTS: &[&str] = &["id_not_found",
@@ -23176,24 +22450,14 @@ impl<'de> ::serde::de::Deserialize<'de> for TeamFolderInvalidStatusError {
                     Some(".tag") => map.next_value()?,
                     _ => return Err(de::Error::missing_field(".tag"))
                 };
-                match tag {
-                    "active" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(TeamFolderInvalidStatusError::Active)
-                    }
-                    "archived" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(TeamFolderInvalidStatusError::Archived)
-                    }
-                    "archive_in_progress" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(TeamFolderInvalidStatusError::ArchiveInProgress)
-                    }
-                    _ => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(TeamFolderInvalidStatusError::Other)
-                    }
-                }
+                let value = match tag {
+                    "active" => TeamFolderInvalidStatusError::Active,
+                    "archived" => TeamFolderInvalidStatusError::Archived,
+                    "archive_in_progress" => TeamFolderInvalidStatusError::ArchiveInProgress,
+                    _ => TeamFolderInvalidStatusError::Other,
+                };
+                crate::eat_json_fields(&mut map)?;
+                Ok(value)
             }
         }
         const VARIANTS: &[&str] = &["active",
@@ -23447,16 +22711,12 @@ impl<'de> ::serde::de::Deserialize<'de> for TeamFolderListContinueError {
                     Some(".tag") => map.next_value()?,
                     _ => return Err(de::Error::missing_field(".tag"))
                 };
-                match tag {
-                    "invalid_cursor" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(TeamFolderListContinueError::InvalidCursor)
-                    }
-                    _ => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(TeamFolderListContinueError::Other)
-                    }
-                }
+                let value = match tag {
+                    "invalid_cursor" => TeamFolderListContinueError::InvalidCursor,
+                    _ => TeamFolderListContinueError::Other,
+                };
+                crate::eat_json_fields(&mut map)?;
+                Ok(value)
             }
         }
         const VARIANTS: &[&str] = &["invalid_cursor",
@@ -23901,33 +23161,32 @@ impl<'de> ::serde::de::Deserialize<'de> for TeamFolderPermanentlyDeleteError {
                     Some(".tag") => map.next_value()?,
                     _ => return Err(de::Error::missing_field(".tag"))
                 };
-                match tag {
+                let value = match tag {
                     "access_error" => {
                         match map.next_key()? {
-                            Some("access_error") => Ok(TeamFolderPermanentlyDeleteError::AccessError(map.next_value()?)),
-                            None => Err(de::Error::missing_field("access_error")),
-                            _ => Err(de::Error::unknown_field(tag, VARIANTS))
+                            Some("access_error") => TeamFolderPermanentlyDeleteError::AccessError(map.next_value()?),
+                            None => return Err(de::Error::missing_field("access_error")),
+                            _ => return Err(de::Error::unknown_field(tag, VARIANTS))
                         }
                     }
                     "status_error" => {
                         match map.next_key()? {
-                            Some("status_error") => Ok(TeamFolderPermanentlyDeleteError::StatusError(map.next_value()?)),
-                            None => Err(de::Error::missing_field("status_error")),
-                            _ => Err(de::Error::unknown_field(tag, VARIANTS))
+                            Some("status_error") => TeamFolderPermanentlyDeleteError::StatusError(map.next_value()?),
+                            None => return Err(de::Error::missing_field("status_error")),
+                            _ => return Err(de::Error::unknown_field(tag, VARIANTS))
                         }
                     }
                     "team_shared_dropbox_error" => {
                         match map.next_key()? {
-                            Some("team_shared_dropbox_error") => Ok(TeamFolderPermanentlyDeleteError::TeamSharedDropboxError(map.next_value()?)),
-                            None => Err(de::Error::missing_field("team_shared_dropbox_error")),
-                            _ => Err(de::Error::unknown_field(tag, VARIANTS))
+                            Some("team_shared_dropbox_error") => TeamFolderPermanentlyDeleteError::TeamSharedDropboxError(map.next_value()?),
+                            None => return Err(de::Error::missing_field("team_shared_dropbox_error")),
+                            _ => return Err(de::Error::unknown_field(tag, VARIANTS))
                         }
                     }
-                    _ => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(TeamFolderPermanentlyDeleteError::Other)
-                    }
-                }
+                    _ => TeamFolderPermanentlyDeleteError::Other,
+                };
+                crate::eat_json_fields(&mut map)?;
+                Ok(value)
             }
         }
         const VARIANTS: &[&str] = &["access_error",
@@ -24126,45 +23385,35 @@ impl<'de> ::serde::de::Deserialize<'de> for TeamFolderRenameError {
                     Some(".tag") => map.next_value()?,
                     _ => return Err(de::Error::missing_field(".tag"))
                 };
-                match tag {
+                let value = match tag {
                     "access_error" => {
                         match map.next_key()? {
-                            Some("access_error") => Ok(TeamFolderRenameError::AccessError(map.next_value()?)),
-                            None => Err(de::Error::missing_field("access_error")),
-                            _ => Err(de::Error::unknown_field(tag, VARIANTS))
+                            Some("access_error") => TeamFolderRenameError::AccessError(map.next_value()?),
+                            None => return Err(de::Error::missing_field("access_error")),
+                            _ => return Err(de::Error::unknown_field(tag, VARIANTS))
                         }
                     }
                     "status_error" => {
                         match map.next_key()? {
-                            Some("status_error") => Ok(TeamFolderRenameError::StatusError(map.next_value()?)),
-                            None => Err(de::Error::missing_field("status_error")),
-                            _ => Err(de::Error::unknown_field(tag, VARIANTS))
+                            Some("status_error") => TeamFolderRenameError::StatusError(map.next_value()?),
+                            None => return Err(de::Error::missing_field("status_error")),
+                            _ => return Err(de::Error::unknown_field(tag, VARIANTS))
                         }
                     }
                     "team_shared_dropbox_error" => {
                         match map.next_key()? {
-                            Some("team_shared_dropbox_error") => Ok(TeamFolderRenameError::TeamSharedDropboxError(map.next_value()?)),
-                            None => Err(de::Error::missing_field("team_shared_dropbox_error")),
-                            _ => Err(de::Error::unknown_field(tag, VARIANTS))
+                            Some("team_shared_dropbox_error") => TeamFolderRenameError::TeamSharedDropboxError(map.next_value()?),
+                            None => return Err(de::Error::missing_field("team_shared_dropbox_error")),
+                            _ => return Err(de::Error::unknown_field(tag, VARIANTS))
                         }
                     }
-                    "invalid_folder_name" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(TeamFolderRenameError::InvalidFolderName)
-                    }
-                    "folder_name_already_used" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(TeamFolderRenameError::FolderNameAlreadyUsed)
-                    }
-                    "folder_name_reserved" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(TeamFolderRenameError::FolderNameReserved)
-                    }
-                    _ => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(TeamFolderRenameError::Other)
-                    }
-                }
+                    "invalid_folder_name" => TeamFolderRenameError::InvalidFolderName,
+                    "folder_name_already_used" => TeamFolderRenameError::FolderNameAlreadyUsed,
+                    "folder_name_reserved" => TeamFolderRenameError::FolderNameReserved,
+                    _ => TeamFolderRenameError::Other,
+                };
+                crate::eat_json_fields(&mut map)?;
+                Ok(value)
             }
         }
         const VARIANTS: &[&str] = &["access_error",
@@ -24281,24 +23530,14 @@ impl<'de> ::serde::de::Deserialize<'de> for TeamFolderStatus {
                     Some(".tag") => map.next_value()?,
                     _ => return Err(de::Error::missing_field(".tag"))
                 };
-                match tag {
-                    "active" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(TeamFolderStatus::Active)
-                    }
-                    "archived" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(TeamFolderStatus::Archived)
-                    }
-                    "archive_in_progress" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(TeamFolderStatus::ArchiveInProgress)
-                    }
-                    _ => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(TeamFolderStatus::Other)
-                    }
-                }
+                let value = match tag {
+                    "active" => TeamFolderStatus::Active,
+                    "archived" => TeamFolderStatus::Archived,
+                    "archive_in_progress" => TeamFolderStatus::ArchiveInProgress,
+                    _ => TeamFolderStatus::Other,
+                };
+                crate::eat_json_fields(&mut map)?;
+                Ok(value)
             }
         }
         const VARIANTS: &[&str] = &["active",
@@ -24362,16 +23601,12 @@ impl<'de> ::serde::de::Deserialize<'de> for TeamFolderTeamSharedDropboxError {
                     Some(".tag") => map.next_value()?,
                     _ => return Err(de::Error::missing_field(".tag"))
                 };
-                match tag {
-                    "disallowed" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(TeamFolderTeamSharedDropboxError::Disallowed)
-                    }
-                    _ => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(TeamFolderTeamSharedDropboxError::Other)
-                    }
-                }
+                let value = match tag {
+                    "disallowed" => TeamFolderTeamSharedDropboxError::Disallowed,
+                    _ => TeamFolderTeamSharedDropboxError::Other,
+                };
+                crate::eat_json_fields(&mut map)?;
+                Ok(value)
             }
         }
         const VARIANTS: &[&str] = &["disallowed",
@@ -24566,40 +23801,39 @@ impl<'de> ::serde::de::Deserialize<'de> for TeamFolderUpdateSyncSettingsError {
                     Some(".tag") => map.next_value()?,
                     _ => return Err(de::Error::missing_field(".tag"))
                 };
-                match tag {
+                let value = match tag {
                     "access_error" => {
                         match map.next_key()? {
-                            Some("access_error") => Ok(TeamFolderUpdateSyncSettingsError::AccessError(map.next_value()?)),
-                            None => Err(de::Error::missing_field("access_error")),
-                            _ => Err(de::Error::unknown_field(tag, VARIANTS))
+                            Some("access_error") => TeamFolderUpdateSyncSettingsError::AccessError(map.next_value()?),
+                            None => return Err(de::Error::missing_field("access_error")),
+                            _ => return Err(de::Error::unknown_field(tag, VARIANTS))
                         }
                     }
                     "status_error" => {
                         match map.next_key()? {
-                            Some("status_error") => Ok(TeamFolderUpdateSyncSettingsError::StatusError(map.next_value()?)),
-                            None => Err(de::Error::missing_field("status_error")),
-                            _ => Err(de::Error::unknown_field(tag, VARIANTS))
+                            Some("status_error") => TeamFolderUpdateSyncSettingsError::StatusError(map.next_value()?),
+                            None => return Err(de::Error::missing_field("status_error")),
+                            _ => return Err(de::Error::unknown_field(tag, VARIANTS))
                         }
                     }
                     "team_shared_dropbox_error" => {
                         match map.next_key()? {
-                            Some("team_shared_dropbox_error") => Ok(TeamFolderUpdateSyncSettingsError::TeamSharedDropboxError(map.next_value()?)),
-                            None => Err(de::Error::missing_field("team_shared_dropbox_error")),
-                            _ => Err(de::Error::unknown_field(tag, VARIANTS))
+                            Some("team_shared_dropbox_error") => TeamFolderUpdateSyncSettingsError::TeamSharedDropboxError(map.next_value()?),
+                            None => return Err(de::Error::missing_field("team_shared_dropbox_error")),
+                            _ => return Err(de::Error::unknown_field(tag, VARIANTS))
                         }
                     }
                     "sync_settings_error" => {
                         match map.next_key()? {
-                            Some("sync_settings_error") => Ok(TeamFolderUpdateSyncSettingsError::SyncSettingsError(map.next_value()?)),
-                            None => Err(de::Error::missing_field("sync_settings_error")),
-                            _ => Err(de::Error::unknown_field(tag, VARIANTS))
+                            Some("sync_settings_error") => TeamFolderUpdateSyncSettingsError::SyncSettingsError(map.next_value()?),
+                            None => return Err(de::Error::missing_field("sync_settings_error")),
+                            _ => return Err(de::Error::unknown_field(tag, VARIANTS))
                         }
                     }
-                    _ => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(TeamFolderUpdateSyncSettingsError::Other)
-                    }
-                }
+                    _ => TeamFolderUpdateSyncSettingsError::Other,
+                };
+                crate::eat_json_fields(&mut map)?;
+                Ok(value)
             }
         }
         const VARIANTS: &[&str] = &["access_error",
@@ -25315,22 +24549,15 @@ impl<'de> ::serde::de::Deserialize<'de> for TeamMemberStatus {
                     Some(".tag") => map.next_value()?,
                     _ => return Err(de::Error::missing_field(".tag"))
                 };
-                match tag {
-                    "active" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(TeamMemberStatus::Active)
-                    }
-                    "invited" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(TeamMemberStatus::Invited)
-                    }
-                    "suspended" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(TeamMemberStatus::Suspended)
-                    }
-                    "removed" => Ok(TeamMemberStatus::Removed(RemovedStatus::internal_deserialize(map)?)),
-                    _ => Err(de::Error::unknown_variant(tag, VARIANTS))
-                }
+                let value = match tag {
+                    "active" => TeamMemberStatus::Active,
+                    "invited" => TeamMemberStatus::Invited,
+                    "suspended" => TeamMemberStatus::Suspended,
+                    "removed" => TeamMemberStatus::Removed(RemovedStatus::internal_deserialize(&mut map)?),
+                    _ => return Err(de::Error::unknown_variant(tag, VARIANTS))
+                };
+                crate::eat_json_fields(&mut map)?;
+                Ok(value)
             }
         }
         const VARIANTS: &[&str] = &["active",
@@ -25399,17 +24626,13 @@ impl<'de> ::serde::de::Deserialize<'de> for TeamMembershipType {
                     Some(".tag") => map.next_value()?,
                     _ => return Err(de::Error::missing_field(".tag"))
                 };
-                match tag {
-                    "full" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(TeamMembershipType::Full)
-                    }
-                    "limited" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(TeamMembershipType::Limited)
-                    }
-                    _ => Err(de::Error::unknown_variant(tag, VARIANTS))
-                }
+                let value = match tag {
+                    "full" => TeamMembershipType::Full,
+                    "limited" => TeamMembershipType::Limited,
+                    _ => return Err(de::Error::unknown_variant(tag, VARIANTS))
+                };
+                crate::eat_json_fields(&mut map)?;
+                Ok(value)
             }
         }
         const VARIANTS: &[&str] = &["full",
@@ -25642,20 +24865,13 @@ impl<'de> ::serde::de::Deserialize<'de> for TeamNamespacesListContinueError {
                     Some(".tag") => map.next_value()?,
                     _ => return Err(de::Error::missing_field(".tag"))
                 };
-                match tag {
-                    "invalid_arg" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(TeamNamespacesListContinueError::InvalidArg)
-                    }
-                    "invalid_cursor" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(TeamNamespacesListContinueError::InvalidCursor)
-                    }
-                    _ => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(TeamNamespacesListContinueError::Other)
-                    }
-                }
+                let value = match tag {
+                    "invalid_arg" => TeamNamespacesListContinueError::InvalidArg,
+                    "invalid_cursor" => TeamNamespacesListContinueError::InvalidCursor,
+                    _ => TeamNamespacesListContinueError::Other,
+                };
+                crate::eat_json_fields(&mut map)?;
+                Ok(value)
             }
         }
         const VARIANTS: &[&str] = &["invalid_arg",
@@ -25725,16 +24941,12 @@ impl<'de> ::serde::de::Deserialize<'de> for TeamNamespacesListError {
                     Some(".tag") => map.next_value()?,
                     _ => return Err(de::Error::missing_field(".tag"))
                 };
-                match tag {
-                    "invalid_arg" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(TeamNamespacesListError::InvalidArg)
-                    }
-                    _ => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(TeamNamespacesListError::Other)
-                    }
-                }
+                let value = match tag {
+                    "invalid_arg" => TeamNamespacesListError::InvalidArg,
+                    _ => TeamNamespacesListError::Other,
+                };
+                crate::eat_json_fields(&mut map)?;
+                Ok(value)
             }
         }
         const VARIANTS: &[&str] = &["invalid_arg",
@@ -25920,24 +25132,14 @@ impl<'de> ::serde::de::Deserialize<'de> for TeamReportFailureReason {
                     Some(".tag") => map.next_value()?,
                     _ => return Err(de::Error::missing_field(".tag"))
                 };
-                match tag {
-                    "temporary_error" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(TeamReportFailureReason::TemporaryError)
-                    }
-                    "many_reports_at_once" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(TeamReportFailureReason::ManyReportsAtOnce)
-                    }
-                    "too_much_data" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(TeamReportFailureReason::TooMuchData)
-                    }
-                    _ => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(TeamReportFailureReason::Other)
-                    }
-                }
+                let value = match tag {
+                    "temporary_error" => TeamReportFailureReason::TemporaryError,
+                    "many_reports_at_once" => TeamReportFailureReason::ManyReportsAtOnce,
+                    "too_much_data" => TeamReportFailureReason::TooMuchData,
+                    _ => TeamReportFailureReason::Other,
+                };
+                crate::eat_json_fields(&mut map)?;
+                Ok(value)
             }
         }
         const VARIANTS: &[&str] = &["temporary_error",
@@ -26007,20 +25209,13 @@ impl<'de> ::serde::de::Deserialize<'de> for TokenGetAuthenticatedAdminError {
                     Some(".tag") => map.next_value()?,
                     _ => return Err(de::Error::missing_field(".tag"))
                 };
-                match tag {
-                    "mapping_not_found" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(TokenGetAuthenticatedAdminError::MappingNotFound)
-                    }
-                    "admin_not_active" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(TokenGetAuthenticatedAdminError::AdminNotActive)
-                    }
-                    _ => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(TokenGetAuthenticatedAdminError::Other)
-                    }
-                }
+                let value = match tag {
+                    "mapping_not_found" => TokenGetAuthenticatedAdminError::MappingNotFound,
+                    "admin_not_active" => TokenGetAuthenticatedAdminError::AdminNotActive,
+                    _ => TokenGetAuthenticatedAdminError::Other,
+                };
+                crate::eat_json_fields(&mut map)?;
+                Ok(value)
             }
         }
         const VARIANTS: &[&str] = &["mapping_not_found",
@@ -26185,23 +25380,19 @@ impl<'de> ::serde::de::Deserialize<'de> for UploadApiRateLimitValue {
                     Some(".tag") => map.next_value()?,
                     _ => return Err(de::Error::missing_field(".tag"))
                 };
-                match tag {
-                    "unlimited" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(UploadApiRateLimitValue::Unlimited)
-                    }
+                let value = match tag {
+                    "unlimited" => UploadApiRateLimitValue::Unlimited,
                     "limit" => {
                         match map.next_key()? {
-                            Some("limit") => Ok(UploadApiRateLimitValue::Limit(map.next_value()?)),
-                            None => Err(de::Error::missing_field("limit")),
-                            _ => Err(de::Error::unknown_field(tag, VARIANTS))
+                            Some("limit") => UploadApiRateLimitValue::Limit(map.next_value()?),
+                            None => return Err(de::Error::missing_field("limit")),
+                            _ => return Err(de::Error::unknown_field(tag, VARIANTS))
                         }
                     }
-                    _ => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(UploadApiRateLimitValue::Other)
-                    }
-                }
+                    _ => UploadApiRateLimitValue::Other,
+                };
+                crate::eat_json_fields(&mut map)?;
+                Ok(value)
             }
         }
         const VARIANTS: &[&str] = &["unlimited",
@@ -26268,34 +25459,33 @@ impl<'de> ::serde::de::Deserialize<'de> for UserAddResult {
                     Some(".tag") => map.next_value()?,
                     _ => return Err(de::Error::missing_field(".tag"))
                 };
-                match tag {
-                    "success" => Ok(UserAddResult::Success(UserSecondaryEmailsResult::internal_deserialize(map)?)),
+                let value = match tag {
+                    "success" => UserAddResult::Success(UserSecondaryEmailsResult::internal_deserialize(&mut map)?),
                     "invalid_user" => {
                         match map.next_key()? {
-                            Some("invalid_user") => Ok(UserAddResult::InvalidUser(map.next_value()?)),
-                            None => Err(de::Error::missing_field("invalid_user")),
-                            _ => Err(de::Error::unknown_field(tag, VARIANTS))
+                            Some("invalid_user") => UserAddResult::InvalidUser(map.next_value()?),
+                            None => return Err(de::Error::missing_field("invalid_user")),
+                            _ => return Err(de::Error::unknown_field(tag, VARIANTS))
                         }
                     }
                     "unverified" => {
                         match map.next_key()? {
-                            Some("unverified") => Ok(UserAddResult::Unverified(map.next_value()?)),
-                            None => Err(de::Error::missing_field("unverified")),
-                            _ => Err(de::Error::unknown_field(tag, VARIANTS))
+                            Some("unverified") => UserAddResult::Unverified(map.next_value()?),
+                            None => return Err(de::Error::missing_field("unverified")),
+                            _ => return Err(de::Error::unknown_field(tag, VARIANTS))
                         }
                     }
                     "placeholder_user" => {
                         match map.next_key()? {
-                            Some("placeholder_user") => Ok(UserAddResult::PlaceholderUser(map.next_value()?)),
-                            None => Err(de::Error::missing_field("placeholder_user")),
-                            _ => Err(de::Error::unknown_field(tag, VARIANTS))
+                            Some("placeholder_user") => UserAddResult::PlaceholderUser(map.next_value()?),
+                            None => return Err(de::Error::missing_field("placeholder_user")),
+                            _ => return Err(de::Error::unknown_field(tag, VARIANTS))
                         }
                     }
-                    _ => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(UserAddResult::Other)
-                    }
-                }
+                    _ => UserAddResult::Other,
+                };
+                crate::eat_json_fields(&mut map)?;
+                Ok(value)
             }
         }
         const VARIANTS: &[&str] = &["success",
@@ -26686,20 +25876,19 @@ impl<'de> ::serde::de::Deserialize<'de> for UserDeleteResult {
                     Some(".tag") => map.next_value()?,
                     _ => return Err(de::Error::missing_field(".tag"))
                 };
-                match tag {
-                    "success" => Ok(UserDeleteResult::Success(UserDeleteEmailsResult::internal_deserialize(map)?)),
+                let value = match tag {
+                    "success" => UserDeleteResult::Success(UserDeleteEmailsResult::internal_deserialize(&mut map)?),
                     "invalid_user" => {
                         match map.next_key()? {
-                            Some("invalid_user") => Ok(UserDeleteResult::InvalidUser(map.next_value()?)),
-                            None => Err(de::Error::missing_field("invalid_user")),
-                            _ => Err(de::Error::unknown_field(tag, VARIANTS))
+                            Some("invalid_user") => UserDeleteResult::InvalidUser(map.next_value()?),
+                            None => return Err(de::Error::missing_field("invalid_user")),
+                            _ => return Err(de::Error::unknown_field(tag, VARIANTS))
                         }
                     }
-                    _ => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(UserDeleteResult::Other)
-                    }
-                }
+                    _ => UserDeleteResult::Other,
+                };
+                crate::eat_json_fields(&mut map)?;
+                Ok(value)
             }
         }
         const VARIANTS: &[&str] = &["success",
@@ -26864,20 +26053,19 @@ impl<'de> ::serde::de::Deserialize<'de> for UserResendResult {
                     Some(".tag") => map.next_value()?,
                     _ => return Err(de::Error::missing_field(".tag"))
                 };
-                match tag {
-                    "success" => Ok(UserResendResult::Success(UserResendEmailsResult::internal_deserialize(map)?)),
+                let value = match tag {
+                    "success" => UserResendResult::Success(UserResendEmailsResult::internal_deserialize(&mut map)?),
                     "invalid_user" => {
                         match map.next_key()? {
-                            Some("invalid_user") => Ok(UserResendResult::InvalidUser(map.next_value()?)),
-                            None => Err(de::Error::missing_field("invalid_user")),
-                            _ => Err(de::Error::unknown_field(tag, VARIANTS))
+                            Some("invalid_user") => UserResendResult::InvalidUser(map.next_value()?),
+                            None => return Err(de::Error::missing_field("invalid_user")),
+                            _ => return Err(de::Error::unknown_field(tag, VARIANTS))
                         }
                     }
-                    _ => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(UserResendResult::Other)
-                    }
-                }
+                    _ => UserResendResult::Other,
+                };
+                crate::eat_json_fields(&mut map)?;
+                Ok(value)
             }
         }
         const VARIANTS: &[&str] = &["success",
@@ -27137,30 +26325,32 @@ impl<'de> ::serde::de::Deserialize<'de> for UserSelectorArg {
                     Some(".tag") => map.next_value()?,
                     _ => return Err(de::Error::missing_field(".tag"))
                 };
-                match tag {
+                let value = match tag {
                     "team_member_id" => {
                         match map.next_key()? {
-                            Some("team_member_id") => Ok(UserSelectorArg::TeamMemberId(map.next_value()?)),
-                            None => Err(de::Error::missing_field("team_member_id")),
-                            _ => Err(de::Error::unknown_field(tag, VARIANTS))
+                            Some("team_member_id") => UserSelectorArg::TeamMemberId(map.next_value()?),
+                            None => return Err(de::Error::missing_field("team_member_id")),
+                            _ => return Err(de::Error::unknown_field(tag, VARIANTS))
                         }
                     }
                     "external_id" => {
                         match map.next_key()? {
-                            Some("external_id") => Ok(UserSelectorArg::ExternalId(map.next_value()?)),
-                            None => Err(de::Error::missing_field("external_id")),
-                            _ => Err(de::Error::unknown_field(tag, VARIANTS))
+                            Some("external_id") => UserSelectorArg::ExternalId(map.next_value()?),
+                            None => return Err(de::Error::missing_field("external_id")),
+                            _ => return Err(de::Error::unknown_field(tag, VARIANTS))
                         }
                     }
                     "email" => {
                         match map.next_key()? {
-                            Some("email") => Ok(UserSelectorArg::Email(map.next_value()?)),
-                            None => Err(de::Error::missing_field("email")),
-                            _ => Err(de::Error::unknown_field(tag, VARIANTS))
+                            Some("email") => UserSelectorArg::Email(map.next_value()?),
+                            None => return Err(de::Error::missing_field("email")),
+                            _ => return Err(de::Error::unknown_field(tag, VARIANTS))
                         }
                     }
-                    _ => Err(de::Error::unknown_variant(tag, VARIANTS))
-                }
+                    _ => return Err(de::Error::unknown_variant(tag, VARIANTS))
+                };
+                crate::eat_json_fields(&mut map)?;
+                Ok(value)
             }
         }
         const VARIANTS: &[&str] = &["team_member_id",
@@ -27224,13 +26414,12 @@ impl<'de> ::serde::de::Deserialize<'de> for UserSelectorError {
                     Some(".tag") => map.next_value()?,
                     _ => return Err(de::Error::missing_field(".tag"))
                 };
-                match tag {
-                    "user_not_found" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(UserSelectorError::UserNotFound)
-                    }
-                    _ => Err(de::Error::unknown_variant(tag, VARIANTS))
-                }
+                let value = match tag {
+                    "user_not_found" => UserSelectorError::UserNotFound,
+                    _ => return Err(de::Error::unknown_variant(tag, VARIANTS))
+                };
+                crate::eat_json_fields(&mut map)?;
+                Ok(value)
             }
         }
         const VARIANTS: &[&str] = &["user_not_found"];
@@ -27290,30 +26479,32 @@ impl<'de> ::serde::de::Deserialize<'de> for UsersSelectorArg {
                     Some(".tag") => map.next_value()?,
                     _ => return Err(de::Error::missing_field(".tag"))
                 };
-                match tag {
+                let value = match tag {
                     "team_member_ids" => {
                         match map.next_key()? {
-                            Some("team_member_ids") => Ok(UsersSelectorArg::TeamMemberIds(map.next_value()?)),
-                            None => Err(de::Error::missing_field("team_member_ids")),
-                            _ => Err(de::Error::unknown_field(tag, VARIANTS))
+                            Some("team_member_ids") => UsersSelectorArg::TeamMemberIds(map.next_value()?),
+                            None => return Err(de::Error::missing_field("team_member_ids")),
+                            _ => return Err(de::Error::unknown_field(tag, VARIANTS))
                         }
                     }
                     "external_ids" => {
                         match map.next_key()? {
-                            Some("external_ids") => Ok(UsersSelectorArg::ExternalIds(map.next_value()?)),
-                            None => Err(de::Error::missing_field("external_ids")),
-                            _ => Err(de::Error::unknown_field(tag, VARIANTS))
+                            Some("external_ids") => UsersSelectorArg::ExternalIds(map.next_value()?),
+                            None => return Err(de::Error::missing_field("external_ids")),
+                            _ => return Err(de::Error::unknown_field(tag, VARIANTS))
                         }
                     }
                     "emails" => {
                         match map.next_key()? {
-                            Some("emails") => Ok(UsersSelectorArg::Emails(map.next_value()?)),
-                            None => Err(de::Error::missing_field("emails")),
-                            _ => Err(de::Error::unknown_field(tag, VARIANTS))
+                            Some("emails") => UsersSelectorArg::Emails(map.next_value()?),
+                            None => return Err(de::Error::missing_field("emails")),
+                            _ => return Err(de::Error::unknown_field(tag, VARIANTS))
                         }
                     }
-                    _ => Err(de::Error::unknown_variant(tag, VARIANTS))
-                }
+                    _ => return Err(de::Error::unknown_variant(tag, VARIANTS))
+                };
+                crate::eat_json_fields(&mut map)?;
+                Ok(value)
             }
         }
         const VARIANTS: &[&str] = &["team_member_ids",

--- a/src/generated/team_common.rs
+++ b/src/generated/team_common.rs
@@ -44,24 +44,14 @@ impl<'de> ::serde::de::Deserialize<'de> for GroupManagementType {
                     Some(".tag") => map.next_value()?,
                     _ => return Err(de::Error::missing_field(".tag"))
                 };
-                match tag {
-                    "user_managed" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(GroupManagementType::UserManaged)
-                    }
-                    "company_managed" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(GroupManagementType::CompanyManaged)
-                    }
-                    "system_managed" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(GroupManagementType::SystemManaged)
-                    }
-                    _ => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(GroupManagementType::Other)
-                    }
-                }
+                let value = match tag {
+                    "user_managed" => GroupManagementType::UserManaged,
+                    "company_managed" => GroupManagementType::CompanyManaged,
+                    "system_managed" => GroupManagementType::SystemManaged,
+                    _ => GroupManagementType::Other,
+                };
+                crate::eat_json_fields(&mut map)?;
+                Ok(value)
             }
         }
         const VARIANTS: &[&str] = &["user_managed",
@@ -284,20 +274,13 @@ impl<'de> ::serde::de::Deserialize<'de> for GroupType {
                     Some(".tag") => map.next_value()?,
                     _ => return Err(de::Error::missing_field(".tag"))
                 };
-                match tag {
-                    "team" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(GroupType::Team)
-                    }
-                    "user_managed" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(GroupType::UserManaged)
-                    }
-                    _ => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(GroupType::Other)
-                    }
-                }
+                let value = match tag {
+                    "team" => GroupType::Team,
+                    "user_managed" => GroupType::UserManaged,
+                    _ => GroupType::Other,
+                };
+                crate::eat_json_fields(&mut map)?;
+                Ok(value)
             }
         }
         const VARIANTS: &[&str] = &["team",
@@ -361,24 +344,14 @@ impl<'de> ::serde::de::Deserialize<'de> for MemberSpaceLimitType {
                     Some(".tag") => map.next_value()?,
                     _ => return Err(de::Error::missing_field(".tag"))
                 };
-                match tag {
-                    "off" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(MemberSpaceLimitType::Off)
-                    }
-                    "alert_only" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(MemberSpaceLimitType::AlertOnly)
-                    }
-                    "stop_sync" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(MemberSpaceLimitType::StopSync)
-                    }
-                    _ => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(MemberSpaceLimitType::Other)
-                    }
-                }
+                let value = match tag {
+                    "off" => MemberSpaceLimitType::Off,
+                    "alert_only" => MemberSpaceLimitType::AlertOnly,
+                    "stop_sync" => MemberSpaceLimitType::StopSync,
+                    _ => MemberSpaceLimitType::Other,
+                };
+                crate::eat_json_fields(&mut map)?;
+                Ok(value)
             }
         }
         const VARIANTS: &[&str] = &["off",

--- a/src/generated/team_policies.rs
+++ b/src/generated/team_policies.rs
@@ -34,20 +34,13 @@ impl<'de> ::serde::de::Deserialize<'de> for CameraUploadsPolicyState {
                     Some(".tag") => map.next_value()?,
                     _ => return Err(de::Error::missing_field(".tag"))
                 };
-                match tag {
-                    "disabled" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(CameraUploadsPolicyState::Disabled)
-                    }
-                    "enabled" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(CameraUploadsPolicyState::Enabled)
-                    }
-                    _ => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(CameraUploadsPolicyState::Other)
-                    }
-                }
+                let value = match tag {
+                    "disabled" => CameraUploadsPolicyState::Disabled,
+                    "enabled" => CameraUploadsPolicyState::Enabled,
+                    _ => CameraUploadsPolicyState::Other,
+                };
+                crate::eat_json_fields(&mut map)?;
+                Ok(value)
             }
         }
         const VARIANTS: &[&str] = &["disabled",
@@ -108,24 +101,14 @@ impl<'de> ::serde::de::Deserialize<'de> for ComputerBackupPolicyState {
                     Some(".tag") => map.next_value()?,
                     _ => return Err(de::Error::missing_field(".tag"))
                 };
-                match tag {
-                    "disabled" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(ComputerBackupPolicyState::Disabled)
-                    }
-                    "enabled" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(ComputerBackupPolicyState::Enabled)
-                    }
-                    "default" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(ComputerBackupPolicyState::Default)
-                    }
-                    _ => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(ComputerBackupPolicyState::Other)
-                    }
-                }
+                let value = match tag {
+                    "disabled" => ComputerBackupPolicyState::Disabled,
+                    "enabled" => ComputerBackupPolicyState::Enabled,
+                    "default" => ComputerBackupPolicyState::Default,
+                    _ => ComputerBackupPolicyState::Other,
+                };
+                crate::eat_json_fields(&mut map)?;
+                Ok(value)
             }
         }
         const VARIANTS: &[&str] = &["disabled",
@@ -193,24 +176,14 @@ impl<'de> ::serde::de::Deserialize<'de> for EmmState {
                     Some(".tag") => map.next_value()?,
                     _ => return Err(de::Error::missing_field(".tag"))
                 };
-                match tag {
-                    "disabled" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(EmmState::Disabled)
-                    }
-                    "optional" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(EmmState::Optional)
-                    }
-                    "required" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(EmmState::Required)
-                    }
-                    _ => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(EmmState::Other)
-                    }
-                }
+                let value = match tag {
+                    "disabled" => EmmState::Disabled,
+                    "optional" => EmmState::Optional,
+                    "required" => EmmState::Required,
+                    _ => EmmState::Other,
+                };
+                crate::eat_json_fields(&mut map)?;
+                Ok(value)
             }
         }
         const VARIANTS: &[&str] = &["disabled",
@@ -276,20 +249,13 @@ impl<'de> ::serde::de::Deserialize<'de> for FileLockingPolicyState {
                     Some(".tag") => map.next_value()?,
                     _ => return Err(de::Error::missing_field(".tag"))
                 };
-                match tag {
-                    "disabled" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(FileLockingPolicyState::Disabled)
-                    }
-                    "enabled" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(FileLockingPolicyState::Enabled)
-                    }
-                    _ => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(FileLockingPolicyState::Other)
-                    }
-                }
+                let value = match tag {
+                    "disabled" => FileLockingPolicyState::Disabled,
+                    "enabled" => FileLockingPolicyState::Enabled,
+                    _ => FileLockingPolicyState::Other,
+                };
+                crate::eat_json_fields(&mut map)?;
+                Ok(value)
             }
         }
         const VARIANTS: &[&str] = &["disabled",
@@ -344,17 +310,13 @@ impl<'de> ::serde::de::Deserialize<'de> for GroupCreation {
                     Some(".tag") => map.next_value()?,
                     _ => return Err(de::Error::missing_field(".tag"))
                 };
-                match tag {
-                    "admins_and_members" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(GroupCreation::AdminsAndMembers)
-                    }
-                    "admins_only" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(GroupCreation::AdminsOnly)
-                    }
-                    _ => Err(de::Error::unknown_variant(tag, VARIANTS))
-                }
+                let value = match tag {
+                    "admins_and_members" => GroupCreation::AdminsAndMembers,
+                    "admins_only" => GroupCreation::AdminsOnly,
+                    _ => return Err(de::Error::unknown_variant(tag, VARIANTS))
+                };
+                crate::eat_json_fields(&mut map)?;
+                Ok(value)
             }
         }
         const VARIANTS: &[&str] = &["admins_and_members",
@@ -411,20 +373,13 @@ impl<'de> ::serde::de::Deserialize<'de> for OfficeAddInPolicy {
                     Some(".tag") => map.next_value()?,
                     _ => return Err(de::Error::missing_field(".tag"))
                 };
-                match tag {
-                    "disabled" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(OfficeAddInPolicy::Disabled)
-                    }
-                    "enabled" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(OfficeAddInPolicy::Enabled)
-                    }
-                    _ => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(OfficeAddInPolicy::Other)
-                    }
-                }
+                let value = match tag {
+                    "disabled" => OfficeAddInPolicy::Disabled,
+                    "enabled" => OfficeAddInPolicy::Enabled,
+                    _ => OfficeAddInPolicy::Other,
+                };
+                crate::eat_json_fields(&mut map)?;
+                Ok(value)
             }
         }
         const VARIANTS: &[&str] = &["disabled",
@@ -483,20 +438,13 @@ impl<'de> ::serde::de::Deserialize<'de> for PaperDefaultFolderPolicy {
                     Some(".tag") => map.next_value()?,
                     _ => return Err(de::Error::missing_field(".tag"))
                 };
-                match tag {
-                    "everyone_in_team" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(PaperDefaultFolderPolicy::EveryoneInTeam)
-                    }
-                    "invite_only" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(PaperDefaultFolderPolicy::InviteOnly)
-                    }
-                    _ => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(PaperDefaultFolderPolicy::Other)
-                    }
-                }
+                let value = match tag {
+                    "everyone_in_team" => PaperDefaultFolderPolicy::EveryoneInTeam,
+                    "invite_only" => PaperDefaultFolderPolicy::InviteOnly,
+                    _ => PaperDefaultFolderPolicy::Other,
+                };
+                crate::eat_json_fields(&mut map)?;
+                Ok(value)
             }
         }
         const VARIANTS: &[&str] = &["everyone_in_team",
@@ -556,20 +504,13 @@ impl<'de> ::serde::de::Deserialize<'de> for PaperDeploymentPolicy {
                     Some(".tag") => map.next_value()?,
                     _ => return Err(de::Error::missing_field(".tag"))
                 };
-                match tag {
-                    "full" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(PaperDeploymentPolicy::Full)
-                    }
-                    "partial" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(PaperDeploymentPolicy::Partial)
-                    }
-                    _ => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(PaperDeploymentPolicy::Other)
-                    }
-                }
+                let value = match tag {
+                    "full" => PaperDeploymentPolicy::Full,
+                    "partial" => PaperDeploymentPolicy::Partial,
+                    _ => PaperDeploymentPolicy::Other,
+                };
+                crate::eat_json_fields(&mut map)?;
+                Ok(value)
             }
         }
         const VARIANTS: &[&str] = &["full",
@@ -628,20 +569,13 @@ impl<'de> ::serde::de::Deserialize<'de> for PaperDesktopPolicy {
                     Some(".tag") => map.next_value()?,
                     _ => return Err(de::Error::missing_field(".tag"))
                 };
-                match tag {
-                    "disabled" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(PaperDesktopPolicy::Disabled)
-                    }
-                    "enabled" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(PaperDesktopPolicy::Enabled)
-                    }
-                    _ => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(PaperDesktopPolicy::Other)
-                    }
-                }
+                let value = match tag {
+                    "disabled" => PaperDesktopPolicy::Disabled,
+                    "enabled" => PaperDesktopPolicy::Enabled,
+                    _ => PaperDesktopPolicy::Other,
+                };
+                crate::eat_json_fields(&mut map)?;
+                Ok(value)
             }
         }
         const VARIANTS: &[&str] = &["disabled",
@@ -702,24 +636,14 @@ impl<'de> ::serde::de::Deserialize<'de> for PaperEnabledPolicy {
                     Some(".tag") => map.next_value()?,
                     _ => return Err(de::Error::missing_field(".tag"))
                 };
-                match tag {
-                    "disabled" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(PaperEnabledPolicy::Disabled)
-                    }
-                    "enabled" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(PaperEnabledPolicy::Enabled)
-                    }
-                    "unspecified" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(PaperEnabledPolicy::Unspecified)
-                    }
-                    _ => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(PaperEnabledPolicy::Other)
-                    }
-                }
+                let value = match tag {
+                    "disabled" => PaperEnabledPolicy::Disabled,
+                    "enabled" => PaperEnabledPolicy::Enabled,
+                    "unspecified" => PaperEnabledPolicy::Unspecified,
+                    _ => PaperEnabledPolicy::Other,
+                };
+                crate::eat_json_fields(&mut map)?;
+                Ok(value)
             }
         }
         const VARIANTS: &[&str] = &["disabled",
@@ -785,20 +709,13 @@ impl<'de> ::serde::de::Deserialize<'de> for PasswordControlMode {
                     Some(".tag") => map.next_value()?,
                     _ => return Err(de::Error::missing_field(".tag"))
                 };
-                match tag {
-                    "disabled" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(PasswordControlMode::Disabled)
-                    }
-                    "enabled" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(PasswordControlMode::Enabled)
-                    }
-                    _ => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(PasswordControlMode::Other)
-                    }
-                }
+                let value = match tag {
+                    "disabled" => PasswordControlMode::Disabled,
+                    "enabled" => PasswordControlMode::Enabled,
+                    _ => PasswordControlMode::Other,
+                };
+                crate::eat_json_fields(&mut map)?;
+                Ok(value)
             }
         }
         const VARIANTS: &[&str] = &["disabled",
@@ -859,24 +776,14 @@ impl<'de> ::serde::de::Deserialize<'de> for PasswordStrengthPolicy {
                     Some(".tag") => map.next_value()?,
                     _ => return Err(de::Error::missing_field(".tag"))
                 };
-                match tag {
-                    "minimal_requirements" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(PasswordStrengthPolicy::MinimalRequirements)
-                    }
-                    "moderate_password" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(PasswordStrengthPolicy::ModeratePassword)
-                    }
-                    "strong_password" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(PasswordStrengthPolicy::StrongPassword)
-                    }
-                    _ => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(PasswordStrengthPolicy::Other)
-                    }
-                }
+                let value = match tag {
+                    "minimal_requirements" => PasswordStrengthPolicy::MinimalRequirements,
+                    "moderate_password" => PasswordStrengthPolicy::ModeratePassword,
+                    "strong_password" => PasswordStrengthPolicy::StrongPassword,
+                    _ => PasswordStrengthPolicy::Other,
+                };
+                crate::eat_json_fields(&mut map)?;
+                Ok(value)
             }
         }
         const VARIANTS: &[&str] = &["minimal_requirements",
@@ -940,21 +847,14 @@ impl<'de> ::serde::de::Deserialize<'de> for RolloutMethod {
                     Some(".tag") => map.next_value()?,
                     _ => return Err(de::Error::missing_field(".tag"))
                 };
-                match tag {
-                    "unlink_all" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(RolloutMethod::UnlinkAll)
-                    }
-                    "unlink_most_inactive" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(RolloutMethod::UnlinkMostInactive)
-                    }
-                    "add_member_to_exceptions" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(RolloutMethod::AddMemberToExceptions)
-                    }
-                    _ => Err(de::Error::unknown_variant(tag, VARIANTS))
-                }
+                let value = match tag {
+                    "unlink_all" => RolloutMethod::UnlinkAll,
+                    "unlink_most_inactive" => RolloutMethod::UnlinkMostInactive,
+                    "add_member_to_exceptions" => RolloutMethod::AddMemberToExceptions,
+                    _ => return Err(de::Error::unknown_variant(tag, VARIANTS))
+                };
+                crate::eat_json_fields(&mut map)?;
+                Ok(value)
             }
         }
         const VARIANTS: &[&str] = &["unlink_all",
@@ -1019,20 +919,13 @@ impl<'de> ::serde::de::Deserialize<'de> for SharedFolderJoinPolicy {
                     Some(".tag") => map.next_value()?,
                     _ => return Err(de::Error::missing_field(".tag"))
                 };
-                match tag {
-                    "from_team_only" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(SharedFolderJoinPolicy::FromTeamOnly)
-                    }
-                    "from_anyone" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(SharedFolderJoinPolicy::FromAnyone)
-                    }
-                    _ => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(SharedFolderJoinPolicy::Other)
-                    }
-                }
+                let value = match tag {
+                    "from_team_only" => SharedFolderJoinPolicy::FromTeamOnly,
+                    "from_anyone" => SharedFolderJoinPolicy::FromAnyone,
+                    _ => SharedFolderJoinPolicy::Other,
+                };
+                crate::eat_json_fields(&mut map)?;
+                Ok(value)
             }
         }
         const VARIANTS: &[&str] = &["from_team_only",
@@ -1092,20 +985,13 @@ impl<'de> ::serde::de::Deserialize<'de> for SharedFolderMemberPolicy {
                     Some(".tag") => map.next_value()?,
                     _ => return Err(de::Error::missing_field(".tag"))
                 };
-                match tag {
-                    "team" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(SharedFolderMemberPolicy::Team)
-                    }
-                    "anyone" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(SharedFolderMemberPolicy::Anyone)
-                    }
-                    _ => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(SharedFolderMemberPolicy::Other)
-                    }
-                }
+                let value = match tag {
+                    "team" => SharedFolderMemberPolicy::Team,
+                    "anyone" => SharedFolderMemberPolicy::Anyone,
+                    _ => SharedFolderMemberPolicy::Other,
+                };
+                crate::eat_json_fields(&mut map)?;
+                Ok(value)
             }
         }
         const VARIANTS: &[&str] = &["team",
@@ -1171,24 +1057,14 @@ impl<'de> ::serde::de::Deserialize<'de> for SharedLinkCreatePolicy {
                     Some(".tag") => map.next_value()?,
                     _ => return Err(de::Error::missing_field(".tag"))
                 };
-                match tag {
-                    "default_public" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(SharedLinkCreatePolicy::DefaultPublic)
-                    }
-                    "default_team_only" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(SharedLinkCreatePolicy::DefaultTeamOnly)
-                    }
-                    "team_only" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(SharedLinkCreatePolicy::TeamOnly)
-                    }
-                    _ => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(SharedLinkCreatePolicy::Other)
-                    }
-                }
+                let value = match tag {
+                    "default_public" => SharedLinkCreatePolicy::DefaultPublic,
+                    "default_team_only" => SharedLinkCreatePolicy::DefaultTeamOnly,
+                    "team_only" => SharedLinkCreatePolicy::TeamOnly,
+                    _ => SharedLinkCreatePolicy::Other,
+                };
+                crate::eat_json_fields(&mut map)?;
+                Ok(value)
             }
         }
         const VARIANTS: &[&str] = &["default_public",
@@ -1254,20 +1130,13 @@ impl<'de> ::serde::de::Deserialize<'de> for ShowcaseDownloadPolicy {
                     Some(".tag") => map.next_value()?,
                     _ => return Err(de::Error::missing_field(".tag"))
                 };
-                match tag {
-                    "disabled" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(ShowcaseDownloadPolicy::Disabled)
-                    }
-                    "enabled" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(ShowcaseDownloadPolicy::Enabled)
-                    }
-                    _ => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(ShowcaseDownloadPolicy::Other)
-                    }
-                }
+                let value = match tag {
+                    "disabled" => ShowcaseDownloadPolicy::Disabled,
+                    "enabled" => ShowcaseDownloadPolicy::Enabled,
+                    _ => ShowcaseDownloadPolicy::Other,
+                };
+                crate::eat_json_fields(&mut map)?;
+                Ok(value)
             }
         }
         const VARIANTS: &[&str] = &["disabled",
@@ -1326,20 +1195,13 @@ impl<'de> ::serde::de::Deserialize<'de> for ShowcaseEnabledPolicy {
                     Some(".tag") => map.next_value()?,
                     _ => return Err(de::Error::missing_field(".tag"))
                 };
-                match tag {
-                    "disabled" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(ShowcaseEnabledPolicy::Disabled)
-                    }
-                    "enabled" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(ShowcaseEnabledPolicy::Enabled)
-                    }
-                    _ => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(ShowcaseEnabledPolicy::Other)
-                    }
-                }
+                let value = match tag {
+                    "disabled" => ShowcaseEnabledPolicy::Disabled,
+                    "enabled" => ShowcaseEnabledPolicy::Enabled,
+                    _ => ShowcaseEnabledPolicy::Other,
+                };
+                crate::eat_json_fields(&mut map)?;
+                Ok(value)
             }
         }
         const VARIANTS: &[&str] = &["disabled",
@@ -1398,20 +1260,13 @@ impl<'de> ::serde::de::Deserialize<'de> for ShowcaseExternalSharingPolicy {
                     Some(".tag") => map.next_value()?,
                     _ => return Err(de::Error::missing_field(".tag"))
                 };
-                match tag {
-                    "disabled" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(ShowcaseExternalSharingPolicy::Disabled)
-                    }
-                    "enabled" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(ShowcaseExternalSharingPolicy::Enabled)
-                    }
-                    _ => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(ShowcaseExternalSharingPolicy::Other)
-                    }
-                }
+                let value = match tag {
+                    "disabled" => ShowcaseExternalSharingPolicy::Disabled,
+                    "enabled" => ShowcaseExternalSharingPolicy::Enabled,
+                    _ => ShowcaseExternalSharingPolicy::Other,
+                };
+                crate::eat_json_fields(&mut map)?;
+                Ok(value)
             }
         }
         const VARIANTS: &[&str] = &["disabled",
@@ -1470,20 +1325,13 @@ impl<'de> ::serde::de::Deserialize<'de> for SmartSyncPolicy {
                     Some(".tag") => map.next_value()?,
                     _ => return Err(de::Error::missing_field(".tag"))
                 };
-                match tag {
-                    "local" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(SmartSyncPolicy::Local)
-                    }
-                    "on_demand" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(SmartSyncPolicy::OnDemand)
-                    }
-                    _ => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(SmartSyncPolicy::Other)
-                    }
-                }
+                let value = match tag {
+                    "local" => SmartSyncPolicy::Local,
+                    "on_demand" => SmartSyncPolicy::OnDemand,
+                    _ => SmartSyncPolicy::Other,
+                };
+                crate::eat_json_fields(&mut map)?;
+                Ok(value)
             }
         }
         const VARIANTS: &[&str] = &["local",
@@ -1542,20 +1390,13 @@ impl<'de> ::serde::de::Deserialize<'de> for SmarterSmartSyncPolicyState {
                     Some(".tag") => map.next_value()?,
                     _ => return Err(de::Error::missing_field(".tag"))
                 };
-                match tag {
-                    "disabled" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(SmarterSmartSyncPolicyState::Disabled)
-                    }
-                    "enabled" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(SmarterSmartSyncPolicyState::Enabled)
-                    }
-                    _ => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(SmarterSmartSyncPolicyState::Other)
-                    }
-                }
+                let value = match tag {
+                    "disabled" => SmarterSmartSyncPolicyState::Disabled,
+                    "enabled" => SmarterSmartSyncPolicyState::Enabled,
+                    _ => SmarterSmartSyncPolicyState::Other,
+                };
+                crate::eat_json_fields(&mut map)?;
+                Ok(value)
             }
         }
         const VARIANTS: &[&str] = &["disabled",
@@ -1616,24 +1457,14 @@ impl<'de> ::serde::de::Deserialize<'de> for SsoPolicy {
                     Some(".tag") => map.next_value()?,
                     _ => return Err(de::Error::missing_field(".tag"))
                 };
-                match tag {
-                    "disabled" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(SsoPolicy::Disabled)
-                    }
-                    "optional" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(SsoPolicy::Optional)
-                    }
-                    "required" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(SsoPolicy::Required)
-                    }
-                    _ => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(SsoPolicy::Other)
-                    }
-                }
+                let value = match tag {
+                    "disabled" => SsoPolicy::Disabled,
+                    "optional" => SsoPolicy::Optional,
+                    "required" => SsoPolicy::Required,
+                    _ => SsoPolicy::Other,
+                };
+                crate::eat_json_fields(&mut map)?;
+                Ok(value)
             }
         }
         const VARIANTS: &[&str] = &["disabled",
@@ -1699,20 +1530,13 @@ impl<'de> ::serde::de::Deserialize<'de> for SuggestMembersPolicy {
                     Some(".tag") => map.next_value()?,
                     _ => return Err(de::Error::missing_field(".tag"))
                 };
-                match tag {
-                    "disabled" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(SuggestMembersPolicy::Disabled)
-                    }
-                    "enabled" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(SuggestMembersPolicy::Enabled)
-                    }
-                    _ => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(SuggestMembersPolicy::Other)
-                    }
-                }
+                let value = match tag {
+                    "disabled" => SuggestMembersPolicy::Disabled,
+                    "enabled" => SuggestMembersPolicy::Enabled,
+                    _ => SuggestMembersPolicy::Other,
+                };
+                crate::eat_json_fields(&mut map)?;
+                Ok(value)
             }
         }
         const VARIANTS: &[&str] = &["disabled",
@@ -2032,20 +1856,13 @@ impl<'de> ::serde::de::Deserialize<'de> for TwoStepVerificationPolicy {
                     Some(".tag") => map.next_value()?,
                     _ => return Err(de::Error::missing_field(".tag"))
                 };
-                match tag {
-                    "require_tfa_enable" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(TwoStepVerificationPolicy::RequireTfaEnable)
-                    }
-                    "require_tfa_disable" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(TwoStepVerificationPolicy::RequireTfaDisable)
-                    }
-                    _ => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(TwoStepVerificationPolicy::Other)
-                    }
-                }
+                let value = match tag {
+                    "require_tfa_enable" => TwoStepVerificationPolicy::RequireTfaEnable,
+                    "require_tfa_disable" => TwoStepVerificationPolicy::RequireTfaDisable,
+                    _ => TwoStepVerificationPolicy::Other,
+                };
+                crate::eat_json_fields(&mut map)?;
+                Ok(value)
             }
         }
         const VARIANTS: &[&str] = &["require_tfa_enable",
@@ -2106,24 +1923,14 @@ impl<'de> ::serde::de::Deserialize<'de> for TwoStepVerificationState {
                     Some(".tag") => map.next_value()?,
                     _ => return Err(de::Error::missing_field(".tag"))
                 };
-                match tag {
-                    "required" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(TwoStepVerificationState::Required)
-                    }
-                    "optional" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(TwoStepVerificationState::Optional)
-                    }
-                    "disabled" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(TwoStepVerificationState::Disabled)
-                    }
-                    _ => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(TwoStepVerificationState::Other)
-                    }
-                }
+                let value = match tag {
+                    "required" => TwoStepVerificationState::Required,
+                    "optional" => TwoStepVerificationState::Optional,
+                    "disabled" => TwoStepVerificationState::Disabled,
+                    _ => TwoStepVerificationState::Other,
+                };
+                crate::eat_json_fields(&mut map)?;
+                Ok(value)
             }
         }
         const VARIANTS: &[&str] = &["required",

--- a/src/generated/users.rs
+++ b/src/generated/users.rs
@@ -478,19 +478,18 @@ impl<'de> ::serde::de::Deserialize<'de> for FileLockingValue {
                     Some(".tag") => map.next_value()?,
                     _ => return Err(de::Error::missing_field(".tag"))
                 };
-                match tag {
+                let value = match tag {
                     "enabled" => {
                         match map.next_key()? {
-                            Some("enabled") => Ok(FileLockingValue::Enabled(map.next_value()?)),
-                            None => Err(de::Error::missing_field("enabled")),
-                            _ => Err(de::Error::unknown_field(tag, VARIANTS))
+                            Some("enabled") => FileLockingValue::Enabled(map.next_value()?),
+                            None => return Err(de::Error::missing_field("enabled")),
+                            _ => return Err(de::Error::unknown_field(tag, VARIANTS))
                         }
                     }
-                    _ => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(FileLockingValue::Other)
-                    }
-                }
+                    _ => FileLockingValue::Other,
+                };
+                crate::eat_json_fields(&mut map)?;
+                Ok(value)
             }
         }
         const VARIANTS: &[&str] = &["enabled",
@@ -1152,19 +1151,18 @@ impl<'de> ::serde::de::Deserialize<'de> for GetAccountBatchError {
                     Some(".tag") => map.next_value()?,
                     _ => return Err(de::Error::missing_field(".tag"))
                 };
-                match tag {
+                let value = match tag {
                     "no_account" => {
                         match map.next_key()? {
-                            Some("no_account") => Ok(GetAccountBatchError::NoAccount(map.next_value()?)),
-                            None => Err(de::Error::missing_field("no_account")),
-                            _ => Err(de::Error::unknown_field(tag, VARIANTS))
+                            Some("no_account") => GetAccountBatchError::NoAccount(map.next_value()?),
+                            None => return Err(de::Error::missing_field("no_account")),
+                            _ => return Err(de::Error::unknown_field(tag, VARIANTS))
                         }
                     }
-                    _ => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(GetAccountBatchError::Other)
-                    }
-                }
+                    _ => GetAccountBatchError::Other,
+                };
+                crate::eat_json_fields(&mut map)?;
+                Ok(value)
             }
         }
         const VARIANTS: &[&str] = &["no_account",
@@ -1227,16 +1225,12 @@ impl<'de> ::serde::de::Deserialize<'de> for GetAccountError {
                     Some(".tag") => map.next_value()?,
                     _ => return Err(de::Error::missing_field(".tag"))
                 };
-                match tag {
-                    "no_account" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(GetAccountError::NoAccount)
-                    }
-                    _ => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(GetAccountError::Other)
-                    }
-                }
+                let value = match tag {
+                    "no_account" => GetAccountError::NoAccount,
+                    _ => GetAccountError::Other,
+                };
+                crate::eat_json_fields(&mut map)?;
+                Ok(value)
             }
         }
         const VARIANTS: &[&str] = &["no_account",
@@ -1539,19 +1533,18 @@ impl<'de> ::serde::de::Deserialize<'de> for PaperAsFilesValue {
                     Some(".tag") => map.next_value()?,
                     _ => return Err(de::Error::missing_field(".tag"))
                 };
-                match tag {
+                let value = match tag {
                     "enabled" => {
                         match map.next_key()? {
-                            Some("enabled") => Ok(PaperAsFilesValue::Enabled(map.next_value()?)),
-                            None => Err(de::Error::missing_field("enabled")),
-                            _ => Err(de::Error::unknown_field(tag, VARIANTS))
+                            Some("enabled") => PaperAsFilesValue::Enabled(map.next_value()?),
+                            None => return Err(de::Error::missing_field("enabled")),
+                            _ => return Err(de::Error::unknown_field(tag, VARIANTS))
                         }
                     }
-                    _ => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(PaperAsFilesValue::Other)
-                    }
-                }
+                    _ => PaperAsFilesValue::Other,
+                };
+                crate::eat_json_fields(&mut map)?;
+                Ok(value)
             }
         }
         const VARIANTS: &[&str] = &["enabled",
@@ -1605,14 +1598,13 @@ impl<'de> ::serde::de::Deserialize<'de> for SpaceAllocation {
                     Some(".tag") => map.next_value()?,
                     _ => return Err(de::Error::missing_field(".tag"))
                 };
-                match tag {
-                    "individual" => Ok(SpaceAllocation::Individual(IndividualSpaceAllocation::internal_deserialize(map)?)),
-                    "team" => Ok(SpaceAllocation::Team(TeamSpaceAllocation::internal_deserialize(map)?)),
-                    _ => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(SpaceAllocation::Other)
-                    }
-                }
+                let value = match tag {
+                    "individual" => SpaceAllocation::Individual(IndividualSpaceAllocation::internal_deserialize(&mut map)?),
+                    "team" => SpaceAllocation::Team(TeamSpaceAllocation::internal_deserialize(&mut map)?),
+                    _ => SpaceAllocation::Other,
+                };
+                crate::eat_json_fields(&mut map)?;
+                Ok(value)
             }
         }
         const VARIANTS: &[&str] = &["individual",
@@ -2031,20 +2023,13 @@ impl<'de> ::serde::de::Deserialize<'de> for UserFeature {
                     Some(".tag") => map.next_value()?,
                     _ => return Err(de::Error::missing_field(".tag"))
                 };
-                match tag {
-                    "paper_as_files" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(UserFeature::PaperAsFiles)
-                    }
-                    "file_locking" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(UserFeature::FileLocking)
-                    }
-                    _ => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(UserFeature::Other)
-                    }
-                }
+                let value = match tag {
+                    "paper_as_files" => UserFeature::PaperAsFiles,
+                    "file_locking" => UserFeature::FileLocking,
+                    _ => UserFeature::Other,
+                };
+                crate::eat_json_fields(&mut map)?;
+                Ok(value)
             }
         }
         const VARIANTS: &[&str] = &["paper_as_files",
@@ -2102,26 +2087,25 @@ impl<'de> ::serde::de::Deserialize<'de> for UserFeatureValue {
                     Some(".tag") => map.next_value()?,
                     _ => return Err(de::Error::missing_field(".tag"))
                 };
-                match tag {
+                let value = match tag {
                     "paper_as_files" => {
                         match map.next_key()? {
-                            Some("paper_as_files") => Ok(UserFeatureValue::PaperAsFiles(map.next_value()?)),
-                            None => Err(de::Error::missing_field("paper_as_files")),
-                            _ => Err(de::Error::unknown_field(tag, VARIANTS))
+                            Some("paper_as_files") => UserFeatureValue::PaperAsFiles(map.next_value()?),
+                            None => return Err(de::Error::missing_field("paper_as_files")),
+                            _ => return Err(de::Error::unknown_field(tag, VARIANTS))
                         }
                     }
                     "file_locking" => {
                         match map.next_key()? {
-                            Some("file_locking") => Ok(UserFeatureValue::FileLocking(map.next_value()?)),
-                            None => Err(de::Error::missing_field("file_locking")),
-                            _ => Err(de::Error::unknown_field(tag, VARIANTS))
+                            Some("file_locking") => UserFeatureValue::FileLocking(map.next_value()?),
+                            None => return Err(de::Error::missing_field("file_locking")),
+                            _ => return Err(de::Error::unknown_field(tag, VARIANTS))
                         }
                     }
-                    _ => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(UserFeatureValue::Other)
-                    }
-                }
+                    _ => UserFeatureValue::Other,
+                };
+                crate::eat_json_fields(&mut map)?;
+                Ok(value)
             }
         }
         const VARIANTS: &[&str] = &["paper_as_files",
@@ -2272,16 +2256,12 @@ impl<'de> ::serde::de::Deserialize<'de> for UserFeaturesGetValuesBatchError {
                     Some(".tag") => map.next_value()?,
                     _ => return Err(de::Error::missing_field(".tag"))
                 };
-                match tag {
-                    "empty_features_list" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(UserFeaturesGetValuesBatchError::EmptyFeaturesList)
-                    }
-                    _ => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(UserFeaturesGetValuesBatchError::Other)
-                    }
-                }
+                let value = match tag {
+                    "empty_features_list" => UserFeaturesGetValuesBatchError::EmptyFeaturesList,
+                    _ => UserFeaturesGetValuesBatchError::Other,
+                };
+                crate::eat_json_fields(&mut map)?;
+                Ok(value)
             }
         }
         const VARIANTS: &[&str] = &["empty_features_list",

--- a/src/generated/users_common.rs
+++ b/src/generated/users_common.rs
@@ -37,21 +37,14 @@ impl<'de> ::serde::de::Deserialize<'de> for AccountType {
                     Some(".tag") => map.next_value()?,
                     _ => return Err(de::Error::missing_field(".tag"))
                 };
-                match tag {
-                    "basic" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(AccountType::Basic)
-                    }
-                    "pro" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(AccountType::Pro)
-                    }
-                    "business" => {
-                        crate::eat_json_fields(&mut map)?;
-                        Ok(AccountType::Business)
-                    }
-                    _ => Err(de::Error::unknown_variant(tag, VARIANTS))
-                }
+                let value = match tag {
+                    "basic" => AccountType::Basic,
+                    "pro" => AccountType::Pro,
+                    "business" => AccountType::Business,
+                    _ => return Err(de::Error::unknown_variant(tag, VARIANTS))
+                };
+                crate::eat_json_fields(&mut map)?;
+                Ok(value)
             }
         }
         const VARIANTS: &[&str] = &["basic",

--- a/tests/compatibility.rs
+++ b/tests/compatibility.rs
@@ -55,6 +55,23 @@ fn test_open_union_fields() {
 }
 
 #[test]
+fn test_open_union_new_field() {
+    let json = r#"{
+        ".tag": "individual",
+        "allocated": 9999,
+        "something else": "some value"
+    }"#;
+    let x = serde_json::from_str::<dropbox_sdk::users::SpaceAllocation>(json).unwrap();
+    if let dropbox_sdk::users::SpaceAllocation::Individual(indiv) = x {
+        if indiv.allocated != 9999 {
+            panic!("wrong value");
+        }
+    } else {
+        panic!("wrong variant");
+    }
+}
+
+#[test]
 fn test_void_union_with_fields() {
     let json = r#"{
         ".tag": "reset",


### PR DESCRIPTION
Avoid repeating eat_json_fields for all nullary variants and just do it at the end to consume any fields not recognized by inner deserializers.

This results in a net of 5161 lines removed.

<!--
Thank you for your pull request. Please provide a description below.
-->

## **Checklist**

**General Contributing**
<!-- Change [ ] to [x] if you have: -->
- [x] I have read the Code of Conduct and signed the [CLA](https://opensource.dropbox.com/cla/).
- [x] I have added an entry to the `RELEASE_NOTES.md` file, or believe it's not necessary for this change.

**Validation**
<!-- Describe which tests cover the changes you've made, and any additional manual validation you
     did to ensure the correctness of this change. Does this change warrant addition of new tests?
     Does this change have performance implications? Etc. -->
Automated tests. Also added another case to the compatibility tests (which passed before, and still passes).