### PR TITLE
give retry_after field in 429 responses a default value

### DIFF
--- a/src/client_helpers.rs
+++ b/src/client_helpers.rs
@@ -19,6 +19,8 @@ struct TopLevelError<T> {
 #[derive(Debug, Deserialize)]
 struct RateLimitedError {
     pub reason: RateLimitedReason,
+
+    #[serde(default)] // too_many_write_operations errors don't include this field; default to 0.
     pub retry_after: u32,
 }
 


### PR DESCRIPTION
Not all 429 errors have this field: `too_many_write_operations` isn't a time-based limit, so it doesn't include it. Currently, encountering this results in `Error::Json` instead of `Error::RateLimited` due to serialization failure in client_helpers.

We could change it to `Optional<u32>`, but that would be a breaking change; instead, default to 0.

It should hopefully be clear from a value of zero that the request can be retried immediately, as long as you're under the limit on concurrent operations.

<!--
Thank you for your pull request. Please provide a description below.
-->

## **Checklist**

**General Contributing**
<!-- Change [ ] to [x] if you have: -->
- [x] I have read the Code of Conduct and signed the [CLA](https://opensource.dropbox.com/cla/).
- [x] I have added an entry to the `RELEASE_NOTES.md` file, or believe it's not necessary for this change.

**Validation**
<!-- Describe which tests cover the changes you've made, and any additional manual validation you
     did to ensure the correctness of this change. Does this change warrant addition of new tests?
     Does this change have performance implications? Etc. -->
I originally hit this when running the integration tests repeatedly, so that's a good test right there.