### PR TITLE
examples/large-file-upload: honor the retry-after field when rate-limited

### DIFF
--- a/examples/large-file-upload.rs
+++ b/examples/large-file-upload.rs
@@ -396,6 +396,12 @@ fn upload_block_with_retry(
             Ok(Ok(())) => {
                 break;
             }
+            Err(dropbox_sdk::Error::RateLimited { reason, retry_after_seconds }) => {
+                eprintln!("rate-limited ({}), waiting {} seconds", reason, retry_after_seconds);
+                if retry_after_seconds > 0 {
+                    sleep(Duration::from_secs(u64::from(retry_after_seconds)));
+                }
+            }
             error => {
                 errors += 1;
                 let msg = format!("Error calling upload_session_append: {:?}", error);


### PR DESCRIPTION
Rather than thrashing and quickly erroring out, do the delay requested by the server.

## **Checklist**

**General Contributing**
<!-- Change [ ] to [x] if you have: -->
- [x] I have read the Code of Conduct and signed the [CLA](https://opensource.dropbox.com/cla/).
- [x] I have added an entry to the `RELEASE_NOTES.md` file, or believe it's not necessary for this change.

**Validation**
<!-- Describe which tests cover the changes you've made, and any additional manual validation you
     did to ensure the correctness of this change. Does this change warrant addition of new tests?
     Does this change have performance implications? Etc. -->
Hit this myself when using it to upload some large backup files, so I tested it manually. This is example code; doesn't need automated testing beyond that.