### PR TITLE
Skip serializing struct fields whose values are `None`

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -5,6 +5,8 @@ xxxx-yy-zz
   * 2021-06-30: (breaking change) remove deprecated sharing::change_file_member_access
     function and associated structs
   * 2021-07-08: sharing namespace additions
+* Changed struct serialization to not emit fields at all where the value is `None`.
+  * (previously it emitted `null` into the JSON as the value of the fields)
 
 # v0.11.3
 2021-05-08

--- a/src/generated/account.rs
+++ b/src/generated/account.rs
@@ -141,7 +141,8 @@ impl SetProfilePhotoArg {
         s: &mut S::SerializeStruct,
     ) -> Result<(), S::Error> {
         use serde::ser::SerializeStruct;
-        s.serialize_field("photo", &self.photo)
+        s.serialize_field("photo", &self.photo)?;
+        Ok(())
     }
 }
 
@@ -342,7 +343,8 @@ impl SetProfilePhotoResult {
         s: &mut S::SerializeStruct,
     ) -> Result<(), S::Error> {
         use serde::ser::SerializeStruct;
-        s.serialize_field("profile_photo_url", &self.profile_photo_url)
+        s.serialize_field("profile_photo_url", &self.profile_photo_url)?;
+        Ok(())
     }
 }
 

--- a/src/generated/auth.rs
+++ b/src/generated/auth.rs
@@ -504,7 +504,8 @@ impl RateLimitError {
     ) -> Result<(), S::Error> {
         use serde::ser::SerializeStruct;
         s.serialize_field("reason", &self.reason)?;
-        s.serialize_field("retry_after", &self.retry_after)
+        s.serialize_field("retry_after", &self.retry_after)?;
+        Ok(())
     }
 }
 
@@ -672,7 +673,8 @@ impl TokenFromOAuth1Arg {
     ) -> Result<(), S::Error> {
         use serde::ser::SerializeStruct;
         s.serialize_field("oauth1_token", &self.oauth1_token)?;
-        s.serialize_field("oauth1_token_secret", &self.oauth1_token_secret)
+        s.serialize_field("oauth1_token_secret", &self.oauth1_token_secret)?;
+        Ok(())
     }
 }
 
@@ -840,7 +842,8 @@ impl TokenFromOAuth1Result {
         s: &mut S::SerializeStruct,
     ) -> Result<(), S::Error> {
         use serde::ser::SerializeStruct;
-        s.serialize_field("oauth2_token", &self.oauth2_token)
+        s.serialize_field("oauth2_token", &self.oauth2_token)?;
+        Ok(())
     }
 }
 
@@ -930,7 +933,8 @@ impl TokenScopeError {
         s: &mut S::SerializeStruct,
     ) -> Result<(), S::Error> {
         use serde::ser::SerializeStruct;
-        s.serialize_field("required_scope", &self.required_scope)
+        s.serialize_field("required_scope", &self.required_scope)?;
+        Ok(())
     }
 }
 

--- a/src/generated/check.rs
+++ b/src/generated/check.rs
@@ -97,7 +97,8 @@ impl EchoArg {
         s: &mut S::SerializeStruct,
     ) -> Result<(), S::Error> {
         use serde::ser::SerializeStruct;
-        s.serialize_field("query", &self.query)
+        s.serialize_field("query", &self.query)?;
+        Ok(())
     }
 }
 
@@ -184,7 +185,8 @@ impl EchoResult {
         s: &mut S::SerializeStruct,
     ) -> Result<(), S::Error> {
         use serde::ser::SerializeStruct;
-        s.serialize_field("result", &self.result)
+        s.serialize_field("result", &self.result)?;
+        Ok(())
     }
 }
 

--- a/src/generated/common.rs
+++ b/src/generated/common.rs
@@ -357,7 +357,8 @@ impl TeamRootInfo {
         use serde::ser::SerializeStruct;
         s.serialize_field("root_namespace_id", &self.root_namespace_id)?;
         s.serialize_field("home_namespace_id", &self.home_namespace_id)?;
-        s.serialize_field("home_path", &self.home_path)
+        s.serialize_field("home_path", &self.home_path)?;
+        Ok(())
     }
 }
 
@@ -464,7 +465,8 @@ impl UserRootInfo {
     ) -> Result<(), S::Error> {
         use serde::ser::SerializeStruct;
         s.serialize_field("root_namespace_id", &self.root_namespace_id)?;
-        s.serialize_field("home_namespace_id", &self.home_namespace_id)
+        s.serialize_field("home_namespace_id", &self.home_namespace_id)?;
+        Ok(())
     }
 }
 

--- a/src/generated/contacts.rs
+++ b/src/generated/contacts.rs
@@ -93,7 +93,8 @@ impl DeleteManualContactsArg {
         s: &mut S::SerializeStruct,
     ) -> Result<(), S::Error> {
         use serde::ser::SerializeStruct;
-        s.serialize_field("email_addresses", &self.email_addresses)
+        s.serialize_field("email_addresses", &self.email_addresses)?;
+        Ok(())
     }
 }
 

--- a/src/generated/dbx_async.rs
+++ b/src/generated/dbx_async.rs
@@ -199,7 +199,8 @@ impl PollArg {
         s: &mut S::SerializeStruct,
     ) -> Result<(), S::Error> {
         use serde::ser::SerializeStruct;
-        s.serialize_field("async_job_id", &self.async_job_id)
+        s.serialize_field("async_job_id", &self.async_job_id)?;
+        Ok(())
     }
 }
 

--- a/src/generated/file_properties.rs
+++ b/src/generated/file_properties.rs
@@ -367,7 +367,8 @@ impl AddPropertiesArg {
     ) -> Result<(), S::Error> {
         use serde::ser::SerializeStruct;
         s.serialize_field("path", &self.path)?;
-        s.serialize_field("property_groups", &self.property_groups)
+        s.serialize_field("property_groups", &self.property_groups)?;
+        Ok(())
     }
 }
 
@@ -647,7 +648,8 @@ impl AddTemplateArg {
         use serde::ser::SerializeStruct;
         s.serialize_field("name", &self.name)?;
         s.serialize_field("description", &self.description)?;
-        s.serialize_field("fields", &self.fields)
+        s.serialize_field("fields", &self.fields)?;
+        Ok(())
     }
 }
 
@@ -739,7 +741,8 @@ impl AddTemplateResult {
         s: &mut S::SerializeStruct,
     ) -> Result<(), S::Error> {
         use serde::ser::SerializeStruct;
-        s.serialize_field("template_id", &self.template_id)
+        s.serialize_field("template_id", &self.template_id)?;
+        Ok(())
     }
 }
 
@@ -831,7 +834,8 @@ impl GetTemplateArg {
         s: &mut S::SerializeStruct,
     ) -> Result<(), S::Error> {
         use serde::ser::SerializeStruct;
-        s.serialize_field("template_id", &self.template_id)
+        s.serialize_field("template_id", &self.template_id)?;
+        Ok(())
     }
 }
 
@@ -948,7 +952,8 @@ impl GetTemplateResult {
         use serde::ser::SerializeStruct;
         s.serialize_field("name", &self.name)?;
         s.serialize_field("description", &self.description)?;
-        s.serialize_field("fields", &self.fields)
+        s.serialize_field("fields", &self.fields)?;
+        Ok(())
     }
 }
 
@@ -1192,7 +1197,8 @@ impl ListTemplateResult {
         s: &mut S::SerializeStruct,
     ) -> Result<(), S::Error> {
         use serde::ser::SerializeStruct;
-        s.serialize_field("template_ids", &self.template_ids)
+        s.serialize_field("template_ids", &self.template_ids)?;
+        Ok(())
     }
 }
 
@@ -1667,7 +1673,8 @@ impl OverwritePropertyGroupArg {
     ) -> Result<(), S::Error> {
         use serde::ser::SerializeStruct;
         s.serialize_field("path", &self.path)?;
-        s.serialize_field("property_groups", &self.property_groups)
+        s.serialize_field("property_groups", &self.property_groups)?;
+        Ok(())
     }
 }
 
@@ -1894,7 +1901,8 @@ impl PropertiesSearchArg {
     ) -> Result<(), S::Error> {
         use serde::ser::SerializeStruct;
         s.serialize_field("queries", &self.queries)?;
-        s.serialize_field("template_filter", &self.template_filter)
+        s.serialize_field("template_filter", &self.template_filter)?;
+        Ok(())
     }
 }
 
@@ -1985,7 +1993,8 @@ impl PropertiesSearchContinueArg {
         s: &mut S::SerializeStruct,
     ) -> Result<(), S::Error> {
         use serde::ser::SerializeStruct;
-        s.serialize_field("cursor", &self.cursor)
+        s.serialize_field("cursor", &self.cursor)?;
+        Ok(())
     }
 }
 
@@ -2263,7 +2272,8 @@ impl PropertiesSearchMatch {
         s.serialize_field("id", &self.id)?;
         s.serialize_field("path", &self.path)?;
         s.serialize_field("is_deleted", &self.is_deleted)?;
-        s.serialize_field("property_groups", &self.property_groups)
+        s.serialize_field("property_groups", &self.property_groups)?;
+        Ok(())
     }
 }
 
@@ -2446,7 +2456,8 @@ impl PropertiesSearchQuery {
         use serde::ser::SerializeStruct;
         s.serialize_field("query", &self.query)?;
         s.serialize_field("mode", &self.mode)?;
-        s.serialize_field("logical_operator", &self.logical_operator)
+        s.serialize_field("logical_operator", &self.logical_operator)?;
+        Ok(())
     }
 }
 
@@ -2555,7 +2566,10 @@ impl PropertiesSearchResult {
     ) -> Result<(), S::Error> {
         use serde::ser::SerializeStruct;
         s.serialize_field("matches", &self.matches)?;
-        s.serialize_field("cursor", &self.cursor)
+        if let Some(val) = &self.cursor {
+            s.serialize_field("cursor", val)?;
+        }
+        Ok(())
     }
 }
 
@@ -2661,7 +2675,8 @@ impl PropertyField {
     ) -> Result<(), S::Error> {
         use serde::ser::SerializeStruct;
         s.serialize_field("name", &self.name)?;
-        s.serialize_field("value", &self.value)
+        s.serialize_field("value", &self.value)?;
+        Ok(())
     }
 }
 
@@ -2780,7 +2795,8 @@ impl PropertyFieldTemplate {
         use serde::ser::SerializeStruct;
         s.serialize_field("name", &self.name)?;
         s.serialize_field("description", &self.description)?;
-        s.serialize_field("type", &self.type_field)
+        s.serialize_field("type", &self.type_field)?;
+        Ok(())
     }
 }
 
@@ -2888,7 +2904,8 @@ impl PropertyGroup {
     ) -> Result<(), S::Error> {
         use serde::ser::SerializeStruct;
         s.serialize_field("template_id", &self.template_id)?;
-        s.serialize_field("fields", &self.fields)
+        s.serialize_field("fields", &self.fields)?;
+        Ok(())
     }
 }
 
@@ -3006,7 +3023,8 @@ impl PropertyGroupTemplate {
         use serde::ser::SerializeStruct;
         s.serialize_field("name", &self.name)?;
         s.serialize_field("description", &self.description)?;
-        s.serialize_field("fields", &self.fields)
+        s.serialize_field("fields", &self.fields)?;
+        Ok(())
     }
 }
 
@@ -3132,8 +3150,13 @@ impl PropertyGroupUpdate {
     ) -> Result<(), S::Error> {
         use serde::ser::SerializeStruct;
         s.serialize_field("template_id", &self.template_id)?;
-        s.serialize_field("add_or_update_fields", &self.add_or_update_fields)?;
-        s.serialize_field("remove_fields", &self.remove_fields)
+        if let Some(val) = &self.add_or_update_fields {
+            s.serialize_field("add_or_update_fields", val)?;
+        }
+        if let Some(val) = &self.remove_fields {
+            s.serialize_field("remove_fields", val)?;
+        }
+        Ok(())
     }
 }
 
@@ -3294,7 +3317,8 @@ impl RemovePropertiesArg {
     ) -> Result<(), S::Error> {
         use serde::ser::SerializeStruct;
         s.serialize_field("path", &self.path)?;
-        s.serialize_field("property_template_ids", &self.property_template_ids)
+        s.serialize_field("property_template_ids", &self.property_template_ids)?;
+        Ok(())
     }
 }
 
@@ -3522,7 +3546,8 @@ impl RemoveTemplateArg {
         s: &mut S::SerializeStruct,
     ) -> Result<(), S::Error> {
         use serde::ser::SerializeStruct;
-        s.serialize_field("template_id", &self.template_id)
+        s.serialize_field("template_id", &self.template_id)?;
+        Ok(())
     }
 }
 
@@ -3911,7 +3936,8 @@ impl UpdatePropertiesArg {
     ) -> Result<(), S::Error> {
         use serde::ser::SerializeStruct;
         s.serialize_field("path", &self.path)?;
-        s.serialize_field("update_property_groups", &self.update_property_groups)
+        s.serialize_field("update_property_groups", &self.update_property_groups)?;
+        Ok(())
     }
 }
 
@@ -4226,9 +4252,16 @@ impl UpdateTemplateArg {
     ) -> Result<(), S::Error> {
         use serde::ser::SerializeStruct;
         s.serialize_field("template_id", &self.template_id)?;
-        s.serialize_field("name", &self.name)?;
-        s.serialize_field("description", &self.description)?;
-        s.serialize_field("add_fields", &self.add_fields)
+        if let Some(val) = &self.name {
+            s.serialize_field("name", val)?;
+        }
+        if let Some(val) = &self.description {
+            s.serialize_field("description", val)?;
+        }
+        if let Some(val) = &self.add_fields {
+            s.serialize_field("add_fields", val)?;
+        }
+        Ok(())
     }
 }
 
@@ -4320,7 +4353,8 @@ impl UpdateTemplateResult {
         s: &mut S::SerializeStruct,
     ) -> Result<(), S::Error> {
         use serde::ser::SerializeStruct;
-        s.serialize_field("template_id", &self.template_id)
+        s.serialize_field("template_id", &self.template_id)?;
+        Ok(())
     }
 }
 

--- a/src/generated/file_requests.rs
+++ b/src/generated/file_requests.rs
@@ -267,7 +267,8 @@ impl CountFileRequestsResult {
         s: &mut S::SerializeStruct,
     ) -> Result<(), S::Error> {
         use serde::ser::SerializeStruct;
-        s.serialize_field("file_request_count", &self.file_request_count)
+        s.serialize_field("file_request_count", &self.file_request_count)?;
+        Ok(())
     }
 }
 
@@ -426,9 +427,14 @@ impl CreateFileRequestArgs {
         use serde::ser::SerializeStruct;
         s.serialize_field("title", &self.title)?;
         s.serialize_field("destination", &self.destination)?;
-        s.serialize_field("deadline", &self.deadline)?;
+        if let Some(val) = &self.deadline {
+            s.serialize_field("deadline", val)?;
+        }
         s.serialize_field("open", &self.open)?;
-        s.serialize_field("description", &self.description)
+        if let Some(val) = &self.description {
+            s.serialize_field("description", val)?;
+        }
+        Ok(())
     }
 }
 
@@ -816,7 +822,8 @@ impl DeleteAllClosedFileRequestsResult {
         s: &mut S::SerializeStruct,
     ) -> Result<(), S::Error> {
         use serde::ser::SerializeStruct;
-        s.serialize_field("file_requests", &self.file_requests)
+        s.serialize_field("file_requests", &self.file_requests)?;
+        Ok(())
     }
 }
 
@@ -907,7 +914,8 @@ impl DeleteFileRequestArgs {
         s: &mut S::SerializeStruct,
     ) -> Result<(), S::Error> {
         use serde::ser::SerializeStruct;
-        s.serialize_field("ids", &self.ids)
+        s.serialize_field("ids", &self.ids)?;
+        Ok(())
     }
 }
 
@@ -1146,7 +1154,8 @@ impl DeleteFileRequestsResult {
         s: &mut S::SerializeStruct,
     ) -> Result<(), S::Error> {
         use serde::ser::SerializeStruct;
-        s.serialize_field("file_requests", &self.file_requests)
+        s.serialize_field("file_requests", &self.file_requests)?;
+        Ok(())
     }
 }
 
@@ -1365,9 +1374,16 @@ impl FileRequest {
         s.serialize_field("created", &self.created)?;
         s.serialize_field("is_open", &self.is_open)?;
         s.serialize_field("file_count", &self.file_count)?;
-        s.serialize_field("destination", &self.destination)?;
-        s.serialize_field("deadline", &self.deadline)?;
-        s.serialize_field("description", &self.description)
+        if let Some(val) = &self.destination {
+            s.serialize_field("destination", val)?;
+        }
+        if let Some(val) = &self.deadline {
+            s.serialize_field("deadline", val)?;
+        }
+        if let Some(val) = &self.description {
+            s.serialize_field("description", val)?;
+        }
+        Ok(())
     }
 }
 
@@ -1476,7 +1492,10 @@ impl FileRequestDeadline {
     ) -> Result<(), S::Error> {
         use serde::ser::SerializeStruct;
         s.serialize_field("deadline", &self.deadline)?;
-        s.serialize_field("allow_late_uploads", &self.allow_late_uploads)
+        if let Some(val) = &self.allow_late_uploads {
+            s.serialize_field("allow_late_uploads", val)?;
+        }
+        Ok(())
     }
 }
 
@@ -1772,7 +1791,8 @@ impl GetFileRequestArgs {
         s: &mut S::SerializeStruct,
     ) -> Result<(), S::Error> {
         use serde::ser::SerializeStruct;
-        s.serialize_field("id", &self.id)
+        s.serialize_field("id", &self.id)?;
+        Ok(())
     }
 }
 
@@ -2086,7 +2106,8 @@ impl ListFileRequestsArg {
         s: &mut S::SerializeStruct,
     ) -> Result<(), S::Error> {
         use serde::ser::SerializeStruct;
-        s.serialize_field("limit", &self.limit)
+        s.serialize_field("limit", &self.limit)?;
+        Ok(())
     }
 }
 
@@ -2176,7 +2197,8 @@ impl ListFileRequestsContinueArg {
         s: &mut S::SerializeStruct,
     ) -> Result<(), S::Error> {
         use serde::ser::SerializeStruct;
-        s.serialize_field("cursor", &self.cursor)
+        s.serialize_field("cursor", &self.cursor)?;
+        Ok(())
     }
 }
 
@@ -2415,7 +2437,8 @@ impl ListFileRequestsResult {
         s: &mut S::SerializeStruct,
     ) -> Result<(), S::Error> {
         use serde::ser::SerializeStruct;
-        s.serialize_field("file_requests", &self.file_requests)
+        s.serialize_field("file_requests", &self.file_requests)?;
+        Ok(())
     }
 }
 
@@ -2534,7 +2557,8 @@ impl ListFileRequestsV2Result {
         use serde::ser::SerializeStruct;
         s.serialize_field("file_requests", &self.file_requests)?;
         s.serialize_field("cursor", &self.cursor)?;
-        s.serialize_field("has_more", &self.has_more)
+        s.serialize_field("has_more", &self.has_more)?;
+        Ok(())
     }
 }
 
@@ -2713,11 +2737,20 @@ impl UpdateFileRequestArgs {
     ) -> Result<(), S::Error> {
         use serde::ser::SerializeStruct;
         s.serialize_field("id", &self.id)?;
-        s.serialize_field("title", &self.title)?;
-        s.serialize_field("destination", &self.destination)?;
+        if let Some(val) = &self.title {
+            s.serialize_field("title", val)?;
+        }
+        if let Some(val) = &self.destination {
+            s.serialize_field("destination", val)?;
+        }
         s.serialize_field("deadline", &self.deadline)?;
-        s.serialize_field("open", &self.open)?;
-        s.serialize_field("description", &self.description)
+        if let Some(val) = &self.open {
+            s.serialize_field("open", val)?;
+        }
+        if let Some(val) = &self.description {
+            s.serialize_field("description", val)?;
+        }
+        Ok(())
     }
 }
 

--- a/src/generated/files.rs
+++ b/src/generated/files.rs
@@ -1361,8 +1361,13 @@ impl AlphaGetMetadataArg {
         s.serialize_field("include_media_info", &self.include_media_info)?;
         s.serialize_field("include_deleted", &self.include_deleted)?;
         s.serialize_field("include_has_explicit_shared_members", &self.include_has_explicit_shared_members)?;
-        s.serialize_field("include_property_groups", &self.include_property_groups)?;
-        s.serialize_field("include_property_templates", &self.include_property_templates)
+        if let Some(val) = &self.include_property_groups {
+            s.serialize_field("include_property_groups", val)?;
+        }
+        if let Some(val) = &self.include_property_templates {
+            s.serialize_field("include_property_templates", val)?;
+        }
+        Ok(())
     }
 }
 
@@ -1659,10 +1664,15 @@ impl CommitInfo {
         s.serialize_field("path", &self.path)?;
         s.serialize_field("mode", &self.mode)?;
         s.serialize_field("autorename", &self.autorename)?;
-        s.serialize_field("client_modified", &self.client_modified)?;
+        if let Some(val) = &self.client_modified {
+            s.serialize_field("client_modified", val)?;
+        }
         s.serialize_field("mute", &self.mute)?;
-        s.serialize_field("property_groups", &self.property_groups)?;
-        s.serialize_field("strict_conflict", &self.strict_conflict)
+        if let Some(val) = &self.property_groups {
+            s.serialize_field("property_groups", val)?;
+        }
+        s.serialize_field("strict_conflict", &self.strict_conflict)?;
+        Ok(())
     }
 }
 
@@ -1870,10 +1880,15 @@ impl CommitInfoWithProperties {
         s.serialize_field("path", &self.path)?;
         s.serialize_field("mode", &self.mode)?;
         s.serialize_field("autorename", &self.autorename)?;
-        s.serialize_field("client_modified", &self.client_modified)?;
+        if let Some(val) = &self.client_modified {
+            s.serialize_field("client_modified", val)?;
+        }
         s.serialize_field("mute", &self.mute)?;
-        s.serialize_field("property_groups", &self.property_groups)?;
-        s.serialize_field("strict_conflict", &self.strict_conflict)
+        if let Some(val) = &self.property_groups {
+            s.serialize_field("property_groups", val)?;
+        }
+        s.serialize_field("strict_conflict", &self.strict_conflict)?;
+        Ok(())
     }
 }
 
@@ -1976,7 +1991,8 @@ impl ContentSyncSetting {
     ) -> Result<(), S::Error> {
         use serde::ser::SerializeStruct;
         s.serialize_field("id", &self.id)?;
-        s.serialize_field("sync_setting", &self.sync_setting)
+        s.serialize_field("sync_setting", &self.sync_setting)?;
+        Ok(())
     }
 }
 
@@ -2079,7 +2095,8 @@ impl ContentSyncSettingArg {
     ) -> Result<(), S::Error> {
         use serde::ser::SerializeStruct;
         s.serialize_field("id", &self.id)?;
-        s.serialize_field("sync_setting", &self.sync_setting)
+        s.serialize_field("sync_setting", &self.sync_setting)?;
+        Ok(())
     }
 }
 
@@ -2188,7 +2205,8 @@ impl CreateFolderArg {
     ) -> Result<(), S::Error> {
         use serde::ser::SerializeStruct;
         s.serialize_field("path", &self.path)?;
-        s.serialize_field("autorename", &self.autorename)
+        s.serialize_field("autorename", &self.autorename)?;
+        Ok(())
     }
 }
 
@@ -2316,7 +2334,8 @@ impl CreateFolderBatchArg {
         use serde::ser::SerializeStruct;
         s.serialize_field("paths", &self.paths)?;
         s.serialize_field("autorename", &self.autorename)?;
-        s.serialize_field("force_async", &self.force_async)
+        s.serialize_field("force_async", &self.force_async)?;
+        Ok(())
     }
 }
 
@@ -2632,7 +2651,8 @@ impl CreateFolderBatchResult {
         s: &mut S::SerializeStruct,
     ) -> Result<(), S::Error> {
         use serde::ser::SerializeStruct;
-        s.serialize_field("entries", &self.entries)
+        s.serialize_field("entries", &self.entries)?;
+        Ok(())
     }
 }
 
@@ -2866,7 +2886,8 @@ impl CreateFolderEntryResult {
         s: &mut S::SerializeStruct,
     ) -> Result<(), S::Error> {
         use serde::ser::SerializeStruct;
-        s.serialize_field("metadata", &self.metadata)
+        s.serialize_field("metadata", &self.metadata)?;
+        Ok(())
     }
 }
 
@@ -3027,7 +3048,8 @@ impl CreateFolderResult {
         s: &mut S::SerializeStruct,
     ) -> Result<(), S::Error> {
         use serde::ser::SerializeStruct;
-        s.serialize_field("metadata", &self.metadata)
+        s.serialize_field("metadata", &self.metadata)?;
+        Ok(())
     }
 }
 
@@ -3136,7 +3158,10 @@ impl DeleteArg {
     ) -> Result<(), S::Error> {
         use serde::ser::SerializeStruct;
         s.serialize_field("path", &self.path)?;
-        s.serialize_field("parent_rev", &self.parent_rev)
+        if let Some(val) = &self.parent_rev {
+            s.serialize_field("parent_rev", val)?;
+        }
+        Ok(())
     }
 }
 
@@ -3225,7 +3250,8 @@ impl DeleteBatchArg {
         s: &mut S::SerializeStruct,
     ) -> Result<(), S::Error> {
         use serde::ser::SerializeStruct;
-        s.serialize_field("entries", &self.entries)
+        s.serialize_field("entries", &self.entries)?;
+        Ok(())
     }
 }
 
@@ -3540,7 +3566,8 @@ impl DeleteBatchResult {
         s: &mut S::SerializeStruct,
     ) -> Result<(), S::Error> {
         use serde::ser::SerializeStruct;
-        s.serialize_field("entries", &self.entries)
+        s.serialize_field("entries", &self.entries)?;
+        Ok(())
     }
 }
 
@@ -3630,7 +3657,8 @@ impl DeleteBatchResultData {
         s: &mut S::SerializeStruct,
     ) -> Result<(), S::Error> {
         use serde::ser::SerializeStruct;
-        s.serialize_field("metadata", &self.metadata)
+        s.serialize_field("metadata", &self.metadata)?;
+        Ok(())
     }
 }
 
@@ -3904,7 +3932,8 @@ impl DeleteResult {
         s: &mut S::SerializeStruct,
     ) -> Result<(), S::Error> {
         use serde::ser::SerializeStruct;
-        s.serialize_field("metadata", &self.metadata)
+        s.serialize_field("metadata", &self.metadata)?;
+        Ok(())
     }
 }
 
@@ -4054,9 +4083,16 @@ impl DeletedMetadata {
     ) -> Result<(), S::Error> {
         use serde::ser::SerializeStruct;
         s.serialize_field("name", &self.name)?;
-        s.serialize_field("path_lower", &self.path_lower)?;
-        s.serialize_field("path_display", &self.path_display)?;
-        s.serialize_field("parent_shared_folder_id", &self.parent_shared_folder_id)
+        if let Some(val) = &self.path_lower {
+            s.serialize_field("path_lower", val)?;
+        }
+        if let Some(val) = &self.path_display {
+            s.serialize_field("path_display", val)?;
+        }
+        if let Some(val) = &self.parent_shared_folder_id {
+            s.serialize_field("parent_shared_folder_id", val)?;
+        }
+        Ok(())
     }
 }
 
@@ -4160,7 +4196,8 @@ impl Dimensions {
     ) -> Result<(), S::Error> {
         use serde::ser::SerializeStruct;
         s.serialize_field("height", &self.height)?;
-        s.serialize_field("width", &self.width)
+        s.serialize_field("width", &self.width)?;
+        Ok(())
     }
 }
 
@@ -4268,7 +4305,10 @@ impl DownloadArg {
     ) -> Result<(), S::Error> {
         use serde::ser::SerializeStruct;
         s.serialize_field("path", &self.path)?;
-        s.serialize_field("rev", &self.rev)
+        if let Some(val) = &self.rev {
+            s.serialize_field("rev", val)?;
+        }
+        Ok(())
     }
 }
 
@@ -4447,7 +4487,8 @@ impl DownloadZipArg {
         s: &mut S::SerializeStruct,
     ) -> Result<(), S::Error> {
         use serde::ser::SerializeStruct;
-        s.serialize_field("path", &self.path)
+        s.serialize_field("path", &self.path)?;
+        Ok(())
     }
 }
 
@@ -4637,7 +4678,8 @@ impl DownloadZipResult {
         s: &mut S::SerializeStruct,
     ) -> Result<(), S::Error> {
         use serde::ser::SerializeStruct;
-        s.serialize_field("metadata", &self.metadata)
+        s.serialize_field("metadata", &self.metadata)?;
+        Ok(())
     }
 }
 
@@ -4747,7 +4789,10 @@ impl ExportArg {
     ) -> Result<(), S::Error> {
         use serde::ser::SerializeStruct;
         s.serialize_field("path", &self.path)?;
-        s.serialize_field("export_format", &self.export_format)
+        if let Some(val) = &self.export_format {
+            s.serialize_field("export_format", val)?;
+        }
+        Ok(())
     }
 }
 
@@ -4963,8 +5008,13 @@ impl ExportInfo {
         s: &mut S::SerializeStruct,
     ) -> Result<(), S::Error> {
         use serde::ser::SerializeStruct;
-        s.serialize_field("export_as", &self.export_as)?;
-        s.serialize_field("export_options", &self.export_options)
+        if let Some(val) = &self.export_as {
+            s.serialize_field("export_as", val)?;
+        }
+        if let Some(val) = &self.export_options {
+            s.serialize_field("export_options", val)?;
+        }
+        Ok(())
     }
 }
 
@@ -5105,8 +5155,13 @@ impl ExportMetadata {
         use serde::ser::SerializeStruct;
         s.serialize_field("name", &self.name)?;
         s.serialize_field("size", &self.size)?;
-        s.serialize_field("export_hash", &self.export_hash)?;
-        s.serialize_field("paper_revision", &self.paper_revision)
+        if let Some(val) = &self.export_hash {
+            s.serialize_field("export_hash", val)?;
+        }
+        if let Some(val) = &self.paper_revision {
+            s.serialize_field("paper_revision", val)?;
+        }
+        Ok(())
     }
 }
 
@@ -5209,7 +5264,8 @@ impl ExportResult {
     ) -> Result<(), S::Error> {
         use serde::ser::SerializeStruct;
         s.serialize_field("export_metadata", &self.export_metadata)?;
-        s.serialize_field("file_metadata", &self.file_metadata)
+        s.serialize_field("file_metadata", &self.file_metadata)?;
+        Ok(())
     }
 }
 
@@ -5444,7 +5500,8 @@ impl FileLock {
         s: &mut S::SerializeStruct,
     ) -> Result<(), S::Error> {
         use serde::ser::SerializeStruct;
-        s.serialize_field("content", &self.content)
+        s.serialize_field("content", &self.content)?;
+        Ok(())
     }
 }
 
@@ -5647,10 +5704,19 @@ impl FileLockMetadata {
         s: &mut S::SerializeStruct,
     ) -> Result<(), S::Error> {
         use serde::ser::SerializeStruct;
-        s.serialize_field("is_lockholder", &self.is_lockholder)?;
-        s.serialize_field("lockholder_name", &self.lockholder_name)?;
-        s.serialize_field("lockholder_account_id", &self.lockholder_account_id)?;
-        s.serialize_field("created", &self.created)
+        if let Some(val) = &self.is_lockholder {
+            s.serialize_field("is_lockholder", val)?;
+        }
+        if let Some(val) = &self.lockholder_name {
+            s.serialize_field("lockholder_name", val)?;
+        }
+        if let Some(val) = &self.lockholder_account_id {
+            s.serialize_field("lockholder_account_id", val)?;
+        }
+        if let Some(val) = &self.created {
+            s.serialize_field("created", val)?;
+        }
+        Ok(())
     }
 }
 
@@ -6042,18 +6108,41 @@ impl FileMetadata {
         s.serialize_field("server_modified", &self.server_modified)?;
         s.serialize_field("rev", &self.rev)?;
         s.serialize_field("size", &self.size)?;
-        s.serialize_field("path_lower", &self.path_lower)?;
-        s.serialize_field("path_display", &self.path_display)?;
-        s.serialize_field("parent_shared_folder_id", &self.parent_shared_folder_id)?;
-        s.serialize_field("media_info", &self.media_info)?;
-        s.serialize_field("symlink_info", &self.symlink_info)?;
-        s.serialize_field("sharing_info", &self.sharing_info)?;
+        if let Some(val) = &self.path_lower {
+            s.serialize_field("path_lower", val)?;
+        }
+        if let Some(val) = &self.path_display {
+            s.serialize_field("path_display", val)?;
+        }
+        if let Some(val) = &self.parent_shared_folder_id {
+            s.serialize_field("parent_shared_folder_id", val)?;
+        }
+        if let Some(val) = &self.media_info {
+            s.serialize_field("media_info", val)?;
+        }
+        if let Some(val) = &self.symlink_info {
+            s.serialize_field("symlink_info", val)?;
+        }
+        if let Some(val) = &self.sharing_info {
+            s.serialize_field("sharing_info", val)?;
+        }
         s.serialize_field("is_downloadable", &self.is_downloadable)?;
-        s.serialize_field("export_info", &self.export_info)?;
-        s.serialize_field("property_groups", &self.property_groups)?;
-        s.serialize_field("has_explicit_shared_members", &self.has_explicit_shared_members)?;
-        s.serialize_field("content_hash", &self.content_hash)?;
-        s.serialize_field("file_lock_info", &self.file_lock_info)
+        if let Some(val) = &self.export_info {
+            s.serialize_field("export_info", val)?;
+        }
+        if let Some(val) = &self.property_groups {
+            s.serialize_field("property_groups", val)?;
+        }
+        if let Some(val) = &self.has_explicit_shared_members {
+            s.serialize_field("has_explicit_shared_members", val)?;
+        }
+        if let Some(val) = &self.content_hash {
+            s.serialize_field("content_hash", val)?;
+        }
+        if let Some(val) = &self.file_lock_info {
+            s.serialize_field("file_lock_info", val)?;
+        }
+        Ok(())
     }
 }
 
@@ -6226,7 +6315,10 @@ impl FileSharingInfo {
         use serde::ser::SerializeStruct;
         s.serialize_field("read_only", &self.read_only)?;
         s.serialize_field("parent_shared_folder_id", &self.parent_shared_folder_id)?;
-        s.serialize_field("modified_by", &self.modified_by)
+        if let Some(val) = &self.modified_by {
+            s.serialize_field("modified_by", val)?;
+        }
+        Ok(())
     }
 }
 
@@ -6507,12 +6599,25 @@ impl FolderMetadata {
         use serde::ser::SerializeStruct;
         s.serialize_field("name", &self.name)?;
         s.serialize_field("id", &self.id)?;
-        s.serialize_field("path_lower", &self.path_lower)?;
-        s.serialize_field("path_display", &self.path_display)?;
-        s.serialize_field("parent_shared_folder_id", &self.parent_shared_folder_id)?;
-        s.serialize_field("shared_folder_id", &self.shared_folder_id)?;
-        s.serialize_field("sharing_info", &self.sharing_info)?;
-        s.serialize_field("property_groups", &self.property_groups)
+        if let Some(val) = &self.path_lower {
+            s.serialize_field("path_lower", val)?;
+        }
+        if let Some(val) = &self.path_display {
+            s.serialize_field("path_display", val)?;
+        }
+        if let Some(val) = &self.parent_shared_folder_id {
+            s.serialize_field("parent_shared_folder_id", val)?;
+        }
+        if let Some(val) = &self.shared_folder_id {
+            s.serialize_field("shared_folder_id", val)?;
+        }
+        if let Some(val) = &self.sharing_info {
+            s.serialize_field("sharing_info", val)?;
+        }
+        if let Some(val) = &self.property_groups {
+            s.serialize_field("property_groups", val)?;
+        }
+        Ok(())
     }
 }
 
@@ -6676,10 +6781,15 @@ impl FolderSharingInfo {
     ) -> Result<(), S::Error> {
         use serde::ser::SerializeStruct;
         s.serialize_field("read_only", &self.read_only)?;
-        s.serialize_field("parent_shared_folder_id", &self.parent_shared_folder_id)?;
-        s.serialize_field("shared_folder_id", &self.shared_folder_id)?;
+        if let Some(val) = &self.parent_shared_folder_id {
+            s.serialize_field("parent_shared_folder_id", val)?;
+        }
+        if let Some(val) = &self.shared_folder_id {
+            s.serialize_field("shared_folder_id", val)?;
+        }
         s.serialize_field("traverse_only", &self.traverse_only)?;
-        s.serialize_field("no_access", &self.no_access)
+        s.serialize_field("no_access", &self.no_access)?;
+        Ok(())
     }
 }
 
@@ -6769,7 +6879,8 @@ impl GetCopyReferenceArg {
         s: &mut S::SerializeStruct,
     ) -> Result<(), S::Error> {
         use serde::ser::SerializeStruct;
-        s.serialize_field("path", &self.path)
+        s.serialize_field("path", &self.path)?;
+        Ok(())
     }
 }
 
@@ -6969,7 +7080,8 @@ impl GetCopyReferenceResult {
         use serde::ser::SerializeStruct;
         s.serialize_field("metadata", &self.metadata)?;
         s.serialize_field("copy_reference", &self.copy_reference)?;
-        s.serialize_field("expires", &self.expires)
+        s.serialize_field("expires", &self.expires)?;
+        Ok(())
     }
 }
 
@@ -7137,7 +7249,10 @@ impl GetMetadataArg {
         s.serialize_field("include_media_info", &self.include_media_info)?;
         s.serialize_field("include_deleted", &self.include_deleted)?;
         s.serialize_field("include_has_explicit_shared_members", &self.include_has_explicit_shared_members)?;
-        s.serialize_field("include_property_groups", &self.include_property_groups)
+        if let Some(val) = &self.include_property_groups {
+            s.serialize_field("include_property_groups", val)?;
+        }
+        Ok(())
     }
 }
 
@@ -7298,7 +7413,8 @@ impl GetTemporaryLinkArg {
         s: &mut S::SerializeStruct,
     ) -> Result<(), S::Error> {
         use serde::ser::SerializeStruct;
-        s.serialize_field("path", &self.path)
+        s.serialize_field("path", &self.path)?;
+        Ok(())
     }
 }
 
@@ -7514,7 +7630,8 @@ impl GetTemporaryLinkResult {
     ) -> Result<(), S::Error> {
         use serde::ser::SerializeStruct;
         s.serialize_field("metadata", &self.metadata)?;
-        s.serialize_field("link", &self.link)
+        s.serialize_field("link", &self.link)?;
+        Ok(())
     }
 }
 
@@ -7624,7 +7741,8 @@ impl GetTemporaryUploadLinkArg {
     ) -> Result<(), S::Error> {
         use serde::ser::SerializeStruct;
         s.serialize_field("commit_info", &self.commit_info)?;
-        s.serialize_field("duration", &self.duration)
+        s.serialize_field("duration", &self.duration)?;
+        Ok(())
     }
 }
 
@@ -7714,7 +7832,8 @@ impl GetTemporaryUploadLinkResult {
         s: &mut S::SerializeStruct,
     ) -> Result<(), S::Error> {
         use serde::ser::SerializeStruct;
-        s.serialize_field("link", &self.link)
+        s.serialize_field("link", &self.link)?;
+        Ok(())
     }
 }
 
@@ -7805,7 +7924,8 @@ impl GetThumbnailBatchArg {
         s: &mut S::SerializeStruct,
     ) -> Result<(), S::Error> {
         use serde::ser::SerializeStruct;
-        s.serialize_field("entries", &self.entries)
+        s.serialize_field("entries", &self.entries)?;
+        Ok(())
     }
 }
 
@@ -7962,7 +8082,8 @@ impl GetThumbnailBatchResult {
         s: &mut S::SerializeStruct,
     ) -> Result<(), S::Error> {
         use serde::ser::SerializeStruct;
-        s.serialize_field("entries", &self.entries)
+        s.serialize_field("entries", &self.entries)?;
+        Ok(())
     }
 }
 
@@ -8064,7 +8185,8 @@ impl GetThumbnailBatchResultData {
     ) -> Result<(), S::Error> {
         use serde::ser::SerializeStruct;
         s.serialize_field("metadata", &self.metadata)?;
-        s.serialize_field("thumbnail", &self.thumbnail)
+        s.serialize_field("thumbnail", &self.thumbnail)?;
+        Ok(())
     }
 }
 
@@ -8240,7 +8362,8 @@ impl GpsCoordinates {
     ) -> Result<(), S::Error> {
         use serde::ser::SerializeStruct;
         s.serialize_field("latitude", &self.latitude)?;
-        s.serialize_field("longitude", &self.longitude)
+        s.serialize_field("longitude", &self.longitude)?;
+        Ok(())
     }
 }
 
@@ -8343,7 +8466,8 @@ impl HighlightSpan {
     ) -> Result<(), S::Error> {
         use serde::ser::SerializeStruct;
         s.serialize_field("highlight_str", &self.highlight_str)?;
-        s.serialize_field("is_highlighted", &self.is_highlighted)
+        s.serialize_field("is_highlighted", &self.is_highlighted)?;
+        Ok(())
     }
 }
 
@@ -8680,10 +8804,17 @@ impl ListFolderArg {
         s.serialize_field("include_deleted", &self.include_deleted)?;
         s.serialize_field("include_has_explicit_shared_members", &self.include_has_explicit_shared_members)?;
         s.serialize_field("include_mounted_folders", &self.include_mounted_folders)?;
-        s.serialize_field("limit", &self.limit)?;
-        s.serialize_field("shared_link", &self.shared_link)?;
-        s.serialize_field("include_property_groups", &self.include_property_groups)?;
-        s.serialize_field("include_non_downloadable_files", &self.include_non_downloadable_files)
+        if let Some(val) = &self.limit {
+            s.serialize_field("limit", val)?;
+        }
+        if let Some(val) = &self.shared_link {
+            s.serialize_field("shared_link", val)?;
+        }
+        if let Some(val) = &self.include_property_groups {
+            s.serialize_field("include_property_groups", val)?;
+        }
+        s.serialize_field("include_non_downloadable_files", &self.include_non_downloadable_files)?;
+        Ok(())
     }
 }
 
@@ -8774,7 +8905,8 @@ impl ListFolderContinueArg {
         s: &mut S::SerializeStruct,
     ) -> Result<(), S::Error> {
         use serde::ser::SerializeStruct;
-        s.serialize_field("cursor", &self.cursor)
+        s.serialize_field("cursor", &self.cursor)?;
+        Ok(())
     }
 }
 
@@ -9052,7 +9184,8 @@ impl ListFolderGetLatestCursorResult {
         s: &mut S::SerializeStruct,
     ) -> Result<(), S::Error> {
         use serde::ser::SerializeStruct;
-        s.serialize_field("cursor", &self.cursor)
+        s.serialize_field("cursor", &self.cursor)?;
+        Ok(())
     }
 }
 
@@ -9164,7 +9297,8 @@ impl ListFolderLongpollArg {
     ) -> Result<(), S::Error> {
         use serde::ser::SerializeStruct;
         s.serialize_field("cursor", &self.cursor)?;
-        s.serialize_field("timeout", &self.timeout)
+        s.serialize_field("timeout", &self.timeout)?;
+        Ok(())
     }
 }
 
@@ -9339,7 +9473,10 @@ impl ListFolderLongpollResult {
     ) -> Result<(), S::Error> {
         use serde::ser::SerializeStruct;
         s.serialize_field("changes", &self.changes)?;
-        s.serialize_field("backoff", &self.backoff)
+        if let Some(val) = &self.backoff {
+            s.serialize_field("backoff", val)?;
+        }
+        Ok(())
     }
 }
 
@@ -9457,7 +9594,8 @@ impl ListFolderResult {
         use serde::ser::SerializeStruct;
         s.serialize_field("entries", &self.entries)?;
         s.serialize_field("cursor", &self.cursor)?;
-        s.serialize_field("has_more", &self.has_more)
+        s.serialize_field("has_more", &self.has_more)?;
+        Ok(())
     }
 }
 
@@ -9583,7 +9721,8 @@ impl ListRevisionsArg {
         use serde::ser::SerializeStruct;
         s.serialize_field("path", &self.path)?;
         s.serialize_field("mode", &self.mode)?;
-        s.serialize_field("limit", &self.limit)
+        s.serialize_field("limit", &self.limit)?;
+        Ok(())
     }
 }
 
@@ -9850,7 +9989,10 @@ impl ListRevisionsResult {
         use serde::ser::SerializeStruct;
         s.serialize_field("is_deleted", &self.is_deleted)?;
         s.serialize_field("entries", &self.entries)?;
-        s.serialize_field("server_deleted", &self.server_deleted)
+        if let Some(val) = &self.server_deleted {
+            s.serialize_field("server_deleted", val)?;
+        }
+        Ok(())
     }
 }
 
@@ -9940,7 +10082,8 @@ impl LockConflictError {
         s: &mut S::SerializeStruct,
     ) -> Result<(), S::Error> {
         use serde::ser::SerializeStruct;
-        s.serialize_field("lock", &self.lock)
+        s.serialize_field("lock", &self.lock)?;
+        Ok(())
     }
 }
 
@@ -10030,7 +10173,8 @@ impl LockFileArg {
         s: &mut S::SerializeStruct,
     ) -> Result<(), S::Error> {
         use serde::ser::SerializeStruct;
-        s.serialize_field("path", &self.path)
+        s.serialize_field("path", &self.path)?;
+        Ok(())
     }
 }
 
@@ -10121,7 +10265,8 @@ impl LockFileBatchArg {
         s: &mut S::SerializeStruct,
     ) -> Result<(), S::Error> {
         use serde::ser::SerializeStruct;
-        s.serialize_field("entries", &self.entries)
+        s.serialize_field("entries", &self.entries)?;
+        Ok(())
     }
 }
 
@@ -10212,7 +10357,8 @@ impl LockFileBatchResult {
         s: &mut S::SerializeStruct,
     ) -> Result<(), S::Error> {
         use serde::ser::SerializeStruct;
-        s.serialize_field("entries", &self.entries)
+        s.serialize_field("entries", &self.entries)?;
+        Ok(())
     }
 }
 
@@ -10474,7 +10620,8 @@ impl LockFileResult {
     ) -> Result<(), S::Error> {
         use serde::ser::SerializeStruct;
         s.serialize_field("metadata", &self.metadata)?;
-        s.serialize_field("lock", &self.lock)
+        s.serialize_field("lock", &self.lock)?;
+        Ok(())
     }
 }
 
@@ -11106,8 +11253,13 @@ impl MinimalFileLinkMetadata {
         use serde::ser::SerializeStruct;
         s.serialize_field("url", &self.url)?;
         s.serialize_field("rev", &self.rev)?;
-        s.serialize_field("id", &self.id)?;
-        s.serialize_field("path", &self.path)
+        if let Some(val) = &self.id {
+            s.serialize_field("id", val)?;
+        }
+        if let Some(val) = &self.path {
+            s.serialize_field("path", val)?;
+        }
+        Ok(())
     }
 }
 
@@ -11235,7 +11387,8 @@ impl MoveBatchArg {
         use serde::ser::SerializeStruct;
         s.serialize_field("entries", &self.entries)?;
         s.serialize_field("autorename", &self.autorename)?;
-        s.serialize_field("allow_ownership_transfer", &self.allow_ownership_transfer)
+        s.serialize_field("allow_ownership_transfer", &self.allow_ownership_transfer)?;
+        Ok(())
     }
 }
 
@@ -11507,7 +11660,8 @@ impl PaperCreateArg {
     ) -> Result<(), S::Error> {
         use serde::ser::SerializeStruct;
         s.serialize_field("path", &self.path)?;
-        s.serialize_field("import_format", &self.import_format)
+        s.serialize_field("import_format", &self.import_format)?;
+        Ok(())
     }
 }
 
@@ -11781,7 +11935,8 @@ impl PaperCreateResult {
         s.serialize_field("url", &self.url)?;
         s.serialize_field("result_path", &self.result_path)?;
         s.serialize_field("file_id", &self.file_id)?;
-        s.serialize_field("paper_revision", &self.paper_revision)
+        s.serialize_field("paper_revision", &self.paper_revision)?;
+        Ok(())
     }
 }
 
@@ -12007,7 +12162,10 @@ impl PaperUpdateArg {
         s.serialize_field("path", &self.path)?;
         s.serialize_field("import_format", &self.import_format)?;
         s.serialize_field("doc_update_policy", &self.doc_update_policy)?;
-        s.serialize_field("paper_revision", &self.paper_revision)
+        if let Some(val) = &self.paper_revision {
+            s.serialize_field("paper_revision", val)?;
+        }
+        Ok(())
     }
 }
 
@@ -12254,7 +12412,8 @@ impl PaperUpdateResult {
         s: &mut S::SerializeStruct,
     ) -> Result<(), S::Error> {
         use serde::ser::SerializeStruct;
-        s.serialize_field("paper_revision", &self.paper_revision)
+        s.serialize_field("paper_revision", &self.paper_revision)?;
+        Ok(())
     }
 }
 
@@ -12446,9 +12605,16 @@ impl PhotoMetadata {
         s: &mut S::SerializeStruct,
     ) -> Result<(), S::Error> {
         use serde::ser::SerializeStruct;
-        s.serialize_field("dimensions", &self.dimensions)?;
-        s.serialize_field("location", &self.location)?;
-        s.serialize_field("time_taken", &self.time_taken)
+        if let Some(val) = &self.dimensions {
+            s.serialize_field("dimensions", val)?;
+        }
+        if let Some(val) = &self.location {
+            s.serialize_field("location", val)?;
+        }
+        if let Some(val) = &self.time_taken {
+            s.serialize_field("time_taken", val)?;
+        }
+        Ok(())
     }
 }
 
@@ -12556,7 +12722,10 @@ impl PreviewArg {
     ) -> Result<(), S::Error> {
         use serde::ser::SerializeStruct;
         s.serialize_field("path", &self.path)?;
-        s.serialize_field("rev", &self.rev)
+        if let Some(val) = &self.rev {
+            s.serialize_field("rev", val)?;
+        }
+        Ok(())
     }
 }
 
@@ -12767,8 +12936,13 @@ impl PreviewResult {
         s: &mut S::SerializeStruct,
     ) -> Result<(), S::Error> {
         use serde::ser::SerializeStruct;
-        s.serialize_field("file_metadata", &self.file_metadata)?;
-        s.serialize_field("link_metadata", &self.link_metadata)
+        if let Some(val) = &self.file_metadata {
+            s.serialize_field("file_metadata", val)?;
+        }
+        if let Some(val) = &self.link_metadata {
+            s.serialize_field("link_metadata", val)?;
+        }
+        Ok(())
     }
 }
 
@@ -12927,7 +13101,8 @@ impl RelocationArg {
         s.serialize_field("to_path", &self.to_path)?;
         s.serialize_field("allow_shared_folder", &self.allow_shared_folder)?;
         s.serialize_field("autorename", &self.autorename)?;
-        s.serialize_field("allow_ownership_transfer", &self.allow_ownership_transfer)
+        s.serialize_field("allow_ownership_transfer", &self.allow_ownership_transfer)?;
+        Ok(())
     }
 }
 
@@ -13073,7 +13248,8 @@ impl RelocationBatchArg {
         s.serialize_field("entries", &self.entries)?;
         s.serialize_field("autorename", &self.autorename)?;
         s.serialize_field("allow_shared_folder", &self.allow_shared_folder)?;
-        s.serialize_field("allow_ownership_transfer", &self.allow_ownership_transfer)
+        s.serialize_field("allow_ownership_transfer", &self.allow_ownership_transfer)?;
+        Ok(())
     }
 }
 
@@ -13182,7 +13358,8 @@ impl RelocationBatchArgBase {
     ) -> Result<(), S::Error> {
         use serde::ser::SerializeStruct;
         s.serialize_field("entries", &self.entries)?;
-        s.serialize_field("autorename", &self.autorename)
+        s.serialize_field("autorename", &self.autorename)?;
+        Ok(())
     }
 }
 
@@ -13751,7 +13928,8 @@ impl RelocationBatchResult {
         s: &mut S::SerializeStruct,
     ) -> Result<(), S::Error> {
         use serde::ser::SerializeStruct;
-        s.serialize_field("entries", &self.entries)
+        s.serialize_field("entries", &self.entries)?;
+        Ok(())
     }
 }
 
@@ -13841,7 +14019,8 @@ impl RelocationBatchResultData {
         s: &mut S::SerializeStruct,
     ) -> Result<(), S::Error> {
         use serde::ser::SerializeStruct;
-        s.serialize_field("metadata", &self.metadata)
+        s.serialize_field("metadata", &self.metadata)?;
+        Ok(())
     }
 }
 
@@ -14141,7 +14320,8 @@ impl RelocationBatchV2Result {
         s: &mut S::SerializeStruct,
     ) -> Result<(), S::Error> {
         use serde::ser::SerializeStruct;
-        s.serialize_field("entries", &self.entries)
+        s.serialize_field("entries", &self.entries)?;
+        Ok(())
     }
 }
 
@@ -14478,7 +14658,8 @@ impl RelocationPath {
     ) -> Result<(), S::Error> {
         use serde::ser::SerializeStruct;
         s.serialize_field("from_path", &self.from_path)?;
-        s.serialize_field("to_path", &self.to_path)
+        s.serialize_field("to_path", &self.to_path)?;
+        Ok(())
     }
 }
 
@@ -14568,7 +14749,8 @@ impl RelocationResult {
         s: &mut S::SerializeStruct,
     ) -> Result<(), S::Error> {
         use serde::ser::SerializeStruct;
-        s.serialize_field("metadata", &self.metadata)
+        s.serialize_field("metadata", &self.metadata)?;
+        Ok(())
     }
 }
 
@@ -14671,7 +14853,8 @@ impl RestoreArg {
     ) -> Result<(), S::Error> {
         use serde::ser::SerializeStruct;
         s.serialize_field("path", &self.path)?;
-        s.serialize_field("rev", &self.rev)
+        s.serialize_field("rev", &self.rev)?;
+        Ok(())
     }
 }
 
@@ -14895,7 +15078,8 @@ impl SaveCopyReferenceArg {
     ) -> Result<(), S::Error> {
         use serde::ser::SerializeStruct;
         s.serialize_field("copy_reference", &self.copy_reference)?;
-        s.serialize_field("path", &self.path)
+        s.serialize_field("path", &self.path)?;
+        Ok(())
     }
 }
 
@@ -15109,7 +15293,8 @@ impl SaveCopyReferenceResult {
         s: &mut S::SerializeStruct,
     ) -> Result<(), S::Error> {
         use serde::ser::SerializeStruct;
-        s.serialize_field("metadata", &self.metadata)
+        s.serialize_field("metadata", &self.metadata)?;
+        Ok(())
     }
 }
 
@@ -15212,7 +15397,8 @@ impl SaveUrlArg {
     ) -> Result<(), S::Error> {
         use serde::ser::SerializeStruct;
         s.serialize_field("path", &self.path)?;
-        s.serialize_field("url", &self.url)
+        s.serialize_field("url", &self.url)?;
+        Ok(())
     }
 }
 
@@ -15629,7 +15815,8 @@ impl SearchArg {
         s.serialize_field("query", &self.query)?;
         s.serialize_field("start", &self.start)?;
         s.serialize_field("max_results", &self.max_results)?;
-        s.serialize_field("mode", &self.mode)
+        s.serialize_field("mode", &self.mode)?;
+        Ok(())
     }
 }
 
@@ -15843,7 +16030,8 @@ impl SearchMatch {
     ) -> Result<(), S::Error> {
         use serde::ser::SerializeStruct;
         s.serialize_field("match_type", &self.match_type)?;
-        s.serialize_field("metadata", &self.metadata)
+        s.serialize_field("metadata", &self.metadata)?;
+        Ok(())
     }
 }
 
@@ -15929,7 +16117,8 @@ impl SearchMatchFieldOptions {
         s: &mut S::SerializeStruct,
     ) -> Result<(), S::Error> {
         use serde::ser::SerializeStruct;
-        s.serialize_field("include_highlights", &self.include_highlights)
+        s.serialize_field("include_highlights", &self.include_highlights)?;
+        Ok(())
     }
 }
 
@@ -16210,8 +16399,13 @@ impl SearchMatchV2 {
     ) -> Result<(), S::Error> {
         use serde::ser::SerializeStruct;
         s.serialize_field("metadata", &self.metadata)?;
-        s.serialize_field("match_type", &self.match_type)?;
-        s.serialize_field("highlight_spans", &self.highlight_spans)
+        if let Some(val) = &self.match_type {
+            s.serialize_field("match_type", val)?;
+        }
+        if let Some(val) = &self.highlight_spans {
+            s.serialize_field("highlight_spans", val)?;
+        }
+        Ok(())
     }
 }
 
@@ -16471,13 +16665,22 @@ impl SearchOptions {
         s: &mut S::SerializeStruct,
     ) -> Result<(), S::Error> {
         use serde::ser::SerializeStruct;
-        s.serialize_field("path", &self.path)?;
+        if let Some(val) = &self.path {
+            s.serialize_field("path", val)?;
+        }
         s.serialize_field("max_results", &self.max_results)?;
-        s.serialize_field("order_by", &self.order_by)?;
+        if let Some(val) = &self.order_by {
+            s.serialize_field("order_by", val)?;
+        }
         s.serialize_field("file_status", &self.file_status)?;
         s.serialize_field("filename_only", &self.filename_only)?;
-        s.serialize_field("file_extensions", &self.file_extensions)?;
-        s.serialize_field("file_categories", &self.file_categories)
+        if let Some(val) = &self.file_extensions {
+            s.serialize_field("file_extensions", val)?;
+        }
+        if let Some(val) = &self.file_categories {
+            s.serialize_field("file_categories", val)?;
+        }
+        Ok(())
     }
 }
 
@@ -16658,7 +16861,8 @@ impl SearchResult {
         use serde::ser::SerializeStruct;
         s.serialize_field("matches", &self.matches)?;
         s.serialize_field("more", &self.more)?;
-        s.serialize_field("start", &self.start)
+        s.serialize_field("start", &self.start)?;
+        Ok(())
     }
 }
 
@@ -16800,9 +17004,16 @@ impl SearchV2Arg {
     ) -> Result<(), S::Error> {
         use serde::ser::SerializeStruct;
         s.serialize_field("query", &self.query)?;
-        s.serialize_field("options", &self.options)?;
-        s.serialize_field("match_field_options", &self.match_field_options)?;
-        s.serialize_field("include_highlights", &self.include_highlights)
+        if let Some(val) = &self.options {
+            s.serialize_field("options", val)?;
+        }
+        if let Some(val) = &self.match_field_options {
+            s.serialize_field("match_field_options", val)?;
+        }
+        if let Some(val) = &self.include_highlights {
+            s.serialize_field("include_highlights", val)?;
+        }
+        Ok(())
     }
 }
 
@@ -16893,7 +17104,8 @@ impl SearchV2ContinueArg {
         s: &mut S::SerializeStruct,
     ) -> Result<(), S::Error> {
         use serde::ser::SerializeStruct;
-        s.serialize_field("cursor", &self.cursor)
+        s.serialize_field("cursor", &self.cursor)?;
+        Ok(())
     }
 }
 
@@ -17016,7 +17228,10 @@ impl SearchV2Result {
         use serde::ser::SerializeStruct;
         s.serialize_field("matches", &self.matches)?;
         s.serialize_field("has_more", &self.has_more)?;
-        s.serialize_field("cursor", &self.cursor)
+        if let Some(val) = &self.cursor {
+            s.serialize_field("cursor", val)?;
+        }
+        Ok(())
     }
 }
 
@@ -17124,7 +17339,10 @@ impl SharedLink {
     ) -> Result<(), S::Error> {
         use serde::ser::SerializeStruct;
         s.serialize_field("url", &self.url)?;
-        s.serialize_field("password", &self.password)
+        if let Some(val) = &self.password {
+            s.serialize_field("password", val)?;
+        }
+        Ok(())
     }
 }
 
@@ -17253,8 +17471,13 @@ impl SharedLinkFileInfo {
     ) -> Result<(), S::Error> {
         use serde::ser::SerializeStruct;
         s.serialize_field("url", &self.url)?;
-        s.serialize_field("path", &self.path)?;
-        s.serialize_field("password", &self.password)
+        if let Some(val) = &self.path {
+            s.serialize_field("path", val)?;
+        }
+        if let Some(val) = &self.password {
+            s.serialize_field("password", val)?;
+        }
+        Ok(())
     }
 }
 
@@ -17345,7 +17568,8 @@ impl SharingInfo {
         s: &mut S::SerializeStruct,
     ) -> Result<(), S::Error> {
         use serde::ser::SerializeStruct;
-        s.serialize_field("read_only", &self.read_only)
+        s.serialize_field("read_only", &self.read_only)?;
+        Ok(())
     }
 }
 
@@ -17469,7 +17693,10 @@ impl SingleUserLock {
         use serde::ser::SerializeStruct;
         s.serialize_field("created", &self.created)?;
         s.serialize_field("lock_holder_account_id", &self.lock_holder_account_id)?;
-        s.serialize_field("lock_holder_team_id", &self.lock_holder_team_id)
+        if let Some(val) = &self.lock_holder_team_id {
+            s.serialize_field("lock_holder_team_id", val)?;
+        }
+        Ok(())
     }
 }
 
@@ -17559,7 +17786,8 @@ impl SymlinkInfo {
         s: &mut S::SerializeStruct,
     ) -> Result<(), S::Error> {
         use serde::ser::SerializeStruct;
-        s.serialize_field("target", &self.target)
+        s.serialize_field("target", &self.target)?;
+        Ok(())
     }
 }
 
@@ -17950,7 +18178,8 @@ impl ThumbnailArg {
         s.serialize_field("path", &self.path)?;
         s.serialize_field("format", &self.format)?;
         s.serialize_field("size", &self.size)?;
-        s.serialize_field("mode", &self.mode)
+        s.serialize_field("mode", &self.mode)?;
+        Ok(())
     }
 }
 
@@ -18457,7 +18686,8 @@ impl ThumbnailV2Arg {
         s.serialize_field("resource", &self.resource)?;
         s.serialize_field("format", &self.format)?;
         s.serialize_field("size", &self.size)?;
-        s.serialize_field("mode", &self.mode)
+        s.serialize_field("mode", &self.mode)?;
+        Ok(())
     }
 }
 
@@ -18682,7 +18912,8 @@ impl UnlockFileArg {
         s: &mut S::SerializeStruct,
     ) -> Result<(), S::Error> {
         use serde::ser::SerializeStruct;
-        s.serialize_field("path", &self.path)
+        s.serialize_field("path", &self.path)?;
+        Ok(())
     }
 }
 
@@ -18773,7 +19004,8 @@ impl UnlockFileBatchArg {
         s: &mut S::SerializeStruct,
     ) -> Result<(), S::Error> {
         use serde::ser::SerializeStruct;
-        s.serialize_field("entries", &self.entries)
+        s.serialize_field("entries", &self.entries)?;
+        Ok(())
     }
 }
 
@@ -19066,7 +19298,8 @@ impl UploadSessionAppendArg {
     ) -> Result<(), S::Error> {
         use serde::ser::SerializeStruct;
         s.serialize_field("cursor", &self.cursor)?;
-        s.serialize_field("close", &self.close)
+        s.serialize_field("close", &self.close)?;
+        Ok(())
     }
 }
 
@@ -19170,7 +19403,8 @@ impl UploadSessionCursor {
     ) -> Result<(), S::Error> {
         use serde::ser::SerializeStruct;
         s.serialize_field("session_id", &self.session_id)?;
-        s.serialize_field("offset", &self.offset)
+        s.serialize_field("offset", &self.offset)?;
+        Ok(())
     }
 }
 
@@ -19273,7 +19507,8 @@ impl UploadSessionFinishArg {
     ) -> Result<(), S::Error> {
         use serde::ser::SerializeStruct;
         s.serialize_field("cursor", &self.cursor)?;
-        s.serialize_field("commit", &self.commit)
+        s.serialize_field("commit", &self.commit)?;
+        Ok(())
     }
 }
 
@@ -19363,7 +19598,8 @@ impl UploadSessionFinishBatchArg {
         s: &mut S::SerializeStruct,
     ) -> Result<(), S::Error> {
         use serde::ser::SerializeStruct;
-        s.serialize_field("entries", &self.entries)
+        s.serialize_field("entries", &self.entries)?;
+        Ok(())
     }
 }
 
@@ -19590,7 +19826,8 @@ impl UploadSessionFinishBatchResult {
         s: &mut S::SerializeStruct,
     ) -> Result<(), S::Error> {
         use serde::ser::SerializeStruct;
-        s.serialize_field("entries", &self.entries)
+        s.serialize_field("entries", &self.entries)?;
+        Ok(())
     }
 }
 
@@ -20060,7 +20297,8 @@ impl UploadSessionOffsetError {
         s: &mut S::SerializeStruct,
     ) -> Result<(), S::Error> {
         use serde::ser::SerializeStruct;
-        s.serialize_field("correct_offset", &self.correct_offset)
+        s.serialize_field("correct_offset", &self.correct_offset)?;
+        Ok(())
     }
 }
 
@@ -20166,7 +20404,10 @@ impl UploadSessionStartArg {
     ) -> Result<(), S::Error> {
         use serde::ser::SerializeStruct;
         s.serialize_field("close", &self.close)?;
-        s.serialize_field("session_type", &self.session_type)
+        if let Some(val) = &self.session_type {
+            s.serialize_field("session_type", val)?;
+        }
+        Ok(())
     }
 }
 
@@ -20336,7 +20577,8 @@ impl UploadSessionStartResult {
         s: &mut S::SerializeStruct,
     ) -> Result<(), S::Error> {
         use serde::ser::SerializeStruct;
-        s.serialize_field("session_id", &self.session_id)
+        s.serialize_field("session_id", &self.session_id)?;
+        Ok(())
     }
 }
 
@@ -20506,7 +20748,8 @@ impl UploadWriteFailed {
     ) -> Result<(), S::Error> {
         use serde::ser::SerializeStruct;
         s.serialize_field("reason", &self.reason)?;
-        s.serialize_field("upload_session_id", &self.upload_session_id)
+        s.serialize_field("upload_session_id", &self.upload_session_id)?;
+        Ok(())
     }
 }
 
@@ -20644,10 +20887,19 @@ impl VideoMetadata {
         s: &mut S::SerializeStruct,
     ) -> Result<(), S::Error> {
         use serde::ser::SerializeStruct;
-        s.serialize_field("dimensions", &self.dimensions)?;
-        s.serialize_field("location", &self.location)?;
-        s.serialize_field("time_taken", &self.time_taken)?;
-        s.serialize_field("duration", &self.duration)
+        if let Some(val) = &self.dimensions {
+            s.serialize_field("dimensions", val)?;
+        }
+        if let Some(val) = &self.location {
+            s.serialize_field("location", val)?;
+        }
+        if let Some(val) = &self.time_taken {
+            s.serialize_field("time_taken", val)?;
+        }
+        if let Some(val) = &self.duration {
+            s.serialize_field("duration", val)?;
+        }
+        Ok(())
     }
 }
 

--- a/src/generated/paper.rs
+++ b/src/generated/paper.rs
@@ -463,7 +463,8 @@ impl AddMember {
     ) -> Result<(), S::Error> {
         use serde::ser::SerializeStruct;
         s.serialize_field("member", &self.member)?;
-        s.serialize_field("permission_level", &self.permission_level)
+        s.serialize_field("permission_level", &self.permission_level)?;
+        Ok(())
     }
 }
 
@@ -602,8 +603,11 @@ impl AddPaperDocUser {
         use serde::ser::SerializeStruct;
         s.serialize_field("doc_id", &self.doc_id)?;
         s.serialize_field("members", &self.members)?;
-        s.serialize_field("custom_message", &self.custom_message)?;
-        s.serialize_field("quiet", &self.quiet)
+        if let Some(val) = &self.custom_message {
+            s.serialize_field("custom_message", val)?;
+        }
+        s.serialize_field("quiet", &self.quiet)?;
+        Ok(())
     }
 }
 
@@ -707,7 +711,8 @@ impl AddPaperDocUserMemberResult {
     ) -> Result<(), S::Error> {
         use serde::ser::SerializeStruct;
         s.serialize_field("member", &self.member)?;
-        s.serialize_field("result", &self.result)
+        s.serialize_field("result", &self.result)?;
+        Ok(())
     }
 }
 
@@ -939,7 +944,10 @@ impl Cursor {
     ) -> Result<(), S::Error> {
         use serde::ser::SerializeStruct;
         s.serialize_field("value", &self.value)?;
-        s.serialize_field("expiration", &self.expiration)
+        if let Some(val) = &self.expiration {
+            s.serialize_field("expiration", val)?;
+        }
+        Ok(())
     }
 }
 
@@ -1269,7 +1277,8 @@ impl Folder {
     ) -> Result<(), S::Error> {
         use serde::ser::SerializeStruct;
         s.serialize_field("id", &self.id)?;
-        s.serialize_field("name", &self.name)
+        s.serialize_field("name", &self.name)?;
+        Ok(())
     }
 }
 
@@ -1514,8 +1523,13 @@ impl FoldersContainingPaperDoc {
         s: &mut S::SerializeStruct,
     ) -> Result<(), S::Error> {
         use serde::ser::SerializeStruct;
-        s.serialize_field("folder_sharing_policy_type", &self.folder_sharing_policy_type)?;
-        s.serialize_field("folders", &self.folders)
+        if let Some(val) = &self.folder_sharing_policy_type {
+            s.serialize_field("folder_sharing_policy_type", val)?;
+        }
+        if let Some(val) = &self.folders {
+            s.serialize_field("folders", val)?;
+        }
+        Ok(())
     }
 }
 
@@ -1699,7 +1713,8 @@ impl InviteeInfoWithPermissionLevel {
     ) -> Result<(), S::Error> {
         use serde::ser::SerializeStruct;
         s.serialize_field("invitee", &self.invitee)?;
-        s.serialize_field("permission_level", &self.permission_level)
+        s.serialize_field("permission_level", &self.permission_level)?;
+        Ok(())
     }
 }
 
@@ -1919,7 +1934,8 @@ impl ListPaperDocsArgs {
         s.serialize_field("filter_by", &self.filter_by)?;
         s.serialize_field("sort_by", &self.sort_by)?;
         s.serialize_field("sort_order", &self.sort_order)?;
-        s.serialize_field("limit", &self.limit)
+        s.serialize_field("limit", &self.limit)?;
+        Ok(())
     }
 }
 
@@ -2010,7 +2026,8 @@ impl ListPaperDocsContinueArgs {
         s: &mut S::SerializeStruct,
     ) -> Result<(), S::Error> {
         use serde::ser::SerializeStruct;
-        s.serialize_field("cursor", &self.cursor)
+        s.serialize_field("cursor", &self.cursor)?;
+        Ok(())
     }
 }
 
@@ -2198,7 +2215,8 @@ impl ListPaperDocsResponse {
         use serde::ser::SerializeStruct;
         s.serialize_field("doc_ids", &self.doc_ids)?;
         s.serialize_field("cursor", &self.cursor)?;
-        s.serialize_field("has_more", &self.has_more)
+        s.serialize_field("has_more", &self.has_more)?;
+        Ok(())
     }
 }
 
@@ -2550,7 +2568,8 @@ impl ListUsersOnFolderArgs {
     ) -> Result<(), S::Error> {
         use serde::ser::SerializeStruct;
         s.serialize_field("doc_id", &self.doc_id)?;
-        s.serialize_field("limit", &self.limit)
+        s.serialize_field("limit", &self.limit)?;
+        Ok(())
     }
 }
 
@@ -2655,7 +2674,8 @@ impl ListUsersOnFolderContinueArgs {
     ) -> Result<(), S::Error> {
         use serde::ser::SerializeStruct;
         s.serialize_field("doc_id", &self.doc_id)?;
-        s.serialize_field("cursor", &self.cursor)
+        s.serialize_field("cursor", &self.cursor)?;
+        Ok(())
     }
 }
 
@@ -2794,7 +2814,8 @@ impl ListUsersOnFolderResponse {
         s.serialize_field("invitees", &self.invitees)?;
         s.serialize_field("users", &self.users)?;
         s.serialize_field("cursor", &self.cursor)?;
-        s.serialize_field("has_more", &self.has_more)
+        s.serialize_field("has_more", &self.has_more)?;
+        Ok(())
     }
 }
 
@@ -2921,7 +2942,8 @@ impl ListUsersOnPaperDocArgs {
         use serde::ser::SerializeStruct;
         s.serialize_field("doc_id", &self.doc_id)?;
         s.serialize_field("limit", &self.limit)?;
-        s.serialize_field("filter_by", &self.filter_by)
+        s.serialize_field("filter_by", &self.filter_by)?;
+        Ok(())
     }
 }
 
@@ -3025,7 +3047,8 @@ impl ListUsersOnPaperDocContinueArgs {
     ) -> Result<(), S::Error> {
         use serde::ser::SerializeStruct;
         s.serialize_field("doc_id", &self.doc_id)?;
-        s.serialize_field("cursor", &self.cursor)
+        s.serialize_field("cursor", &self.cursor)?;
+        Ok(())
     }
 }
 
@@ -3179,7 +3202,8 @@ impl ListUsersOnPaperDocResponse {
         s.serialize_field("users", &self.users)?;
         s.serialize_field("doc_owner", &self.doc_owner)?;
         s.serialize_field("cursor", &self.cursor)?;
-        s.serialize_field("has_more", &self.has_more)
+        s.serialize_field("has_more", &self.has_more)?;
+        Ok(())
     }
 }
 
@@ -3456,7 +3480,10 @@ impl PaperDocCreateArgs {
     ) -> Result<(), S::Error> {
         use serde::ser::SerializeStruct;
         s.serialize_field("import_format", &self.import_format)?;
-        s.serialize_field("parent_folder_id", &self.parent_folder_id)
+        if let Some(val) = &self.parent_folder_id {
+            s.serialize_field("parent_folder_id", val)?;
+        }
+        Ok(())
     }
 }
 
@@ -3686,7 +3713,8 @@ impl PaperDocCreateUpdateResult {
         use serde::ser::SerializeStruct;
         s.serialize_field("doc_id", &self.doc_id)?;
         s.serialize_field("revision", &self.revision)?;
-        s.serialize_field("title", &self.title)
+        s.serialize_field("title", &self.title)?;
+        Ok(())
     }
 }
 
@@ -3788,7 +3816,8 @@ impl PaperDocExport {
     ) -> Result<(), S::Error> {
         use serde::ser::SerializeStruct;
         s.serialize_field("doc_id", &self.doc_id)?;
-        s.serialize_field("export_format", &self.export_format)
+        s.serialize_field("export_format", &self.export_format)?;
+        Ok(())
     }
 }
 
@@ -3918,7 +3947,8 @@ impl PaperDocExportResult {
         s.serialize_field("owner", &self.owner)?;
         s.serialize_field("title", &self.title)?;
         s.serialize_field("revision", &self.revision)?;
-        s.serialize_field("mime_type", &self.mime_type)
+        s.serialize_field("mime_type", &self.mime_type)?;
+        Ok(())
     }
 }
 
@@ -4086,7 +4116,8 @@ impl PaperDocSharingPolicy {
     ) -> Result<(), S::Error> {
         use serde::ser::SerializeStruct;
         s.serialize_field("doc_id", &self.doc_id)?;
-        s.serialize_field("sharing_policy", &self.sharing_policy)
+        s.serialize_field("sharing_policy", &self.sharing_policy)?;
+        Ok(())
     }
 }
 
@@ -4221,7 +4252,8 @@ impl PaperDocUpdateArgs {
         s.serialize_field("doc_id", &self.doc_id)?;
         s.serialize_field("doc_update_policy", &self.doc_update_policy)?;
         s.serialize_field("revision", &self.revision)?;
-        s.serialize_field("import_format", &self.import_format)
+        s.serialize_field("import_format", &self.import_format)?;
+        Ok(())
     }
 }
 
@@ -4573,8 +4605,13 @@ impl PaperFolderCreateArg {
     ) -> Result<(), S::Error> {
         use serde::ser::SerializeStruct;
         s.serialize_field("name", &self.name)?;
-        s.serialize_field("parent_folder_id", &self.parent_folder_id)?;
-        s.serialize_field("is_team_folder", &self.is_team_folder)
+        if let Some(val) = &self.parent_folder_id {
+            s.serialize_field("parent_folder_id", val)?;
+        }
+        if let Some(val) = &self.is_team_folder {
+            s.serialize_field("is_team_folder", val)?;
+        }
+        Ok(())
     }
 }
 
@@ -4755,7 +4792,8 @@ impl PaperFolderCreateResult {
         s: &mut S::SerializeStruct,
     ) -> Result<(), S::Error> {
         use serde::ser::SerializeStruct;
-        s.serialize_field("folder_id", &self.folder_id)
+        s.serialize_field("folder_id", &self.folder_id)?;
+        Ok(())
     }
 }
 
@@ -4845,7 +4883,8 @@ impl RefPaperDoc {
         s: &mut S::SerializeStruct,
     ) -> Result<(), S::Error> {
         use serde::ser::SerializeStruct;
-        s.serialize_field("doc_id", &self.doc_id)
+        s.serialize_field("doc_id", &self.doc_id)?;
+        Ok(())
     }
 }
 
@@ -4949,7 +4988,8 @@ impl RemovePaperDocUser {
     ) -> Result<(), S::Error> {
         use serde::ser::SerializeStruct;
         s.serialize_field("doc_id", &self.doc_id)?;
-        s.serialize_field("member", &self.member)
+        s.serialize_field("member", &self.member)?;
+        Ok(())
     }
 }
 
@@ -5053,8 +5093,13 @@ impl SharingPolicy {
         s: &mut S::SerializeStruct,
     ) -> Result<(), S::Error> {
         use serde::ser::SerializeStruct;
-        s.serialize_field("public_sharing_policy", &self.public_sharing_policy)?;
-        s.serialize_field("team_sharing_policy", &self.team_sharing_policy)
+        if let Some(val) = &self.public_sharing_policy {
+            s.serialize_field("public_sharing_policy", val)?;
+        }
+        if let Some(val) = &self.team_sharing_policy {
+            s.serialize_field("team_sharing_policy", val)?;
+        }
+        Ok(())
     }
 }
 
@@ -5306,7 +5351,8 @@ impl UserInfoWithPermissionLevel {
     ) -> Result<(), S::Error> {
         use serde::ser::SerializeStruct;
         s.serialize_field("user", &self.user)?;
-        s.serialize_field("permission_level", &self.permission_level)
+        s.serialize_field("permission_level", &self.permission_level)?;
+        Ok(())
     }
 }
 

--- a/src/generated/secondary_emails.rs
+++ b/src/generated/secondary_emails.rs
@@ -78,7 +78,8 @@ impl SecondaryEmail {
     ) -> Result<(), S::Error> {
         use serde::ser::SerializeStruct;
         s.serialize_field("email", &self.email)?;
-        s.serialize_field("is_verified", &self.is_verified)
+        s.serialize_field("is_verified", &self.is_verified)?;
+        Ok(())
     }
 }
 

--- a/src/generated/sharing.rs
+++ b/src/generated/sharing.rs
@@ -1039,10 +1039,13 @@ impl AddFileMemberArgs {
         use serde::ser::SerializeStruct;
         s.serialize_field("file", &self.file)?;
         s.serialize_field("members", &self.members)?;
-        s.serialize_field("custom_message", &self.custom_message)?;
+        if let Some(val) = &self.custom_message {
+            s.serialize_field("custom_message", val)?;
+        }
         s.serialize_field("quiet", &self.quiet)?;
         s.serialize_field("access_level", &self.access_level)?;
-        s.serialize_field("add_message_as_comment", &self.add_message_as_comment)
+        s.serialize_field("add_message_as_comment", &self.add_message_as_comment)?;
+        Ok(())
     }
 }
 
@@ -1302,7 +1305,10 @@ impl AddFolderMemberArg {
         s.serialize_field("shared_folder_id", &self.shared_folder_id)?;
         s.serialize_field("members", &self.members)?;
         s.serialize_field("quiet", &self.quiet)?;
-        s.serialize_field("custom_message", &self.custom_message)
+        if let Some(val) = &self.custom_message {
+            s.serialize_field("custom_message", val)?;
+        }
+        Ok(())
     }
 }
 
@@ -1649,7 +1655,8 @@ impl AddMember {
     ) -> Result<(), S::Error> {
         use serde::ser::SerializeStruct;
         s.serialize_field("member", &self.member)?;
-        s.serialize_field("access_level", &self.access_level)
+        s.serialize_field("access_level", &self.access_level)?;
+        Ok(())
     }
 }
 
@@ -2004,7 +2011,8 @@ impl AudienceExceptionContentInfo {
         s: &mut S::SerializeStruct,
     ) -> Result<(), S::Error> {
         use serde::ser::SerializeStruct;
-        s.serialize_field("name", &self.name)
+        s.serialize_field("name", &self.name)?;
+        Ok(())
     }
 }
 
@@ -2110,7 +2118,8 @@ impl AudienceExceptions {
     ) -> Result<(), S::Error> {
         use serde::ser::SerializeStruct;
         s.serialize_field("count", &self.count)?;
-        s.serialize_field("exceptions", &self.exceptions)
+        s.serialize_field("exceptions", &self.exceptions)?;
+        Ok(())
     }
 }
 
@@ -2232,7 +2241,8 @@ impl AudienceRestrictingSharedFolder {
         use serde::ser::SerializeStruct;
         s.serialize_field("shared_folder_id", &self.shared_folder_id)?;
         s.serialize_field("name", &self.name)?;
-        s.serialize_field("audience", &self.audience)
+        s.serialize_field("audience", &self.audience)?;
+        Ok(())
     }
 }
 
@@ -2354,7 +2364,10 @@ impl CollectionLinkMetadata {
         use serde::ser::SerializeStruct;
         s.serialize_field("url", &self.url)?;
         s.serialize_field("visibility", &self.visibility)?;
-        s.serialize_field("expires", &self.expires)
+        if let Some(val) = &self.expires {
+            s.serialize_field("expires", val)?;
+        }
+        Ok(())
     }
 }
 
@@ -2483,7 +2496,10 @@ impl CreateSharedLinkArg {
         use serde::ser::SerializeStruct;
         s.serialize_field("path", &self.path)?;
         s.serialize_field("short_url", &self.short_url)?;
-        s.serialize_field("pending_upload", &self.pending_upload)
+        if let Some(val) = &self.pending_upload {
+            s.serialize_field("pending_upload", val)?;
+        }
+        Ok(())
     }
 }
 
@@ -2670,7 +2686,10 @@ impl CreateSharedLinkWithSettingsArg {
     ) -> Result<(), S::Error> {
         use serde::ser::SerializeStruct;
         s.serialize_field("path", &self.path)?;
-        s.serialize_field("settings", &self.settings)
+        if let Some(val) = &self.settings {
+            s.serialize_field("settings", val)?;
+        }
+        Ok(())
     }
 }
 
@@ -3001,9 +3020,16 @@ impl ExpectedSharedContentLinkMetadata {
         s.serialize_field("current_audience", &self.current_audience)?;
         s.serialize_field("link_permissions", &self.link_permissions)?;
         s.serialize_field("password_protected", &self.password_protected)?;
-        s.serialize_field("access_level", &self.access_level)?;
-        s.serialize_field("audience_restricting_shared_folder", &self.audience_restricting_shared_folder)?;
-        s.serialize_field("expiry", &self.expiry)
+        if let Some(val) = &self.access_level {
+            s.serialize_field("access_level", val)?;
+        }
+        if let Some(val) = &self.audience_restricting_shared_folder {
+            s.serialize_field("audience_restricting_shared_folder", val)?;
+        }
+        if let Some(val) = &self.expiry {
+            s.serialize_field("expiry", val)?;
+        }
+        Ok(())
     }
 }
 
@@ -3536,11 +3562,22 @@ impl FileLinkMetadata {
         s.serialize_field("server_modified", &self.server_modified)?;
         s.serialize_field("rev", &self.rev)?;
         s.serialize_field("size", &self.size)?;
-        s.serialize_field("id", &self.id)?;
-        s.serialize_field("expires", &self.expires)?;
-        s.serialize_field("path_lower", &self.path_lower)?;
-        s.serialize_field("team_member_info", &self.team_member_info)?;
-        s.serialize_field("content_owner_team_info", &self.content_owner_team_info)
+        if let Some(val) = &self.id {
+            s.serialize_field("id", val)?;
+        }
+        if let Some(val) = &self.expires {
+            s.serialize_field("expires", val)?;
+        }
+        if let Some(val) = &self.path_lower {
+            s.serialize_field("path_lower", val)?;
+        }
+        if let Some(val) = &self.team_member_info {
+            s.serialize_field("team_member_info", val)?;
+        }
+        if let Some(val) = &self.content_owner_team_info {
+            s.serialize_field("content_owner_team_info", val)?;
+        }
+        Ok(())
     }
 }
 
@@ -3834,7 +3871,8 @@ impl FileMemberActionResult {
     ) -> Result<(), S::Error> {
         use serde::ser::SerializeStruct;
         s.serialize_field("member", &self.member)?;
-        s.serialize_field("result", &self.result)
+        s.serialize_field("result", &self.result)?;
+        Ok(())
     }
 }
 
@@ -4029,7 +4067,10 @@ impl FilePermission {
         use serde::ser::SerializeStruct;
         s.serialize_field("action", &self.action)?;
         s.serialize_field("allow", &self.allow)?;
-        s.serialize_field("reason", &self.reason)
+        if let Some(val) = &self.reason {
+            s.serialize_field("reason", val)?;
+        }
+        Ok(())
     }
 }
 
@@ -4422,11 +4463,22 @@ impl FolderLinkMetadata {
         s.serialize_field("url", &self.url)?;
         s.serialize_field("name", &self.name)?;
         s.serialize_field("link_permissions", &self.link_permissions)?;
-        s.serialize_field("id", &self.id)?;
-        s.serialize_field("expires", &self.expires)?;
-        s.serialize_field("path_lower", &self.path_lower)?;
-        s.serialize_field("team_member_info", &self.team_member_info)?;
-        s.serialize_field("content_owner_team_info", &self.content_owner_team_info)
+        if let Some(val) = &self.id {
+            s.serialize_field("id", val)?;
+        }
+        if let Some(val) = &self.expires {
+            s.serialize_field("expires", val)?;
+        }
+        if let Some(val) = &self.path_lower {
+            s.serialize_field("path_lower", val)?;
+        }
+        if let Some(val) = &self.team_member_info {
+            s.serialize_field("team_member_info", val)?;
+        }
+        if let Some(val) = &self.content_owner_team_info {
+            s.serialize_field("content_owner_team_info", val)?;
+        }
+        Ok(())
     }
 }
 
@@ -4549,7 +4601,10 @@ impl FolderPermission {
         use serde::ser::SerializeStruct;
         s.serialize_field("action", &self.action)?;
         s.serialize_field("allow", &self.allow)?;
-        s.serialize_field("reason", &self.reason)
+        if let Some(val) = &self.reason {
+            s.serialize_field("reason", val)?;
+        }
+        Ok(())
     }
 }
 
@@ -4709,9 +4764,16 @@ impl FolderPolicy {
         use serde::ser::SerializeStruct;
         s.serialize_field("acl_update_policy", &self.acl_update_policy)?;
         s.serialize_field("shared_link_policy", &self.shared_link_policy)?;
-        s.serialize_field("member_policy", &self.member_policy)?;
-        s.serialize_field("resolved_member_policy", &self.resolved_member_policy)?;
-        s.serialize_field("viewer_info_policy", &self.viewer_info_policy)
+        if let Some(val) = &self.member_policy {
+            s.serialize_field("member_policy", val)?;
+        }
+        if let Some(val) = &self.resolved_member_policy {
+            s.serialize_field("resolved_member_policy", val)?;
+        }
+        if let Some(val) = &self.viewer_info_policy {
+            s.serialize_field("viewer_info_policy", val)?;
+        }
+        Ok(())
     }
 }
 
@@ -4822,7 +4884,10 @@ impl GetFileMetadataArg {
     ) -> Result<(), S::Error> {
         use serde::ser::SerializeStruct;
         s.serialize_field("file", &self.file)?;
-        s.serialize_field("actions", &self.actions)
+        if let Some(val) = &self.actions {
+            s.serialize_field("actions", val)?;
+        }
+        Ok(())
     }
 }
 
@@ -4933,7 +4998,10 @@ impl GetFileMetadataBatchArg {
     ) -> Result<(), S::Error> {
         use serde::ser::SerializeStruct;
         s.serialize_field("files", &self.files)?;
-        s.serialize_field("actions", &self.actions)
+        if let Some(val) = &self.actions {
+            s.serialize_field("actions", val)?;
+        }
+        Ok(())
     }
 }
 
@@ -5038,7 +5106,8 @@ impl GetFileMetadataBatchResult {
     ) -> Result<(), S::Error> {
         use serde::ser::SerializeStruct;
         s.serialize_field("file", &self.file)?;
-        s.serialize_field("result", &self.result)
+        s.serialize_field("result", &self.result)?;
+        Ok(())
     }
 }
 
@@ -5319,7 +5388,10 @@ impl GetMetadataArgs {
     ) -> Result<(), S::Error> {
         use serde::ser::SerializeStruct;
         s.serialize_field("shared_folder_id", &self.shared_folder_id)?;
-        s.serialize_field("actions", &self.actions)
+        if let Some(val) = &self.actions {
+            s.serialize_field("actions", val)?;
+        }
+        Ok(())
     }
 }
 
@@ -5544,8 +5616,13 @@ impl GetSharedLinkMetadataArg {
     ) -> Result<(), S::Error> {
         use serde::ser::SerializeStruct;
         s.serialize_field("url", &self.url)?;
-        s.serialize_field("path", &self.path)?;
-        s.serialize_field("link_password", &self.link_password)
+        if let Some(val) = &self.path {
+            s.serialize_field("path", val)?;
+        }
+        if let Some(val) = &self.link_password {
+            s.serialize_field("link_password", val)?;
+        }
+        Ok(())
     }
 }
 
@@ -5631,7 +5708,10 @@ impl GetSharedLinksArg {
         s: &mut S::SerializeStruct,
     ) -> Result<(), S::Error> {
         use serde::ser::SerializeStruct;
-        s.serialize_field("path", &self.path)
+        if let Some(val) = &self.path {
+            s.serialize_field("path", val)?;
+        }
+        Ok(())
     }
 }
 
@@ -5797,7 +5877,8 @@ impl GetSharedLinksResult {
         s: &mut S::SerializeStruct,
     ) -> Result<(), S::Error> {
         use serde::ser::SerializeStruct;
-        s.serialize_field("links", &self.links)
+        s.serialize_field("links", &self.links)?;
+        Ok(())
     }
 }
 
@@ -6008,8 +6089,13 @@ impl GroupInfo {
         s.serialize_field("is_member", &self.is_member)?;
         s.serialize_field("is_owner", &self.is_owner)?;
         s.serialize_field("same_team", &self.same_team)?;
-        s.serialize_field("group_external_id", &self.group_external_id)?;
-        s.serialize_field("member_count", &self.member_count)
+        if let Some(val) = &self.group_external_id {
+            s.serialize_field("group_external_id", val)?;
+        }
+        if let Some(val) = &self.member_count {
+            s.serialize_field("member_count", val)?;
+        }
+        Ok(())
     }
 }
 
@@ -6167,9 +6253,14 @@ impl GroupMembershipInfo {
         use serde::ser::SerializeStruct;
         s.serialize_field("access_type", &self.access_type)?;
         s.serialize_field("group", &self.group)?;
-        s.serialize_field("permissions", &self.permissions)?;
-        s.serialize_field("initials", &self.initials)?;
-        s.serialize_field("is_inherited", &self.is_inherited)
+        if let Some(val) = &self.permissions {
+            s.serialize_field("permissions", val)?;
+        }
+        if let Some(val) = &self.initials {
+            s.serialize_field("initials", val)?;
+        }
+        s.serialize_field("is_inherited", &self.is_inherited)?;
+        Ok(())
     }
 }
 
@@ -6278,7 +6369,10 @@ impl InsufficientPlan {
     ) -> Result<(), S::Error> {
         use serde::ser::SerializeStruct;
         s.serialize_field("message", &self.message)?;
-        s.serialize_field("upsell_url", &self.upsell_url)
+        if let Some(val) = &self.upsell_url {
+            s.serialize_field("upsell_url", val)?;
+        }
+        Ok(())
     }
 }
 
@@ -6394,7 +6488,8 @@ impl InsufficientQuotaAmounts {
         use serde::ser::SerializeStruct;
         s.serialize_field("space_needed", &self.space_needed)?;
         s.serialize_field("space_shortage", &self.space_shortage)?;
-        s.serialize_field("space_left", &self.space_left)
+        s.serialize_field("space_left", &self.space_left)?;
+        Ok(())
     }
 }
 
@@ -6632,10 +6727,17 @@ impl InviteeMembershipInfo {
         use serde::ser::SerializeStruct;
         s.serialize_field("access_type", &self.access_type)?;
         s.serialize_field("invitee", &self.invitee)?;
-        s.serialize_field("permissions", &self.permissions)?;
-        s.serialize_field("initials", &self.initials)?;
+        if let Some(val) = &self.permissions {
+            s.serialize_field("permissions", val)?;
+        }
+        if let Some(val) = &self.initials {
+            s.serialize_field("initials", val)?;
+        }
         s.serialize_field("is_inherited", &self.is_inherited)?;
-        s.serialize_field("user", &self.user)
+        if let Some(val) = &self.user {
+            s.serialize_field("user", val)?;
+        }
+        Ok(())
     }
 }
 
@@ -7330,7 +7432,10 @@ impl LinkAudienceOption {
         use serde::ser::SerializeStruct;
         s.serialize_field("audience", &self.audience)?;
         s.serialize_field("allowed", &self.allowed)?;
-        s.serialize_field("disallowed_reason", &self.disallowed_reason)
+        if let Some(val) = &self.disallowed_reason {
+            s.serialize_field("disallowed_reason", val)?;
+        }
+        Ok(())
     }
 }
 
@@ -7663,7 +7768,10 @@ impl LinkPermission {
         use serde::ser::SerializeStruct;
         s.serialize_field("action", &self.action)?;
         s.serialize_field("allow", &self.allow)?;
-        s.serialize_field("reason", &self.reason)
+        if let Some(val) = &self.reason {
+            s.serialize_field("reason", val)?;
+        }
+        Ok(())
     }
 }
 
@@ -8056,16 +8164,37 @@ impl LinkPermissions {
         s.serialize_field("can_disallow_download", &self.can_disallow_download)?;
         s.serialize_field("allow_comments", &self.allow_comments)?;
         s.serialize_field("team_restricts_comments", &self.team_restricts_comments)?;
-        s.serialize_field("resolved_visibility", &self.resolved_visibility)?;
-        s.serialize_field("requested_visibility", &self.requested_visibility)?;
-        s.serialize_field("revoke_failure_reason", &self.revoke_failure_reason)?;
-        s.serialize_field("effective_audience", &self.effective_audience)?;
-        s.serialize_field("link_access_level", &self.link_access_level)?;
-        s.serialize_field("audience_options", &self.audience_options)?;
-        s.serialize_field("can_set_password", &self.can_set_password)?;
-        s.serialize_field("can_remove_password", &self.can_remove_password)?;
-        s.serialize_field("require_password", &self.require_password)?;
-        s.serialize_field("can_use_extended_sharing_controls", &self.can_use_extended_sharing_controls)
+        if let Some(val) = &self.resolved_visibility {
+            s.serialize_field("resolved_visibility", val)?;
+        }
+        if let Some(val) = &self.requested_visibility {
+            s.serialize_field("requested_visibility", val)?;
+        }
+        if let Some(val) = &self.revoke_failure_reason {
+            s.serialize_field("revoke_failure_reason", val)?;
+        }
+        if let Some(val) = &self.effective_audience {
+            s.serialize_field("effective_audience", val)?;
+        }
+        if let Some(val) = &self.link_access_level {
+            s.serialize_field("link_access_level", val)?;
+        }
+        if let Some(val) = &self.audience_options {
+            s.serialize_field("audience_options", val)?;
+        }
+        if let Some(val) = &self.can_set_password {
+            s.serialize_field("can_set_password", val)?;
+        }
+        if let Some(val) = &self.can_remove_password {
+            s.serialize_field("can_remove_password", val)?;
+        }
+        if let Some(val) = &self.require_password {
+            s.serialize_field("require_password", val)?;
+        }
+        if let Some(val) = &self.can_use_extended_sharing_controls {
+            s.serialize_field("can_use_extended_sharing_controls", val)?;
+        }
+        Ok(())
     }
 }
 
@@ -8204,10 +8333,19 @@ impl LinkSettings {
         s: &mut S::SerializeStruct,
     ) -> Result<(), S::Error> {
         use serde::ser::SerializeStruct;
-        s.serialize_field("access_level", &self.access_level)?;
-        s.serialize_field("audience", &self.audience)?;
-        s.serialize_field("expiry", &self.expiry)?;
-        s.serialize_field("password", &self.password)
+        if let Some(val) = &self.access_level {
+            s.serialize_field("access_level", val)?;
+        }
+        if let Some(val) = &self.audience {
+            s.serialize_field("audience", val)?;
+        }
+        if let Some(val) = &self.expiry {
+            s.serialize_field("expiry", val)?;
+        }
+        if let Some(val) = &self.password {
+            s.serialize_field("password", val)?;
+        }
+        Ok(())
     }
 }
 
@@ -8350,9 +8488,12 @@ impl ListFileMembersArg {
     ) -> Result<(), S::Error> {
         use serde::ser::SerializeStruct;
         s.serialize_field("file", &self.file)?;
-        s.serialize_field("actions", &self.actions)?;
+        if let Some(val) = &self.actions {
+            s.serialize_field("actions", val)?;
+        }
         s.serialize_field("include_inherited", &self.include_inherited)?;
-        s.serialize_field("limit", &self.limit)
+        s.serialize_field("limit", &self.limit)?;
+        Ok(())
     }
 }
 
@@ -8461,7 +8602,8 @@ impl ListFileMembersBatchArg {
     ) -> Result<(), S::Error> {
         use serde::ser::SerializeStruct;
         s.serialize_field("files", &self.files)?;
-        s.serialize_field("limit", &self.limit)
+        s.serialize_field("limit", &self.limit)?;
+        Ok(())
     }
 }
 
@@ -8565,7 +8707,8 @@ impl ListFileMembersBatchResult {
     ) -> Result<(), S::Error> {
         use serde::ser::SerializeStruct;
         s.serialize_field("file", &self.file)?;
-        s.serialize_field("result", &self.result)
+        s.serialize_field("result", &self.result)?;
+        Ok(())
     }
 }
 
@@ -8658,7 +8801,8 @@ impl ListFileMembersContinueArg {
         s: &mut S::SerializeStruct,
     ) -> Result<(), S::Error> {
         use serde::ser::SerializeStruct;
-        s.serialize_field("cursor", &self.cursor)
+        s.serialize_field("cursor", &self.cursor)?;
+        Ok(())
     }
 }
 
@@ -8869,7 +9013,8 @@ impl ListFileMembersCountResult {
     ) -> Result<(), S::Error> {
         use serde::ser::SerializeStruct;
         s.serialize_field("members", &self.members)?;
-        s.serialize_field("member_count", &self.member_count)
+        s.serialize_field("member_count", &self.member_count)?;
+        Ok(())
     }
 }
 
@@ -9147,7 +9292,10 @@ impl ListFilesArg {
     ) -> Result<(), S::Error> {
         use serde::ser::SerializeStruct;
         s.serialize_field("limit", &self.limit)?;
-        s.serialize_field("actions", &self.actions)
+        if let Some(val) = &self.actions {
+            s.serialize_field("actions", val)?;
+        }
+        Ok(())
     }
 }
 
@@ -9238,7 +9386,8 @@ impl ListFilesContinueArg {
         s: &mut S::SerializeStruct,
     ) -> Result<(), S::Error> {
         use serde::ser::SerializeStruct;
-        s.serialize_field("cursor", &self.cursor)
+        s.serialize_field("cursor", &self.cursor)?;
+        Ok(())
     }
 }
 
@@ -9438,7 +9587,10 @@ impl ListFilesResult {
     ) -> Result<(), S::Error> {
         use serde::ser::SerializeStruct;
         s.serialize_field("entries", &self.entries)?;
-        s.serialize_field("cursor", &self.cursor)
+        if let Some(val) = &self.cursor {
+            s.serialize_field("cursor", val)?;
+        }
+        Ok(())
     }
 }
 
@@ -9566,8 +9718,11 @@ impl ListFolderMembersArgs {
     ) -> Result<(), S::Error> {
         use serde::ser::SerializeStruct;
         s.serialize_field("shared_folder_id", &self.shared_folder_id)?;
-        s.serialize_field("actions", &self.actions)?;
-        s.serialize_field("limit", &self.limit)
+        if let Some(val) = &self.actions {
+            s.serialize_field("actions", val)?;
+        }
+        s.serialize_field("limit", &self.limit)?;
+        Ok(())
     }
 }
 
@@ -9658,7 +9813,8 @@ impl ListFolderMembersContinueArg {
         s: &mut S::SerializeStruct,
     ) -> Result<(), S::Error> {
         use serde::ser::SerializeStruct;
-        s.serialize_field("cursor", &self.cursor)
+        s.serialize_field("cursor", &self.cursor)?;
+        Ok(())
     }
 }
 
@@ -9853,8 +10009,11 @@ impl ListFolderMembersCursorArg {
         s: &mut S::SerializeStruct,
     ) -> Result<(), S::Error> {
         use serde::ser::SerializeStruct;
-        s.serialize_field("actions", &self.actions)?;
-        s.serialize_field("limit", &self.limit)
+        if let Some(val) = &self.actions {
+            s.serialize_field("actions", val)?;
+        }
+        s.serialize_field("limit", &self.limit)?;
+        Ok(())
     }
 }
 
@@ -9960,7 +10119,10 @@ impl ListFoldersArgs {
     ) -> Result<(), S::Error> {
         use serde::ser::SerializeStruct;
         s.serialize_field("limit", &self.limit)?;
-        s.serialize_field("actions", &self.actions)
+        if let Some(val) = &self.actions {
+            s.serialize_field("actions", val)?;
+        }
+        Ok(())
     }
 }
 
@@ -10050,7 +10212,8 @@ impl ListFoldersContinueArg {
         s: &mut S::SerializeStruct,
     ) -> Result<(), S::Error> {
         use serde::ser::SerializeStruct;
-        s.serialize_field("cursor", &self.cursor)
+        s.serialize_field("cursor", &self.cursor)?;
+        Ok(())
     }
 }
 
@@ -10230,7 +10393,10 @@ impl ListFoldersResult {
     ) -> Result<(), S::Error> {
         use serde::ser::SerializeStruct;
         s.serialize_field("entries", &self.entries)?;
-        s.serialize_field("cursor", &self.cursor)
+        if let Some(val) = &self.cursor {
+            s.serialize_field("cursor", val)?;
+        }
+        Ok(())
     }
 }
 
@@ -10350,9 +10516,16 @@ impl ListSharedLinksArg {
         s: &mut S::SerializeStruct,
     ) -> Result<(), S::Error> {
         use serde::ser::SerializeStruct;
-        s.serialize_field("path", &self.path)?;
-        s.serialize_field("cursor", &self.cursor)?;
-        s.serialize_field("direct_only", &self.direct_only)
+        if let Some(val) = &self.path {
+            s.serialize_field("path", val)?;
+        }
+        if let Some(val) = &self.cursor {
+            s.serialize_field("cursor", val)?;
+        }
+        if let Some(val) = &self.direct_only {
+            s.serialize_field("direct_only", val)?;
+        }
+        Ok(())
     }
 }
 
@@ -10565,7 +10738,10 @@ impl ListSharedLinksResult {
         use serde::ser::SerializeStruct;
         s.serialize_field("links", &self.links)?;
         s.serialize_field("has_more", &self.has_more)?;
-        s.serialize_field("cursor", &self.cursor)
+        if let Some(val) = &self.cursor {
+            s.serialize_field("cursor", val)?;
+        }
+        Ok(())
     }
 }
 
@@ -10688,9 +10864,16 @@ impl MemberAccessLevelResult {
         s: &mut S::SerializeStruct,
     ) -> Result<(), S::Error> {
         use serde::ser::SerializeStruct;
-        s.serialize_field("access_level", &self.access_level)?;
-        s.serialize_field("warning", &self.warning)?;
-        s.serialize_field("access_details", &self.access_details)
+        if let Some(val) = &self.access_level {
+            s.serialize_field("access_level", val)?;
+        }
+        if let Some(val) = &self.warning {
+            s.serialize_field("warning", val)?;
+        }
+        if let Some(val) = &self.access_details {
+            s.serialize_field("access_details", val)?;
+        }
+        Ok(())
     }
 }
 
@@ -10918,7 +11101,10 @@ impl MemberPermission {
         use serde::ser::SerializeStruct;
         s.serialize_field("action", &self.action)?;
         s.serialize_field("allow", &self.allow)?;
-        s.serialize_field("reason", &self.reason)
+        if let Some(val) = &self.reason {
+            s.serialize_field("reason", val)?;
+        }
+        Ok(())
     }
 }
 
@@ -11210,9 +11396,14 @@ impl MembershipInfo {
     ) -> Result<(), S::Error> {
         use serde::ser::SerializeStruct;
         s.serialize_field("access_type", &self.access_type)?;
-        s.serialize_field("permissions", &self.permissions)?;
-        s.serialize_field("initials", &self.initials)?;
-        s.serialize_field("is_inherited", &self.is_inherited)
+        if let Some(val) = &self.permissions {
+            s.serialize_field("permissions", val)?;
+        }
+        if let Some(val) = &self.initials {
+            s.serialize_field("initials", val)?;
+        }
+        s.serialize_field("is_inherited", &self.is_inherited)?;
+        Ok(())
     }
 }
 
@@ -11333,7 +11524,8 @@ impl ModifySharedLinkSettingsArgs {
         use serde::ser::SerializeStruct;
         s.serialize_field("url", &self.url)?;
         s.serialize_field("settings", &self.settings)?;
-        s.serialize_field("remove_expiration", &self.remove_expiration)
+        s.serialize_field("remove_expiration", &self.remove_expiration)?;
+        Ok(())
     }
 }
 
@@ -11547,7 +11739,8 @@ impl MountFolderArg {
         s: &mut S::SerializeStruct,
     ) -> Result<(), S::Error> {
         use serde::ser::SerializeStruct;
-        s.serialize_field("shared_folder_id", &self.shared_folder_id)
+        s.serialize_field("shared_folder_id", &self.shared_folder_id)?;
+        Ok(())
     }
 }
 
@@ -11818,7 +12011,8 @@ impl ParentFolderAccessInfo {
         s.serialize_field("folder_name", &self.folder_name)?;
         s.serialize_field("shared_folder_id", &self.shared_folder_id)?;
         s.serialize_field("permissions", &self.permissions)?;
-        s.serialize_field("path", &self.path)
+        s.serialize_field("path", &self.path)?;
+        Ok(())
     }
 }
 
@@ -11953,7 +12147,10 @@ impl PathLinkMetadata {
         s.serialize_field("url", &self.url)?;
         s.serialize_field("visibility", &self.visibility)?;
         s.serialize_field("path", &self.path)?;
-        s.serialize_field("expires", &self.expires)
+        if let Some(val) = &self.expires {
+            s.serialize_field("expires", val)?;
+        }
+        Ok(())
     }
 }
 
@@ -12299,7 +12496,8 @@ impl RelinquishFileMembershipArg {
         s: &mut S::SerializeStruct,
     ) -> Result<(), S::Error> {
         use serde::ser::SerializeStruct;
-        s.serialize_field("file", &self.file)
+        s.serialize_field("file", &self.file)?;
+        Ok(())
     }
 }
 
@@ -12509,7 +12707,8 @@ impl RelinquishFolderMembershipArg {
     ) -> Result<(), S::Error> {
         use serde::ser::SerializeStruct;
         s.serialize_field("shared_folder_id", &self.shared_folder_id)?;
-        s.serialize_field("leave_a_copy", &self.leave_a_copy)
+        s.serialize_field("leave_a_copy", &self.leave_a_copy)?;
+        Ok(())
     }
 }
 
@@ -12764,7 +12963,8 @@ impl RemoveFileMemberArg {
     ) -> Result<(), S::Error> {
         use serde::ser::SerializeStruct;
         s.serialize_field("file", &self.file)?;
-        s.serialize_field("member", &self.member)
+        s.serialize_field("member", &self.member)?;
+        Ok(())
     }
 }
 
@@ -12997,7 +13197,8 @@ impl RemoveFolderMemberArg {
         use serde::ser::SerializeStruct;
         s.serialize_field("shared_folder_id", &self.shared_folder_id)?;
         s.serialize_field("member", &self.member)?;
-        s.serialize_field("leave_a_copy", &self.leave_a_copy)
+        s.serialize_field("leave_a_copy", &self.leave_a_copy)?;
+        Ok(())
     }
 }
 
@@ -13589,7 +13790,8 @@ impl RevokeSharedLinkArg {
         s: &mut S::SerializeStruct,
     ) -> Result<(), S::Error> {
         use serde::ser::SerializeStruct;
-        s.serialize_field("url", &self.url)
+        s.serialize_field("url", &self.url)?;
+        Ok(())
     }
 }
 
@@ -13796,7 +13998,8 @@ impl SetAccessInheritanceArg {
     ) -> Result<(), S::Error> {
         use serde::ser::SerializeStruct;
         s.serialize_field("shared_folder_id", &self.shared_folder_id)?;
-        s.serialize_field("access_inheritance", &self.access_inheritance)
+        s.serialize_field("access_inheritance", &self.access_inheritance)?;
+        Ok(())
     }
 }
 
@@ -14118,14 +14321,27 @@ impl ShareFolderArg {
     ) -> Result<(), S::Error> {
         use serde::ser::SerializeStruct;
         s.serialize_field("path", &self.path)?;
-        s.serialize_field("acl_update_policy", &self.acl_update_policy)?;
+        if let Some(val) = &self.acl_update_policy {
+            s.serialize_field("acl_update_policy", val)?;
+        }
         s.serialize_field("force_async", &self.force_async)?;
-        s.serialize_field("member_policy", &self.member_policy)?;
-        s.serialize_field("shared_link_policy", &self.shared_link_policy)?;
-        s.serialize_field("viewer_info_policy", &self.viewer_info_policy)?;
+        if let Some(val) = &self.member_policy {
+            s.serialize_field("member_policy", val)?;
+        }
+        if let Some(val) = &self.shared_link_policy {
+            s.serialize_field("shared_link_policy", val)?;
+        }
+        if let Some(val) = &self.viewer_info_policy {
+            s.serialize_field("viewer_info_policy", val)?;
+        }
         s.serialize_field("access_inheritance", &self.access_inheritance)?;
-        s.serialize_field("actions", &self.actions)?;
-        s.serialize_field("link_settings", &self.link_settings)
+        if let Some(val) = &self.actions {
+            s.serialize_field("actions", val)?;
+        }
+        if let Some(val) = &self.link_settings {
+            s.serialize_field("link_settings", val)?;
+        }
+        Ok(())
     }
 }
 
@@ -14320,12 +14536,21 @@ impl ShareFolderArgBase {
     ) -> Result<(), S::Error> {
         use serde::ser::SerializeStruct;
         s.serialize_field("path", &self.path)?;
-        s.serialize_field("acl_update_policy", &self.acl_update_policy)?;
+        if let Some(val) = &self.acl_update_policy {
+            s.serialize_field("acl_update_policy", val)?;
+        }
         s.serialize_field("force_async", &self.force_async)?;
-        s.serialize_field("member_policy", &self.member_policy)?;
-        s.serialize_field("shared_link_policy", &self.shared_link_policy)?;
-        s.serialize_field("viewer_info_policy", &self.viewer_info_policy)?;
-        s.serialize_field("access_inheritance", &self.access_inheritance)
+        if let Some(val) = &self.member_policy {
+            s.serialize_field("member_policy", val)?;
+        }
+        if let Some(val) = &self.shared_link_policy {
+            s.serialize_field("shared_link_policy", val)?;
+        }
+        if let Some(val) = &self.viewer_info_policy {
+            s.serialize_field("viewer_info_policy", val)?;
+        }
+        s.serialize_field("access_inheritance", &self.access_inheritance)?;
+        Ok(())
     }
 }
 
@@ -15136,10 +15361,19 @@ impl SharedContentLinkMetadata {
         s.serialize_field("link_permissions", &self.link_permissions)?;
         s.serialize_field("password_protected", &self.password_protected)?;
         s.serialize_field("url", &self.url)?;
-        s.serialize_field("access_level", &self.access_level)?;
-        s.serialize_field("audience_restricting_shared_folder", &self.audience_restricting_shared_folder)?;
-        s.serialize_field("expiry", &self.expiry)?;
-        s.serialize_field("audience_exceptions", &self.audience_exceptions)
+        if let Some(val) = &self.access_level {
+            s.serialize_field("access_level", val)?;
+        }
+        if let Some(val) = &self.audience_restricting_shared_folder {
+            s.serialize_field("audience_restricting_shared_folder", val)?;
+        }
+        if let Some(val) = &self.expiry {
+            s.serialize_field("expiry", val)?;
+        }
+        if let Some(val) = &self.audience_exceptions {
+            s.serialize_field("audience_exceptions", val)?;
+        }
+        Ok(())
     }
 }
 
@@ -15332,9 +15566,16 @@ impl SharedContentLinkMetadataBase {
         s.serialize_field("current_audience", &self.current_audience)?;
         s.serialize_field("link_permissions", &self.link_permissions)?;
         s.serialize_field("password_protected", &self.password_protected)?;
-        s.serialize_field("access_level", &self.access_level)?;
-        s.serialize_field("audience_restricting_shared_folder", &self.audience_restricting_shared_folder)?;
-        s.serialize_field("expiry", &self.expiry)
+        if let Some(val) = &self.access_level {
+            s.serialize_field("access_level", val)?;
+        }
+        if let Some(val) = &self.audience_restricting_shared_folder {
+            s.serialize_field("audience_restricting_shared_folder", val)?;
+        }
+        if let Some(val) = &self.expiry {
+            s.serialize_field("expiry", val)?;
+        }
+        Ok(())
     }
 }
 
@@ -15478,7 +15719,10 @@ impl SharedFileMembers {
         s.serialize_field("users", &self.users)?;
         s.serialize_field("groups", &self.groups)?;
         s.serialize_field("invitees", &self.invitees)?;
-        s.serialize_field("cursor", &self.cursor)
+        if let Some(val) = &self.cursor {
+            s.serialize_field("cursor", val)?;
+        }
+        Ok(())
     }
 }
 
@@ -15798,16 +16042,37 @@ impl SharedFileMetadata {
         s.serialize_field("name", &self.name)?;
         s.serialize_field("policy", &self.policy)?;
         s.serialize_field("preview_url", &self.preview_url)?;
-        s.serialize_field("access_type", &self.access_type)?;
-        s.serialize_field("expected_link_metadata", &self.expected_link_metadata)?;
-        s.serialize_field("link_metadata", &self.link_metadata)?;
-        s.serialize_field("owner_display_names", &self.owner_display_names)?;
-        s.serialize_field("owner_team", &self.owner_team)?;
-        s.serialize_field("parent_shared_folder_id", &self.parent_shared_folder_id)?;
-        s.serialize_field("path_display", &self.path_display)?;
-        s.serialize_field("path_lower", &self.path_lower)?;
-        s.serialize_field("permissions", &self.permissions)?;
-        s.serialize_field("time_invited", &self.time_invited)
+        if let Some(val) = &self.access_type {
+            s.serialize_field("access_type", val)?;
+        }
+        if let Some(val) = &self.expected_link_metadata {
+            s.serialize_field("expected_link_metadata", val)?;
+        }
+        if let Some(val) = &self.link_metadata {
+            s.serialize_field("link_metadata", val)?;
+        }
+        if let Some(val) = &self.owner_display_names {
+            s.serialize_field("owner_display_names", val)?;
+        }
+        if let Some(val) = &self.owner_team {
+            s.serialize_field("owner_team", val)?;
+        }
+        if let Some(val) = &self.parent_shared_folder_id {
+            s.serialize_field("parent_shared_folder_id", val)?;
+        }
+        if let Some(val) = &self.path_display {
+            s.serialize_field("path_display", val)?;
+        }
+        if let Some(val) = &self.path_lower {
+            s.serialize_field("path_lower", val)?;
+        }
+        if let Some(val) = &self.permissions {
+            s.serialize_field("permissions", val)?;
+        }
+        if let Some(val) = &self.time_invited {
+            s.serialize_field("time_invited", val)?;
+        }
+        Ok(())
     }
 }
 
@@ -16139,7 +16404,10 @@ impl SharedFolderMembers {
         s.serialize_field("users", &self.users)?;
         s.serialize_field("groups", &self.groups)?;
         s.serialize_field("invitees", &self.invitees)?;
-        s.serialize_field("cursor", &self.cursor)
+        if let Some(val) = &self.cursor {
+            s.serialize_field("cursor", val)?;
+        }
+        Ok(())
     }
 }
 
@@ -16473,14 +16741,29 @@ impl SharedFolderMetadata {
         s.serialize_field("preview_url", &self.preview_url)?;
         s.serialize_field("shared_folder_id", &self.shared_folder_id)?;
         s.serialize_field("time_invited", &self.time_invited)?;
-        s.serialize_field("owner_display_names", &self.owner_display_names)?;
-        s.serialize_field("owner_team", &self.owner_team)?;
-        s.serialize_field("parent_shared_folder_id", &self.parent_shared_folder_id)?;
-        s.serialize_field("path_lower", &self.path_lower)?;
-        s.serialize_field("parent_folder_name", &self.parent_folder_name)?;
-        s.serialize_field("link_metadata", &self.link_metadata)?;
-        s.serialize_field("permissions", &self.permissions)?;
-        s.serialize_field("access_inheritance", &self.access_inheritance)
+        if let Some(val) = &self.owner_display_names {
+            s.serialize_field("owner_display_names", val)?;
+        }
+        if let Some(val) = &self.owner_team {
+            s.serialize_field("owner_team", val)?;
+        }
+        if let Some(val) = &self.parent_shared_folder_id {
+            s.serialize_field("parent_shared_folder_id", val)?;
+        }
+        if let Some(val) = &self.path_lower {
+            s.serialize_field("path_lower", val)?;
+        }
+        if let Some(val) = &self.parent_folder_name {
+            s.serialize_field("parent_folder_name", val)?;
+        }
+        if let Some(val) = &self.link_metadata {
+            s.serialize_field("link_metadata", val)?;
+        }
+        if let Some(val) = &self.permissions {
+            s.serialize_field("permissions", val)?;
+        }
+        s.serialize_field("access_inheritance", &self.access_inheritance)?;
+        Ok(())
     }
 }
 
@@ -16691,11 +16974,22 @@ impl SharedFolderMetadataBase {
         s.serialize_field("access_type", &self.access_type)?;
         s.serialize_field("is_inside_team_folder", &self.is_inside_team_folder)?;
         s.serialize_field("is_team_folder", &self.is_team_folder)?;
-        s.serialize_field("owner_display_names", &self.owner_display_names)?;
-        s.serialize_field("owner_team", &self.owner_team)?;
-        s.serialize_field("parent_shared_folder_id", &self.parent_shared_folder_id)?;
-        s.serialize_field("path_lower", &self.path_lower)?;
-        s.serialize_field("parent_folder_name", &self.parent_folder_name)
+        if let Some(val) = &self.owner_display_names {
+            s.serialize_field("owner_display_names", val)?;
+        }
+        if let Some(val) = &self.owner_team {
+            s.serialize_field("owner_team", val)?;
+        }
+        if let Some(val) = &self.parent_shared_folder_id {
+            s.serialize_field("parent_shared_folder_id", val)?;
+        }
+        if let Some(val) = &self.path_lower {
+            s.serialize_field("path_lower", val)?;
+        }
+        if let Some(val) = &self.parent_folder_name {
+            s.serialize_field("parent_folder_name", val)?;
+        }
+        Ok(())
     }
 }
 
@@ -17292,13 +17586,28 @@ impl SharedLinkSettings {
         s: &mut S::SerializeStruct,
     ) -> Result<(), S::Error> {
         use serde::ser::SerializeStruct;
-        s.serialize_field("require_password", &self.require_password)?;
-        s.serialize_field("link_password", &self.link_password)?;
-        s.serialize_field("expires", &self.expires)?;
-        s.serialize_field("audience", &self.audience)?;
-        s.serialize_field("access", &self.access)?;
-        s.serialize_field("requested_visibility", &self.requested_visibility)?;
-        s.serialize_field("allow_download", &self.allow_download)
+        if let Some(val) = &self.require_password {
+            s.serialize_field("require_password", val)?;
+        }
+        if let Some(val) = &self.link_password {
+            s.serialize_field("link_password", val)?;
+        }
+        if let Some(val) = &self.expires {
+            s.serialize_field("expires", val)?;
+        }
+        if let Some(val) = &self.audience {
+            s.serialize_field("audience", val)?;
+        }
+        if let Some(val) = &self.access {
+            s.serialize_field("access", val)?;
+        }
+        if let Some(val) = &self.requested_visibility {
+            s.serialize_field("requested_visibility", val)?;
+        }
+        if let Some(val) = &self.allow_download {
+            s.serialize_field("allow_download", val)?;
+        }
+        Ok(())
     }
 }
 
@@ -17675,7 +17984,10 @@ impl TeamMemberInfo {
         use serde::ser::SerializeStruct;
         s.serialize_field("team_info", &self.team_info)?;
         s.serialize_field("display_name", &self.display_name)?;
-        s.serialize_field("member_id", &self.member_id)
+        if let Some(val) = &self.member_id {
+            s.serialize_field("member_id", val)?;
+        }
+        Ok(())
     }
 }
 
@@ -17778,7 +18090,8 @@ impl TransferFolderArg {
     ) -> Result<(), S::Error> {
         use serde::ser::SerializeStruct;
         s.serialize_field("shared_folder_id", &self.shared_folder_id)?;
-        s.serialize_field("to_dropbox_id", &self.to_dropbox_id)
+        s.serialize_field("to_dropbox_id", &self.to_dropbox_id)?;
+        Ok(())
     }
 }
 
@@ -18013,7 +18326,8 @@ impl UnmountFolderArg {
         s: &mut S::SerializeStruct,
     ) -> Result<(), S::Error> {
         use serde::ser::SerializeStruct;
-        s.serialize_field("shared_folder_id", &self.shared_folder_id)
+        s.serialize_field("shared_folder_id", &self.shared_folder_id)?;
+        Ok(())
     }
 }
 
@@ -18206,7 +18520,8 @@ impl UnshareFileArg {
         s: &mut S::SerializeStruct,
     ) -> Result<(), S::Error> {
         use serde::ser::SerializeStruct;
-        s.serialize_field("file", &self.file)
+        s.serialize_field("file", &self.file)?;
+        Ok(())
     }
 }
 
@@ -18414,7 +18729,8 @@ impl UnshareFolderArg {
     ) -> Result<(), S::Error> {
         use serde::ser::SerializeStruct;
         s.serialize_field("shared_folder_id", &self.shared_folder_id)?;
-        s.serialize_field("leave_a_copy", &self.leave_a_copy)
+        s.serialize_field("leave_a_copy", &self.leave_a_copy)?;
+        Ok(())
     }
 }
 
@@ -18643,7 +18959,8 @@ impl UpdateFileMemberArgs {
         use serde::ser::SerializeStruct;
         s.serialize_field("file", &self.file)?;
         s.serialize_field("member", &self.member)?;
-        s.serialize_field("access_level", &self.access_level)
+        s.serialize_field("access_level", &self.access_level)?;
+        Ok(())
     }
 }
 
@@ -18764,7 +19081,8 @@ impl UpdateFolderMemberArg {
         use serde::ser::SerializeStruct;
         s.serialize_field("shared_folder_id", &self.shared_folder_id)?;
         s.serialize_field("member", &self.member)?;
-        s.serialize_field("access_level", &self.access_level)
+        s.serialize_field("access_level", &self.access_level)?;
+        Ok(())
     }
 }
 
@@ -19103,12 +19421,25 @@ impl UpdateFolderPolicyArg {
     ) -> Result<(), S::Error> {
         use serde::ser::SerializeStruct;
         s.serialize_field("shared_folder_id", &self.shared_folder_id)?;
-        s.serialize_field("member_policy", &self.member_policy)?;
-        s.serialize_field("acl_update_policy", &self.acl_update_policy)?;
-        s.serialize_field("viewer_info_policy", &self.viewer_info_policy)?;
-        s.serialize_field("shared_link_policy", &self.shared_link_policy)?;
-        s.serialize_field("link_settings", &self.link_settings)?;
-        s.serialize_field("actions", &self.actions)
+        if let Some(val) = &self.member_policy {
+            s.serialize_field("member_policy", val)?;
+        }
+        if let Some(val) = &self.acl_update_policy {
+            s.serialize_field("acl_update_policy", val)?;
+        }
+        if let Some(val) = &self.viewer_info_policy {
+            s.serialize_field("viewer_info_policy", val)?;
+        }
+        if let Some(val) = &self.shared_link_policy {
+            s.serialize_field("shared_link_policy", val)?;
+        }
+        if let Some(val) = &self.link_settings {
+            s.serialize_field("link_settings", val)?;
+        }
+        if let Some(val) = &self.actions {
+            s.serialize_field("actions", val)?;
+        }
+        Ok(())
     }
 }
 
@@ -19433,11 +19764,20 @@ impl UserFileMembershipInfo {
         use serde::ser::SerializeStruct;
         s.serialize_field("access_type", &self.access_type)?;
         s.serialize_field("user", &self.user)?;
-        s.serialize_field("permissions", &self.permissions)?;
-        s.serialize_field("initials", &self.initials)?;
+        if let Some(val) = &self.permissions {
+            s.serialize_field("permissions", val)?;
+        }
+        if let Some(val) = &self.initials {
+            s.serialize_field("initials", val)?;
+        }
         s.serialize_field("is_inherited", &self.is_inherited)?;
-        s.serialize_field("time_last_seen", &self.time_last_seen)?;
-        s.serialize_field("platform_type", &self.platform_type)
+        if let Some(val) = &self.time_last_seen {
+            s.serialize_field("time_last_seen", val)?;
+        }
+        if let Some(val) = &self.platform_type {
+            s.serialize_field("platform_type", val)?;
+        }
+        Ok(())
     }
 }
 
@@ -19592,7 +19932,10 @@ impl UserInfo {
         s.serialize_field("email", &self.email)?;
         s.serialize_field("display_name", &self.display_name)?;
         s.serialize_field("same_team", &self.same_team)?;
-        s.serialize_field("team_member_id", &self.team_member_id)
+        if let Some(val) = &self.team_member_id {
+            s.serialize_field("team_member_id", val)?;
+        }
+        Ok(())
     }
 }
 
@@ -19750,9 +20093,14 @@ impl UserMembershipInfo {
         use serde::ser::SerializeStruct;
         s.serialize_field("access_type", &self.access_type)?;
         s.serialize_field("user", &self.user)?;
-        s.serialize_field("permissions", &self.permissions)?;
-        s.serialize_field("initials", &self.initials)?;
-        s.serialize_field("is_inherited", &self.is_inherited)
+        if let Some(val) = &self.permissions {
+            s.serialize_field("permissions", val)?;
+        }
+        if let Some(val) = &self.initials {
+            s.serialize_field("initials", val)?;
+        }
+        s.serialize_field("is_inherited", &self.is_inherited)?;
+        Ok(())
     }
 }
 
@@ -20056,7 +20404,10 @@ impl VisibilityPolicy {
         s.serialize_field("policy", &self.policy)?;
         s.serialize_field("resolved_policy", &self.resolved_policy)?;
         s.serialize_field("allowed", &self.allowed)?;
-        s.serialize_field("disallowed_reason", &self.disallowed_reason)
+        if let Some(val) = &self.disallowed_reason {
+            s.serialize_field("disallowed_reason", val)?;
+        }
+        Ok(())
     }
 }
 

--- a/src/generated/team.rs
+++ b/src/generated/team.rs
@@ -1550,11 +1550,22 @@ impl ActiveWebSession {
         s.serialize_field("user_agent", &self.user_agent)?;
         s.serialize_field("os", &self.os)?;
         s.serialize_field("browser", &self.browser)?;
-        s.serialize_field("ip_address", &self.ip_address)?;
-        s.serialize_field("country", &self.country)?;
-        s.serialize_field("created", &self.created)?;
-        s.serialize_field("updated", &self.updated)?;
-        s.serialize_field("expires", &self.expires)
+        if let Some(val) = &self.ip_address {
+            s.serialize_field("ip_address", val)?;
+        }
+        if let Some(val) = &self.country {
+            s.serialize_field("country", val)?;
+        }
+        if let Some(val) = &self.created {
+            s.serialize_field("created", val)?;
+        }
+        if let Some(val) = &self.updated {
+            s.serialize_field("updated", val)?;
+        }
+        if let Some(val) = &self.expires {
+            s.serialize_field("expires", val)?;
+        }
+        Ok(())
     }
 }
 
@@ -1839,7 +1850,8 @@ impl AddSecondaryEmailsArg {
         s: &mut S::SerializeStruct,
     ) -> Result<(), S::Error> {
         use serde::ser::SerializeStruct;
-        s.serialize_field("new_secondary_emails", &self.new_secondary_emails)
+        s.serialize_field("new_secondary_emails", &self.new_secondary_emails)?;
+        Ok(())
     }
 }
 
@@ -2008,7 +2020,8 @@ impl AddSecondaryEmailsResult {
         s: &mut S::SerializeStruct,
     ) -> Result<(), S::Error> {
         use serde::ser::SerializeStruct;
-        s.serialize_field("results", &self.results)
+        s.serialize_field("results", &self.results)?;
+        Ok(())
     }
 }
 
@@ -2258,9 +2271,16 @@ impl ApiApp {
         s.serialize_field("app_id", &self.app_id)?;
         s.serialize_field("app_name", &self.app_name)?;
         s.serialize_field("is_app_folder", &self.is_app_folder)?;
-        s.serialize_field("publisher", &self.publisher)?;
-        s.serialize_field("publisher_url", &self.publisher_url)?;
-        s.serialize_field("linked", &self.linked)
+        if let Some(val) = &self.publisher {
+            s.serialize_field("publisher", val)?;
+        }
+        if let Some(val) = &self.publisher_url {
+            s.serialize_field("publisher_url", val)?;
+        }
+        if let Some(val) = &self.linked {
+            s.serialize_field("linked", val)?;
+        }
+        Ok(())
     }
 }
 
@@ -2351,7 +2371,8 @@ impl BaseDfbReport {
         s: &mut S::SerializeStruct,
     ) -> Result<(), S::Error> {
         use serde::ser::SerializeStruct;
-        s.serialize_field("start_date", &self.start_date)
+        s.serialize_field("start_date", &self.start_date)?;
+        Ok(())
     }
 }
 
@@ -2699,7 +2720,8 @@ impl CustomQuotaUsersArg {
         s: &mut S::SerializeStruct,
     ) -> Result<(), S::Error> {
         use serde::ser::SerializeStruct;
-        s.serialize_field("users", &self.users)
+        s.serialize_field("users", &self.users)?;
+        Ok(())
     }
 }
 
@@ -2804,8 +2826,13 @@ impl DateRange {
         s: &mut S::SerializeStruct,
     ) -> Result<(), S::Error> {
         use serde::ser::SerializeStruct;
-        s.serialize_field("start_date", &self.start_date)?;
-        s.serialize_field("end_date", &self.end_date)
+        if let Some(val) = &self.start_date {
+            s.serialize_field("start_date", val)?;
+        }
+        if let Some(val) = &self.end_date {
+            s.serialize_field("end_date", val)?;
+        }
+        Ok(())
     }
 }
 
@@ -3046,7 +3073,8 @@ impl DeleteSecondaryEmailsArg {
         s: &mut S::SerializeStruct,
     ) -> Result<(), S::Error> {
         use serde::ser::SerializeStruct;
-        s.serialize_field("emails_to_delete", &self.emails_to_delete)
+        s.serialize_field("emails_to_delete", &self.emails_to_delete)?;
+        Ok(())
     }
 }
 
@@ -3135,7 +3163,8 @@ impl DeleteSecondaryEmailsResult {
         s: &mut S::SerializeStruct,
     ) -> Result<(), S::Error> {
         use serde::ser::SerializeStruct;
-        s.serialize_field("results", &self.results)
+        s.serialize_field("results", &self.results)?;
+        Ok(())
     }
 }
 
@@ -3367,10 +3396,19 @@ impl DesktopClientSession {
         s.serialize_field("client_version", &self.client_version)?;
         s.serialize_field("platform", &self.platform)?;
         s.serialize_field("is_delete_on_unlink_supported", &self.is_delete_on_unlink_supported)?;
-        s.serialize_field("ip_address", &self.ip_address)?;
-        s.serialize_field("country", &self.country)?;
-        s.serialize_field("created", &self.created)?;
-        s.serialize_field("updated", &self.updated)
+        if let Some(val) = &self.ip_address {
+            s.serialize_field("ip_address", val)?;
+        }
+        if let Some(val) = &self.country {
+            s.serialize_field("country", val)?;
+        }
+        if let Some(val) = &self.created {
+            s.serialize_field("created", val)?;
+        }
+        if let Some(val) = &self.updated {
+            s.serialize_field("updated", val)?;
+        }
+        Ok(())
     }
 }
 
@@ -3604,10 +3642,19 @@ impl DeviceSession {
     ) -> Result<(), S::Error> {
         use serde::ser::SerializeStruct;
         s.serialize_field("session_id", &self.session_id)?;
-        s.serialize_field("ip_address", &self.ip_address)?;
-        s.serialize_field("country", &self.country)?;
-        s.serialize_field("created", &self.created)?;
-        s.serialize_field("updated", &self.updated)
+        if let Some(val) = &self.ip_address {
+            s.serialize_field("ip_address", val)?;
+        }
+        if let Some(val) = &self.country {
+            s.serialize_field("country", val)?;
+        }
+        if let Some(val) = &self.created {
+            s.serialize_field("created", val)?;
+        }
+        if let Some(val) = &self.updated {
+            s.serialize_field("updated", val)?;
+        }
+        Ok(())
     }
 }
 
@@ -3710,7 +3757,8 @@ impl DeviceSessionArg {
     ) -> Result<(), S::Error> {
         use serde::ser::SerializeStruct;
         s.serialize_field("session_id", &self.session_id)?;
-        s.serialize_field("team_member_id", &self.team_member_id)
+        s.serialize_field("team_member_id", &self.team_member_id)?;
+        Ok(())
     }
 }
 
@@ -3889,7 +3937,8 @@ impl DevicesActive {
         s.serialize_field("ios", &self.ios)?;
         s.serialize_field("android", &self.android)?;
         s.serialize_field("other", &self.other)?;
-        s.serialize_field("total", &self.total)
+        s.serialize_field("total", &self.total)?;
+        Ok(())
     }
 }
 
@@ -3976,7 +4025,8 @@ impl ExcludedUsersListArg {
         s: &mut S::SerializeStruct,
     ) -> Result<(), S::Error> {
         use serde::ser::SerializeStruct;
-        s.serialize_field("limit", &self.limit)
+        s.serialize_field("limit", &self.limit)?;
+        Ok(())
     }
 }
 
@@ -4067,7 +4117,8 @@ impl ExcludedUsersListContinueArg {
         s: &mut S::SerializeStruct,
     ) -> Result<(), S::Error> {
         use serde::ser::SerializeStruct;
-        s.serialize_field("cursor", &self.cursor)
+        s.serialize_field("cursor", &self.cursor)?;
+        Ok(())
     }
 }
 
@@ -4329,7 +4380,10 @@ impl ExcludedUsersListResult {
         use serde::ser::SerializeStruct;
         s.serialize_field("users", &self.users)?;
         s.serialize_field("has_more", &self.has_more)?;
-        s.serialize_field("cursor", &self.cursor)
+        if let Some(val) = &self.cursor {
+            s.serialize_field("cursor", val)?;
+        }
+        Ok(())
     }
 }
 
@@ -4417,7 +4471,10 @@ impl ExcludedUsersUpdateArg {
         s: &mut S::SerializeStruct,
     ) -> Result<(), S::Error> {
         use serde::ser::SerializeStruct;
-        s.serialize_field("users", &self.users)
+        if let Some(val) = &self.users {
+            s.serialize_field("users", val)?;
+        }
+        Ok(())
     }
 }
 
@@ -4587,7 +4644,8 @@ impl ExcludedUsersUpdateResult {
         s: &mut S::SerializeStruct,
     ) -> Result<(), S::Error> {
         use serde::ser::SerializeStruct;
-        s.serialize_field("status", &self.status)
+        s.serialize_field("status", &self.status)?;
+        Ok(())
     }
 }
 
@@ -4931,7 +4989,8 @@ impl FeaturesGetValuesBatchArg {
         s: &mut S::SerializeStruct,
     ) -> Result<(), S::Error> {
         use serde::ser::SerializeStruct;
-        s.serialize_field("features", &self.features)
+        s.serialize_field("features", &self.features)?;
+        Ok(())
     }
 }
 
@@ -5085,7 +5144,8 @@ impl FeaturesGetValuesBatchResult {
         s: &mut S::SerializeStruct,
     ) -> Result<(), S::Error> {
         use serde::ser::SerializeStruct;
-        s.serialize_field("values", &self.values)
+        s.serialize_field("values", &self.values)?;
+        Ok(())
     }
 }
 
@@ -5377,7 +5437,8 @@ impl GetActivityReport {
         s.serialize_field("shared_links_viewed_by_team", &self.shared_links_viewed_by_team)?;
         s.serialize_field("shared_links_viewed_by_outside_user", &self.shared_links_viewed_by_outside_user)?;
         s.serialize_field("shared_links_viewed_by_not_logged_in", &self.shared_links_viewed_by_not_logged_in)?;
-        s.serialize_field("shared_links_viewed_total", &self.shared_links_viewed_total)
+        s.serialize_field("shared_links_viewed_total", &self.shared_links_viewed_total)?;
+        Ok(())
     }
 }
 
@@ -5514,7 +5575,8 @@ impl GetDevicesReport {
         s.serialize_field("start_date", &self.start_date)?;
         s.serialize_field("active_1_day", &self.active_1_day)?;
         s.serialize_field("active_7_day", &self.active_7_day)?;
-        s.serialize_field("active_28_day", &self.active_28_day)
+        s.serialize_field("active_28_day", &self.active_28_day)?;
+        Ok(())
     }
 }
 
@@ -5678,7 +5740,8 @@ impl GetMembershipReport {
         s.serialize_field("pending_invites", &self.pending_invites)?;
         s.serialize_field("members_joined", &self.members_joined)?;
         s.serialize_field("suspended_members", &self.suspended_members)?;
-        s.serialize_field("licenses", &self.licenses)
+        s.serialize_field("licenses", &self.licenses)?;
+        Ok(())
     }
 }
 
@@ -5845,7 +5908,8 @@ impl GetStorageReport {
         s.serialize_field("shared_usage", &self.shared_usage)?;
         s.serialize_field("unshared_usage", &self.unshared_usage)?;
         s.serialize_field("shared_folders", &self.shared_folders)?;
-        s.serialize_field("member_storage_map", &self.member_storage_map)
+        s.serialize_field("member_storage_map", &self.member_storage_map)?;
+        Ok(())
     }
 }
 
@@ -6051,8 +6115,13 @@ impl GroupCreateArg {
         use serde::ser::SerializeStruct;
         s.serialize_field("group_name", &self.group_name)?;
         s.serialize_field("add_creator_as_owner", &self.add_creator_as_owner)?;
-        s.serialize_field("group_external_id", &self.group_external_id)?;
-        s.serialize_field("group_management_type", &self.group_management_type)
+        if let Some(val) = &self.group_external_id {
+            s.serialize_field("group_external_id", val)?;
+        }
+        if let Some(val) = &self.group_management_type {
+            s.serialize_field("group_management_type", val)?;
+        }
+        Ok(())
     }
 }
 
@@ -6426,9 +6495,16 @@ impl GroupFullInfo {
         s.serialize_field("group_id", &self.group_id)?;
         s.serialize_field("group_management_type", &self.group_management_type)?;
         s.serialize_field("created", &self.created)?;
-        s.serialize_field("group_external_id", &self.group_external_id)?;
-        s.serialize_field("member_count", &self.member_count)?;
-        s.serialize_field("members", &self.members)
+        if let Some(val) = &self.group_external_id {
+            s.serialize_field("group_external_id", val)?;
+        }
+        if let Some(val) = &self.member_count {
+            s.serialize_field("member_count", val)?;
+        }
+        if let Some(val) = &self.members {
+            s.serialize_field("members", val)?;
+        }
+        Ok(())
     }
 }
 
@@ -6532,7 +6608,8 @@ impl GroupMemberInfo {
     ) -> Result<(), S::Error> {
         use serde::ser::SerializeStruct;
         s.serialize_field("profile", &self.profile)?;
-        s.serialize_field("access_type", &self.access_type)
+        s.serialize_field("access_type", &self.access_type)?;
+        Ok(())
     }
 }
 
@@ -6636,7 +6713,8 @@ impl GroupMemberSelector {
     ) -> Result<(), S::Error> {
         use serde::ser::SerializeStruct;
         s.serialize_field("group", &self.group)?;
-        s.serialize_field("user", &self.user)
+        s.serialize_field("user", &self.user)?;
+        Ok(())
     }
 }
 
@@ -6950,7 +7028,8 @@ impl GroupMembersAddArg {
         use serde::ser::SerializeStruct;
         s.serialize_field("group", &self.group)?;
         s.serialize_field("members", &self.members)?;
-        s.serialize_field("return_members", &self.return_members)
+        s.serialize_field("return_members", &self.return_members)?;
+        Ok(())
     }
 }
 
@@ -7225,7 +7304,8 @@ impl GroupMembersChangeResult {
     ) -> Result<(), S::Error> {
         use serde::ser::SerializeStruct;
         s.serialize_field("group_info", &self.group_info)?;
-        s.serialize_field("async_job_id", &self.async_job_id)
+        s.serialize_field("async_job_id", &self.async_job_id)?;
+        Ok(())
     }
 }
 
@@ -7348,7 +7428,8 @@ impl GroupMembersRemoveArg {
         use serde::ser::SerializeStruct;
         s.serialize_field("group", &self.group)?;
         s.serialize_field("users", &self.users)?;
-        s.serialize_field("return_members", &self.return_members)
+        s.serialize_field("return_members", &self.return_members)?;
+        Ok(())
     }
 }
 
@@ -7589,7 +7670,8 @@ impl GroupMembersSelector {
     ) -> Result<(), S::Error> {
         use serde::ser::SerializeStruct;
         s.serialize_field("group", &self.group)?;
-        s.serialize_field("users", &self.users)
+        s.serialize_field("users", &self.users)?;
+        Ok(())
     }
 }
 
@@ -7816,7 +7898,8 @@ impl GroupMembersSetAccessTypeArg {
         s.serialize_field("group", &self.group)?;
         s.serialize_field("user", &self.user)?;
         s.serialize_field("access_type", &self.access_type)?;
-        s.serialize_field("return_members", &self.return_members)
+        s.serialize_field("return_members", &self.return_members)?;
+        Ok(())
     }
 }
 
@@ -8207,9 +8290,16 @@ impl GroupUpdateArgs {
         use serde::ser::SerializeStruct;
         s.serialize_field("group", &self.group)?;
         s.serialize_field("return_members", &self.return_members)?;
-        s.serialize_field("new_group_name", &self.new_group_name)?;
-        s.serialize_field("new_group_external_id", &self.new_group_external_id)?;
-        s.serialize_field("new_group_management_type", &self.new_group_management_type)
+        if let Some(val) = &self.new_group_name {
+            s.serialize_field("new_group_name", val)?;
+        }
+        if let Some(val) = &self.new_group_external_id {
+            s.serialize_field("new_group_external_id", val)?;
+        }
+        if let Some(val) = &self.new_group_management_type {
+            s.serialize_field("new_group_management_type", val)?;
+        }
+        Ok(())
     }
 }
 
@@ -8542,7 +8632,8 @@ impl GroupsListArg {
         s: &mut S::SerializeStruct,
     ) -> Result<(), S::Error> {
         use serde::ser::SerializeStruct;
-        s.serialize_field("limit", &self.limit)
+        s.serialize_field("limit", &self.limit)?;
+        Ok(())
     }
 }
 
@@ -8632,7 +8723,8 @@ impl GroupsListContinueArg {
         s: &mut S::SerializeStruct,
     ) -> Result<(), S::Error> {
         use serde::ser::SerializeStruct;
-        s.serialize_field("cursor", &self.cursor)
+        s.serialize_field("cursor", &self.cursor)?;
+        Ok(())
     }
 }
 
@@ -8820,7 +8912,8 @@ impl GroupsListResult {
         use serde::ser::SerializeStruct;
         s.serialize_field("groups", &self.groups)?;
         s.serialize_field("cursor", &self.cursor)?;
-        s.serialize_field("has_more", &self.has_more)
+        s.serialize_field("has_more", &self.has_more)?;
+        Ok(())
     }
 }
 
@@ -8928,7 +9021,8 @@ impl GroupsMembersListArg {
     ) -> Result<(), S::Error> {
         use serde::ser::SerializeStruct;
         s.serialize_field("group", &self.group)?;
-        s.serialize_field("limit", &self.limit)
+        s.serialize_field("limit", &self.limit)?;
+        Ok(())
     }
 }
 
@@ -9018,7 +9112,8 @@ impl GroupsMembersListContinueArg {
         s: &mut S::SerializeStruct,
     ) -> Result<(), S::Error> {
         use serde::ser::SerializeStruct;
-        s.serialize_field("cursor", &self.cursor)
+        s.serialize_field("cursor", &self.cursor)?;
+        Ok(())
     }
 }
 
@@ -9202,7 +9297,8 @@ impl GroupsMembersListResult {
         use serde::ser::SerializeStruct;
         s.serialize_field("members", &self.members)?;
         s.serialize_field("cursor", &self.cursor)?;
-        s.serialize_field("has_more", &self.has_more)
+        s.serialize_field("has_more", &self.has_more)?;
+        Ok(())
     }
 }
 
@@ -9643,7 +9739,8 @@ impl IncludeMembersArg {
         s: &mut S::SerializeStruct,
     ) -> Result<(), S::Error> {
         use serde::ser::SerializeStruct;
-        s.serialize_field("return_members", &self.return_members)
+        s.serialize_field("return_members", &self.return_members)?;
+        Ok(())
     }
 }
 
@@ -9863,7 +9960,8 @@ impl LegalHoldHeldRevisionMetadata {
         s.serialize_field("author_email", &self.author_email)?;
         s.serialize_field("file_type", &self.file_type)?;
         s.serialize_field("size", &self.size)?;
-        s.serialize_field("content_hash", &self.content_hash)
+        s.serialize_field("content_hash", &self.content_hash)?;
+        Ok(())
     }
 }
 
@@ -10063,9 +10161,16 @@ impl LegalHoldPolicy {
         s.serialize_field("members", &self.members)?;
         s.serialize_field("status", &self.status)?;
         s.serialize_field("start_date", &self.start_date)?;
-        s.serialize_field("description", &self.description)?;
-        s.serialize_field("activation_time", &self.activation_time)?;
-        s.serialize_field("end_date", &self.end_date)
+        if let Some(val) = &self.description {
+            s.serialize_field("description", val)?;
+        }
+        if let Some(val) = &self.activation_time {
+            s.serialize_field("activation_time", val)?;
+        }
+        if let Some(val) = &self.end_date {
+            s.serialize_field("end_date", val)?;
+        }
+        Ok(())
     }
 }
 
@@ -10338,7 +10443,8 @@ impl LegalHoldsGetPolicyArg {
         s: &mut S::SerializeStruct,
     ) -> Result<(), S::Error> {
         use serde::ser::SerializeStruct;
-        s.serialize_field("id", &self.id)
+        s.serialize_field("id", &self.id)?;
+        Ok(())
     }
 }
 
@@ -10550,7 +10656,10 @@ impl LegalHoldsListHeldRevisionResult {
         use serde::ser::SerializeStruct;
         s.serialize_field("entries", &self.entries)?;
         s.serialize_field("has_more", &self.has_more)?;
-        s.serialize_field("cursor", &self.cursor)
+        if let Some(val) = &self.cursor {
+            s.serialize_field("cursor", val)?;
+        }
+        Ok(())
     }
 }
 
@@ -10640,7 +10749,8 @@ impl LegalHoldsListHeldRevisionsArg {
         s: &mut S::SerializeStruct,
     ) -> Result<(), S::Error> {
         use serde::ser::SerializeStruct;
-        s.serialize_field("id", &self.id)
+        s.serialize_field("id", &self.id)?;
+        Ok(())
     }
 }
 
@@ -10749,7 +10859,10 @@ impl LegalHoldsListHeldRevisionsContinueArg {
     ) -> Result<(), S::Error> {
         use serde::ser::SerializeStruct;
         s.serialize_field("id", &self.id)?;
-        s.serialize_field("cursor", &self.cursor)
+        if let Some(val) = &self.cursor {
+            s.serialize_field("cursor", val)?;
+        }
+        Ok(())
     }
 }
 
@@ -11036,7 +11149,8 @@ impl LegalHoldsListPoliciesArg {
         s: &mut S::SerializeStruct,
     ) -> Result<(), S::Error> {
         use serde::ser::SerializeStruct;
-        s.serialize_field("include_released", &self.include_released)
+        s.serialize_field("include_released", &self.include_released)?;
+        Ok(())
     }
 }
 
@@ -11214,7 +11328,8 @@ impl LegalHoldsListPoliciesResult {
         s: &mut S::SerializeStruct,
     ) -> Result<(), S::Error> {
         use serde::ser::SerializeStruct;
-        s.serialize_field("policies", &self.policies)
+        s.serialize_field("policies", &self.policies)?;
+        Ok(())
     }
 }
 
@@ -11369,9 +11484,16 @@ impl LegalHoldsPolicyCreateArg {
         use serde::ser::SerializeStruct;
         s.serialize_field("name", &self.name)?;
         s.serialize_field("members", &self.members)?;
-        s.serialize_field("description", &self.description)?;
-        s.serialize_field("start_date", &self.start_date)?;
-        s.serialize_field("end_date", &self.end_date)
+        if let Some(val) = &self.description {
+            s.serialize_field("description", val)?;
+        }
+        if let Some(val) = &self.start_date {
+            s.serialize_field("start_date", val)?;
+        }
+        if let Some(val) = &self.end_date {
+            s.serialize_field("end_date", val)?;
+        }
+        Ok(())
     }
 }
 
@@ -11627,7 +11749,8 @@ impl LegalHoldsPolicyReleaseArg {
         s: &mut S::SerializeStruct,
     ) -> Result<(), S::Error> {
         use serde::ser::SerializeStruct;
-        s.serialize_field("id", &self.id)
+        s.serialize_field("id", &self.id)?;
+        Ok(())
     }
 }
 
@@ -11880,9 +12003,16 @@ impl LegalHoldsPolicyUpdateArg {
     ) -> Result<(), S::Error> {
         use serde::ser::SerializeStruct;
         s.serialize_field("id", &self.id)?;
-        s.serialize_field("name", &self.name)?;
-        s.serialize_field("description", &self.description)?;
-        s.serialize_field("members", &self.members)
+        if let Some(val) = &self.name {
+            s.serialize_field("name", val)?;
+        }
+        if let Some(val) = &self.description {
+            s.serialize_field("description", val)?;
+        }
+        if let Some(val) = &self.members {
+            s.serialize_field("members", val)?;
+        }
+        Ok(())
     }
 }
 
@@ -12138,7 +12268,8 @@ impl ListMemberAppsArg {
         s: &mut S::SerializeStruct,
     ) -> Result<(), S::Error> {
         use serde::ser::SerializeStruct;
-        s.serialize_field("team_member_id", &self.team_member_id)
+        s.serialize_field("team_member_id", &self.team_member_id)?;
+        Ok(())
     }
 }
 
@@ -12297,7 +12428,8 @@ impl ListMemberAppsResult {
         s: &mut S::SerializeStruct,
     ) -> Result<(), S::Error> {
         use serde::ser::SerializeStruct;
-        s.serialize_field("linked_api_apps", &self.linked_api_apps)
+        s.serialize_field("linked_api_apps", &self.linked_api_apps)?;
+        Ok(())
     }
 }
 
@@ -12441,7 +12573,8 @@ impl ListMemberDevicesArg {
         s.serialize_field("team_member_id", &self.team_member_id)?;
         s.serialize_field("include_web_sessions", &self.include_web_sessions)?;
         s.serialize_field("include_desktop_clients", &self.include_desktop_clients)?;
-        s.serialize_field("include_mobile_clients", &self.include_mobile_clients)
+        s.serialize_field("include_mobile_clients", &self.include_mobile_clients)?;
+        Ok(())
     }
 }
 
@@ -12628,9 +12761,16 @@ impl ListMemberDevicesResult {
         s: &mut S::SerializeStruct,
     ) -> Result<(), S::Error> {
         use serde::ser::SerializeStruct;
-        s.serialize_field("active_web_sessions", &self.active_web_sessions)?;
-        s.serialize_field("desktop_client_sessions", &self.desktop_client_sessions)?;
-        s.serialize_field("mobile_client_sessions", &self.mobile_client_sessions)
+        if let Some(val) = &self.active_web_sessions {
+            s.serialize_field("active_web_sessions", val)?;
+        }
+        if let Some(val) = &self.desktop_client_sessions {
+            s.serialize_field("desktop_client_sessions", val)?;
+        }
+        if let Some(val) = &self.mobile_client_sessions {
+            s.serialize_field("mobile_client_sessions", val)?;
+        }
+        Ok(())
     }
 }
 
@@ -12721,7 +12861,10 @@ impl ListMembersAppsArg {
         s: &mut S::SerializeStruct,
     ) -> Result<(), S::Error> {
         use serde::ser::SerializeStruct;
-        s.serialize_field("cursor", &self.cursor)
+        if let Some(val) = &self.cursor {
+            s.serialize_field("cursor", val)?;
+        }
+        Ok(())
     }
 }
 
@@ -12916,7 +13059,10 @@ impl ListMembersAppsResult {
         use serde::ser::SerializeStruct;
         s.serialize_field("apps", &self.apps)?;
         s.serialize_field("has_more", &self.has_more)?;
-        s.serialize_field("cursor", &self.cursor)
+        if let Some(val) = &self.cursor {
+            s.serialize_field("cursor", val)?;
+        }
+        Ok(())
     }
 }
 
@@ -13056,10 +13202,13 @@ impl ListMembersDevicesArg {
         s: &mut S::SerializeStruct,
     ) -> Result<(), S::Error> {
         use serde::ser::SerializeStruct;
-        s.serialize_field("cursor", &self.cursor)?;
+        if let Some(val) = &self.cursor {
+            s.serialize_field("cursor", val)?;
+        }
         s.serialize_field("include_web_sessions", &self.include_web_sessions)?;
         s.serialize_field("include_desktop_clients", &self.include_desktop_clients)?;
-        s.serialize_field("include_mobile_clients", &self.include_mobile_clients)
+        s.serialize_field("include_mobile_clients", &self.include_mobile_clients)?;
+        Ok(())
     }
 }
 
@@ -13248,7 +13397,10 @@ impl ListMembersDevicesResult {
         use serde::ser::SerializeStruct;
         s.serialize_field("devices", &self.devices)?;
         s.serialize_field("has_more", &self.has_more)?;
-        s.serialize_field("cursor", &self.cursor)
+        if let Some(val) = &self.cursor {
+            s.serialize_field("cursor", val)?;
+        }
+        Ok(())
     }
 }
 
@@ -13339,7 +13491,10 @@ impl ListTeamAppsArg {
         s: &mut S::SerializeStruct,
     ) -> Result<(), S::Error> {
         use serde::ser::SerializeStruct;
-        s.serialize_field("cursor", &self.cursor)
+        if let Some(val) = &self.cursor {
+            s.serialize_field("cursor", val)?;
+        }
+        Ok(())
     }
 }
 
@@ -13533,7 +13688,10 @@ impl ListTeamAppsResult {
         use serde::ser::SerializeStruct;
         s.serialize_field("apps", &self.apps)?;
         s.serialize_field("has_more", &self.has_more)?;
-        s.serialize_field("cursor", &self.cursor)
+        if let Some(val) = &self.cursor {
+            s.serialize_field("cursor", val)?;
+        }
+        Ok(())
     }
 }
 
@@ -13673,10 +13831,13 @@ impl ListTeamDevicesArg {
         s: &mut S::SerializeStruct,
     ) -> Result<(), S::Error> {
         use serde::ser::SerializeStruct;
-        s.serialize_field("cursor", &self.cursor)?;
+        if let Some(val) = &self.cursor {
+            s.serialize_field("cursor", val)?;
+        }
         s.serialize_field("include_web_sessions", &self.include_web_sessions)?;
         s.serialize_field("include_desktop_clients", &self.include_desktop_clients)?;
-        s.serialize_field("include_mobile_clients", &self.include_mobile_clients)
+        s.serialize_field("include_mobile_clients", &self.include_mobile_clients)?;
+        Ok(())
     }
 }
 
@@ -13865,7 +14026,10 @@ impl ListTeamDevicesResult {
         use serde::ser::SerializeStruct;
         s.serialize_field("devices", &self.devices)?;
         s.serialize_field("has_more", &self.has_more)?;
-        s.serialize_field("cursor", &self.cursor)
+        if let Some(val) = &self.cursor {
+            s.serialize_field("cursor", val)?;
+        }
+        Ok(())
     }
 }
 
@@ -13969,7 +14133,8 @@ impl MemberAccess {
     ) -> Result<(), S::Error> {
         use serde::ser::SerializeStruct;
         s.serialize_field("user", &self.user)?;
-        s.serialize_field("access_type", &self.access_type)
+        s.serialize_field("access_type", &self.access_type)?;
+        Ok(())
     }
 }
 
@@ -14180,13 +14345,24 @@ impl MemberAddArg {
     ) -> Result<(), S::Error> {
         use serde::ser::SerializeStruct;
         s.serialize_field("member_email", &self.member_email)?;
-        s.serialize_field("member_given_name", &self.member_given_name)?;
-        s.serialize_field("member_surname", &self.member_surname)?;
-        s.serialize_field("member_external_id", &self.member_external_id)?;
-        s.serialize_field("member_persistent_id", &self.member_persistent_id)?;
+        if let Some(val) = &self.member_given_name {
+            s.serialize_field("member_given_name", val)?;
+        }
+        if let Some(val) = &self.member_surname {
+            s.serialize_field("member_surname", val)?;
+        }
+        if let Some(val) = &self.member_external_id {
+            s.serialize_field("member_external_id", val)?;
+        }
+        if let Some(val) = &self.member_persistent_id {
+            s.serialize_field("member_persistent_id", val)?;
+        }
         s.serialize_field("send_welcome_email", &self.send_welcome_email)?;
-        s.serialize_field("is_directory_restricted", &self.is_directory_restricted)?;
-        s.serialize_field("role", &self.role)
+        if let Some(val) = &self.is_directory_restricted {
+            s.serialize_field("is_directory_restricted", val)?;
+        }
+        s.serialize_field("role", &self.role)?;
+        Ok(())
     }
 }
 
@@ -14381,12 +14557,23 @@ impl MemberAddArgBase {
     ) -> Result<(), S::Error> {
         use serde::ser::SerializeStruct;
         s.serialize_field("member_email", &self.member_email)?;
-        s.serialize_field("member_given_name", &self.member_given_name)?;
-        s.serialize_field("member_surname", &self.member_surname)?;
-        s.serialize_field("member_external_id", &self.member_external_id)?;
-        s.serialize_field("member_persistent_id", &self.member_persistent_id)?;
+        if let Some(val) = &self.member_given_name {
+            s.serialize_field("member_given_name", val)?;
+        }
+        if let Some(val) = &self.member_surname {
+            s.serialize_field("member_surname", val)?;
+        }
+        if let Some(val) = &self.member_external_id {
+            s.serialize_field("member_external_id", val)?;
+        }
+        if let Some(val) = &self.member_persistent_id {
+            s.serialize_field("member_persistent_id", val)?;
+        }
         s.serialize_field("send_welcome_email", &self.send_welcome_email)?;
-        s.serialize_field("is_directory_restricted", &self.is_directory_restricted)
+        if let Some(val) = &self.is_directory_restricted {
+            s.serialize_field("is_directory_restricted", val)?;
+        }
+        Ok(())
     }
 }
 
@@ -15039,13 +15226,26 @@ impl MemberAddV2Arg {
     ) -> Result<(), S::Error> {
         use serde::ser::SerializeStruct;
         s.serialize_field("member_email", &self.member_email)?;
-        s.serialize_field("member_given_name", &self.member_given_name)?;
-        s.serialize_field("member_surname", &self.member_surname)?;
-        s.serialize_field("member_external_id", &self.member_external_id)?;
-        s.serialize_field("member_persistent_id", &self.member_persistent_id)?;
+        if let Some(val) = &self.member_given_name {
+            s.serialize_field("member_given_name", val)?;
+        }
+        if let Some(val) = &self.member_surname {
+            s.serialize_field("member_surname", val)?;
+        }
+        if let Some(val) = &self.member_external_id {
+            s.serialize_field("member_external_id", val)?;
+        }
+        if let Some(val) = &self.member_persistent_id {
+            s.serialize_field("member_persistent_id", val)?;
+        }
         s.serialize_field("send_welcome_email", &self.send_welcome_email)?;
-        s.serialize_field("is_directory_restricted", &self.is_directory_restricted)?;
-        s.serialize_field("role_ids", &self.role_ids)
+        if let Some(val) = &self.is_directory_restricted {
+            s.serialize_field("is_directory_restricted", val)?;
+        }
+        if let Some(val) = &self.role_ids {
+            s.serialize_field("role_ids", val)?;
+        }
+        Ok(())
     }
 }
 
@@ -15422,9 +15622,16 @@ impl MemberDevices {
     ) -> Result<(), S::Error> {
         use serde::ser::SerializeStruct;
         s.serialize_field("team_member_id", &self.team_member_id)?;
-        s.serialize_field("web_sessions", &self.web_sessions)?;
-        s.serialize_field("desktop_clients", &self.desktop_clients)?;
-        s.serialize_field("mobile_clients", &self.mobile_clients)
+        if let Some(val) = &self.web_sessions {
+            s.serialize_field("web_sessions", val)?;
+        }
+        if let Some(val) = &self.desktop_clients {
+            s.serialize_field("desktop_clients", val)?;
+        }
+        if let Some(val) = &self.mobile_clients {
+            s.serialize_field("mobile_clients", val)?;
+        }
+        Ok(())
     }
 }
 
@@ -15528,7 +15735,8 @@ impl MemberLinkedApps {
     ) -> Result<(), S::Error> {
         use serde::ser::SerializeStruct;
         s.serialize_field("team_member_id", &self.team_member_id)?;
-        s.serialize_field("linked_api_apps", &self.linked_api_apps)
+        s.serialize_field("linked_api_apps", &self.linked_api_apps)?;
+        Ok(())
     }
 }
 
@@ -15853,15 +16061,34 @@ impl MemberProfile {
         s.serialize_field("status", &self.status)?;
         s.serialize_field("name", &self.name)?;
         s.serialize_field("membership_type", &self.membership_type)?;
-        s.serialize_field("external_id", &self.external_id)?;
-        s.serialize_field("account_id", &self.account_id)?;
-        s.serialize_field("secondary_emails", &self.secondary_emails)?;
-        s.serialize_field("invited_on", &self.invited_on)?;
-        s.serialize_field("joined_on", &self.joined_on)?;
-        s.serialize_field("suspended_on", &self.suspended_on)?;
-        s.serialize_field("persistent_id", &self.persistent_id)?;
-        s.serialize_field("is_directory_restricted", &self.is_directory_restricted)?;
-        s.serialize_field("profile_photo_url", &self.profile_photo_url)
+        if let Some(val) = &self.external_id {
+            s.serialize_field("external_id", val)?;
+        }
+        if let Some(val) = &self.account_id {
+            s.serialize_field("account_id", val)?;
+        }
+        if let Some(val) = &self.secondary_emails {
+            s.serialize_field("secondary_emails", val)?;
+        }
+        if let Some(val) = &self.invited_on {
+            s.serialize_field("invited_on", val)?;
+        }
+        if let Some(val) = &self.joined_on {
+            s.serialize_field("joined_on", val)?;
+        }
+        if let Some(val) = &self.suspended_on {
+            s.serialize_field("suspended_on", val)?;
+        }
+        if let Some(val) = &self.persistent_id {
+            s.serialize_field("persistent_id", val)?;
+        }
+        if let Some(val) = &self.is_directory_restricted {
+            s.serialize_field("is_directory_restricted", val)?;
+        }
+        if let Some(val) = &self.profile_photo_url {
+            s.serialize_field("profile_photo_url", val)?;
+        }
+        Ok(())
     }
 }
 
@@ -16041,7 +16268,8 @@ impl MembersAddArg {
     ) -> Result<(), S::Error> {
         use serde::ser::SerializeStruct;
         s.serialize_field("new_members", &self.new_members)?;
-        s.serialize_field("force_async", &self.force_async)
+        s.serialize_field("force_async", &self.force_async)?;
+        Ok(())
     }
 }
 
@@ -16127,7 +16355,8 @@ impl MembersAddArgBase {
         s: &mut S::SerializeStruct,
     ) -> Result<(), S::Error> {
         use serde::ser::SerializeStruct;
-        s.serialize_field("force_async", &self.force_async)
+        s.serialize_field("force_async", &self.force_async)?;
+        Ok(())
     }
 }
 
@@ -16563,7 +16792,8 @@ impl MembersAddV2Arg {
     ) -> Result<(), S::Error> {
         use serde::ser::SerializeStruct;
         s.serialize_field("new_members", &self.new_members)?;
-        s.serialize_field("force_async", &self.force_async)
+        s.serialize_field("force_async", &self.force_async)?;
+        Ok(())
     }
 }
 
@@ -16683,7 +16913,8 @@ impl MembersDataTransferArg {
         use serde::ser::SerializeStruct;
         s.serialize_field("user", &self.user)?;
         s.serialize_field("transfer_dest_id", &self.transfer_dest_id)?;
-        s.serialize_field("transfer_admin_id", &self.transfer_admin_id)
+        s.serialize_field("transfer_admin_id", &self.transfer_admin_id)?;
+        Ok(())
     }
 }
 
@@ -16791,7 +17022,8 @@ impl MembersDeactivateArg {
     ) -> Result<(), S::Error> {
         use serde::ser::SerializeStruct;
         s.serialize_field("user", &self.user)?;
-        s.serialize_field("wipe_data", &self.wipe_data)
+        s.serialize_field("wipe_data", &self.wipe_data)?;
+        Ok(())
     }
 }
 
@@ -16883,7 +17115,8 @@ impl MembersDeactivateBaseArg {
         s: &mut S::SerializeStruct,
     ) -> Result<(), S::Error> {
         use serde::ser::SerializeStruct;
-        s.serialize_field("user", &self.user)
+        s.serialize_field("user", &self.user)?;
+        Ok(())
     }
 }
 
@@ -17052,7 +17285,8 @@ impl MembersDeleteProfilePhotoArg {
         s: &mut S::SerializeStruct,
     ) -> Result<(), S::Error> {
         use serde::ser::SerializeStruct;
-        s.serialize_field("user", &self.user)
+        s.serialize_field("user", &self.user)?;
+        Ok(())
     }
 }
 
@@ -17234,7 +17468,8 @@ impl MembersGetAvailableTeamMemberRolesResult {
         s: &mut S::SerializeStruct,
     ) -> Result<(), S::Error> {
         use serde::ser::SerializeStruct;
-        s.serialize_field("roles", &self.roles)
+        s.serialize_field("roles", &self.roles)?;
+        Ok(())
     }
 }
 
@@ -17324,7 +17559,8 @@ impl MembersGetInfoArgs {
         s: &mut S::SerializeStruct,
     ) -> Result<(), S::Error> {
         use serde::ser::SerializeStruct;
-        s.serialize_field("members", &self.members)
+        s.serialize_field("members", &self.members)?;
+        Ok(())
     }
 }
 
@@ -17675,7 +17911,8 @@ impl MembersGetInfoV2Arg {
         s: &mut S::SerializeStruct,
     ) -> Result<(), S::Error> {
         use serde::ser::SerializeStruct;
-        s.serialize_field("members", &self.members)
+        s.serialize_field("members", &self.members)?;
+        Ok(())
     }
 }
 
@@ -17765,7 +18002,8 @@ impl MembersGetInfoV2Result {
         s: &mut S::SerializeStruct,
     ) -> Result<(), S::Error> {
         use serde::ser::SerializeStruct;
-        s.serialize_field("members_info", &self.members_info)
+        s.serialize_field("members_info", &self.members_info)?;
+        Ok(())
     }
 }
 
@@ -17871,7 +18109,8 @@ impl MembersInfo {
     ) -> Result<(), S::Error> {
         use serde::ser::SerializeStruct;
         s.serialize_field("team_member_ids", &self.team_member_ids)?;
-        s.serialize_field("permanently_deleted_users", &self.permanently_deleted_users)
+        s.serialize_field("permanently_deleted_users", &self.permanently_deleted_users)?;
+        Ok(())
     }
 }
 
@@ -17975,7 +18214,8 @@ impl MembersListArg {
     ) -> Result<(), S::Error> {
         use serde::ser::SerializeStruct;
         s.serialize_field("limit", &self.limit)?;
-        s.serialize_field("include_removed", &self.include_removed)
+        s.serialize_field("include_removed", &self.include_removed)?;
+        Ok(())
     }
 }
 
@@ -18065,7 +18305,8 @@ impl MembersListContinueArg {
         s: &mut S::SerializeStruct,
     ) -> Result<(), S::Error> {
         use serde::ser::SerializeStruct;
-        s.serialize_field("cursor", &self.cursor)
+        s.serialize_field("cursor", &self.cursor)?;
+        Ok(())
     }
 }
 
@@ -18302,7 +18543,8 @@ impl MembersListResult {
         use serde::ser::SerializeStruct;
         s.serialize_field("members", &self.members)?;
         s.serialize_field("cursor", &self.cursor)?;
-        s.serialize_field("has_more", &self.has_more)
+        s.serialize_field("has_more", &self.has_more)?;
+        Ok(())
     }
 }
 
@@ -18420,7 +18662,8 @@ impl MembersListV2Result {
         use serde::ser::SerializeStruct;
         s.serialize_field("members", &self.members)?;
         s.serialize_field("cursor", &self.cursor)?;
-        s.serialize_field("has_more", &self.has_more)
+        s.serialize_field("has_more", &self.has_more)?;
+        Ok(())
     }
 }
 
@@ -18512,7 +18755,8 @@ impl MembersRecoverArg {
         s: &mut S::SerializeStruct,
     ) -> Result<(), S::Error> {
         use serde::ser::SerializeStruct;
-        s.serialize_field("user", &self.user)
+        s.serialize_field("user", &self.user)?;
+        Ok(())
     }
 }
 
@@ -18797,10 +19041,15 @@ impl MembersRemoveArg {
         use serde::ser::SerializeStruct;
         s.serialize_field("user", &self.user)?;
         s.serialize_field("wipe_data", &self.wipe_data)?;
-        s.serialize_field("transfer_dest_id", &self.transfer_dest_id)?;
-        s.serialize_field("transfer_admin_id", &self.transfer_admin_id)?;
+        if let Some(val) = &self.transfer_dest_id {
+            s.serialize_field("transfer_dest_id", val)?;
+        }
+        if let Some(val) = &self.transfer_admin_id {
+            s.serialize_field("transfer_admin_id", val)?;
+        }
         s.serialize_field("keep_account", &self.keep_account)?;
-        s.serialize_field("retain_team_shares", &self.retain_team_shares)
+        s.serialize_field("retain_team_shares", &self.retain_team_shares)?;
+        Ok(())
     }
 }
 
@@ -19293,7 +19542,10 @@ impl MembersSetPermissions2Arg {
     ) -> Result<(), S::Error> {
         use serde::ser::SerializeStruct;
         s.serialize_field("user", &self.user)?;
-        s.serialize_field("new_roles", &self.new_roles)
+        if let Some(val) = &self.new_roles {
+            s.serialize_field("new_roles", val)?;
+        }
+        Ok(())
     }
 }
 
@@ -19513,7 +19765,10 @@ impl MembersSetPermissions2Result {
     ) -> Result<(), S::Error> {
         use serde::ser::SerializeStruct;
         s.serialize_field("team_member_id", &self.team_member_id)?;
-        s.serialize_field("roles", &self.roles)
+        if let Some(val) = &self.roles {
+            s.serialize_field("roles", val)?;
+        }
+        Ok(())
     }
 }
 
@@ -19618,7 +19873,8 @@ impl MembersSetPermissionsArg {
     ) -> Result<(), S::Error> {
         use serde::ser::SerializeStruct;
         s.serialize_field("user", &self.user)?;
-        s.serialize_field("new_role", &self.new_role)
+        s.serialize_field("new_role", &self.new_role)?;
+        Ok(())
     }
 }
 
@@ -19833,7 +20089,8 @@ impl MembersSetPermissionsResult {
     ) -> Result<(), S::Error> {
         use serde::ser::SerializeStruct;
         s.serialize_field("team_member_id", &self.team_member_id)?;
-        s.serialize_field("role", &self.role)
+        s.serialize_field("role", &self.role)?;
+        Ok(())
     }
 }
 
@@ -20030,12 +20287,25 @@ impl MembersSetProfileArg {
     ) -> Result<(), S::Error> {
         use serde::ser::SerializeStruct;
         s.serialize_field("user", &self.user)?;
-        s.serialize_field("new_email", &self.new_email)?;
-        s.serialize_field("new_external_id", &self.new_external_id)?;
-        s.serialize_field("new_given_name", &self.new_given_name)?;
-        s.serialize_field("new_surname", &self.new_surname)?;
-        s.serialize_field("new_persistent_id", &self.new_persistent_id)?;
-        s.serialize_field("new_is_directory_restricted", &self.new_is_directory_restricted)
+        if let Some(val) = &self.new_email {
+            s.serialize_field("new_email", val)?;
+        }
+        if let Some(val) = &self.new_external_id {
+            s.serialize_field("new_external_id", val)?;
+        }
+        if let Some(val) = &self.new_given_name {
+            s.serialize_field("new_given_name", val)?;
+        }
+        if let Some(val) = &self.new_surname {
+            s.serialize_field("new_surname", val)?;
+        }
+        if let Some(val) = &self.new_persistent_id {
+            s.serialize_field("new_persistent_id", val)?;
+        }
+        if let Some(val) = &self.new_is_directory_restricted {
+            s.serialize_field("new_is_directory_restricted", val)?;
+        }
+        Ok(())
     }
 }
 
@@ -20317,7 +20587,8 @@ impl MembersSetProfilePhotoArg {
     ) -> Result<(), S::Error> {
         use serde::ser::SerializeStruct;
         s.serialize_field("user", &self.user)?;
-        s.serialize_field("photo", &self.photo)
+        s.serialize_field("photo", &self.photo)?;
+        Ok(())
     }
 }
 
@@ -21034,7 +21305,8 @@ impl MembersUnsuspendArg {
         s: &mut S::SerializeStruct,
     ) -> Result<(), S::Error> {
         use serde::ser::SerializeStruct;
-        s.serialize_field("user", &self.user)
+        s.serialize_field("user", &self.user)?;
+        Ok(())
     }
 }
 
@@ -21471,13 +21743,28 @@ impl MobileClientSession {
         s.serialize_field("session_id", &self.session_id)?;
         s.serialize_field("device_name", &self.device_name)?;
         s.serialize_field("client_type", &self.client_type)?;
-        s.serialize_field("ip_address", &self.ip_address)?;
-        s.serialize_field("country", &self.country)?;
-        s.serialize_field("created", &self.created)?;
-        s.serialize_field("updated", &self.updated)?;
-        s.serialize_field("client_version", &self.client_version)?;
-        s.serialize_field("os_version", &self.os_version)?;
-        s.serialize_field("last_carrier", &self.last_carrier)
+        if let Some(val) = &self.ip_address {
+            s.serialize_field("ip_address", val)?;
+        }
+        if let Some(val) = &self.country {
+            s.serialize_field("country", val)?;
+        }
+        if let Some(val) = &self.created {
+            s.serialize_field("created", val)?;
+        }
+        if let Some(val) = &self.updated {
+            s.serialize_field("updated", val)?;
+        }
+        if let Some(val) = &self.client_version {
+            s.serialize_field("client_version", val)?;
+        }
+        if let Some(val) = &self.os_version {
+            s.serialize_field("os_version", val)?;
+        }
+        if let Some(val) = &self.last_carrier {
+            s.serialize_field("last_carrier", val)?;
+        }
+        Ok(())
     }
 }
 
@@ -21617,7 +21904,10 @@ impl NamespaceMetadata {
         s.serialize_field("name", &self.name)?;
         s.serialize_field("namespace_id", &self.namespace_id)?;
         s.serialize_field("namespace_type", &self.namespace_type)?;
-        s.serialize_field("team_member_id", &self.team_member_id)
+        if let Some(val) = &self.team_member_id {
+            s.serialize_field("team_member_id", val)?;
+        }
+        Ok(())
     }
 }
 
@@ -21885,7 +22175,8 @@ impl RemovedStatus {
     ) -> Result<(), S::Error> {
         use serde::ser::SerializeStruct;
         s.serialize_field("is_recoverable", &self.is_recoverable)?;
-        s.serialize_field("is_disconnected", &self.is_disconnected)
+        s.serialize_field("is_disconnected", &self.is_disconnected)?;
+        Ok(())
     }
 }
 
@@ -22074,7 +22365,8 @@ impl ResendVerificationEmailArg {
         s: &mut S::SerializeStruct,
     ) -> Result<(), S::Error> {
         use serde::ser::SerializeStruct;
-        s.serialize_field("emails_to_resend", &self.emails_to_resend)
+        s.serialize_field("emails_to_resend", &self.emails_to_resend)?;
+        Ok(())
     }
 }
 
@@ -22164,7 +22456,8 @@ impl ResendVerificationEmailResult {
         s: &mut S::SerializeStruct,
     ) -> Result<(), S::Error> {
         use serde::ser::SerializeStruct;
-        s.serialize_field("results", &self.results)
+        s.serialize_field("results", &self.results)?;
+        Ok(())
     }
 }
 
@@ -22286,7 +22579,8 @@ impl RevokeDesktopClientArg {
         use serde::ser::SerializeStruct;
         s.serialize_field("session_id", &self.session_id)?;
         s.serialize_field("team_member_id", &self.team_member_id)?;
-        s.serialize_field("delete_on_unlink", &self.delete_on_unlink)
+        s.serialize_field("delete_on_unlink", &self.delete_on_unlink)?;
+        Ok(())
     }
 }
 
@@ -22447,7 +22741,8 @@ impl RevokeDeviceSessionBatchArg {
         s: &mut S::SerializeStruct,
     ) -> Result<(), S::Error> {
         use serde::ser::SerializeStruct;
-        s.serialize_field("revoke_devices", &self.revoke_devices)
+        s.serialize_field("revoke_devices", &self.revoke_devices)?;
+        Ok(())
     }
 }
 
@@ -22588,7 +22883,8 @@ impl RevokeDeviceSessionBatchResult {
         s: &mut S::SerializeStruct,
     ) -> Result<(), S::Error> {
         use serde::ser::SerializeStruct;
-        s.serialize_field("revoke_devices_status", &self.revoke_devices_status)
+        s.serialize_field("revoke_devices_status", &self.revoke_devices_status)?;
+        Ok(())
     }
 }
 
@@ -22774,7 +23070,10 @@ impl RevokeDeviceSessionStatus {
     ) -> Result<(), S::Error> {
         use serde::ser::SerializeStruct;
         s.serialize_field("success", &self.success)?;
-        s.serialize_field("error_type", &self.error_type)
+        if let Some(val) = &self.error_type {
+            s.serialize_field("error_type", val)?;
+        }
+        Ok(())
     }
 }
 
@@ -22896,7 +23195,8 @@ impl RevokeLinkedApiAppArg {
         use serde::ser::SerializeStruct;
         s.serialize_field("app_id", &self.app_id)?;
         s.serialize_field("team_member_id", &self.team_member_id)?;
-        s.serialize_field("keep_app_folder", &self.keep_app_folder)
+        s.serialize_field("keep_app_folder", &self.keep_app_folder)?;
+        Ok(())
     }
 }
 
@@ -22985,7 +23285,8 @@ impl RevokeLinkedApiAppBatchArg {
         s: &mut S::SerializeStruct,
     ) -> Result<(), S::Error> {
         use serde::ser::SerializeStruct;
-        s.serialize_field("revoke_linked_app", &self.revoke_linked_app)
+        s.serialize_field("revoke_linked_app", &self.revoke_linked_app)?;
+        Ok(())
     }
 }
 
@@ -23127,7 +23428,8 @@ impl RevokeLinkedAppBatchResult {
         s: &mut S::SerializeStruct,
     ) -> Result<(), S::Error> {
         use serde::ser::SerializeStruct;
-        s.serialize_field("revoke_linked_app_status", &self.revoke_linked_app_status)
+        s.serialize_field("revoke_linked_app_status", &self.revoke_linked_app_status)?;
+        Ok(())
     }
 }
 
@@ -23325,7 +23627,10 @@ impl RevokeLinkedAppStatus {
     ) -> Result<(), S::Error> {
         use serde::ser::SerializeStruct;
         s.serialize_field("success", &self.success)?;
-        s.serialize_field("error_type", &self.error_type)
+        if let Some(val) = &self.error_type {
+            s.serialize_field("error_type", val)?;
+        }
+        Ok(())
     }
 }
 
@@ -23415,7 +23720,8 @@ impl SetCustomQuotaArg {
         s: &mut S::SerializeStruct,
     ) -> Result<(), S::Error> {
         use serde::ser::SerializeStruct;
-        s.serialize_field("users_and_quotas", &self.users_and_quotas)
+        s.serialize_field("users_and_quotas", &self.users_and_quotas)?;
+        Ok(())
     }
 }
 
@@ -23599,7 +23905,8 @@ impl StorageBucket {
     ) -> Result<(), S::Error> {
         use serde::ser::SerializeStruct;
         s.serialize_field("bucket", &self.bucket)?;
-        s.serialize_field("users", &self.users)
+        s.serialize_field("users", &self.users)?;
+        Ok(())
     }
 }
 
@@ -23901,7 +24208,8 @@ impl TeamFolderArchiveArg {
     ) -> Result<(), S::Error> {
         use serde::ser::SerializeStruct;
         s.serialize_field("team_folder_id", &self.team_folder_id)?;
-        s.serialize_field("force_async_off", &self.force_async_off)
+        s.serialize_field("force_async_off", &self.force_async_off)?;
+        Ok(())
     }
 }
 
@@ -24271,7 +24579,10 @@ impl TeamFolderCreateArg {
     ) -> Result<(), S::Error> {
         use serde::ser::SerializeStruct;
         s.serialize_field("name", &self.name)?;
-        s.serialize_field("sync_setting", &self.sync_setting)
+        if let Some(val) = &self.sync_setting {
+            s.serialize_field("sync_setting", val)?;
+        }
+        Ok(())
     }
 }
 
@@ -24542,7 +24853,8 @@ impl TeamFolderIdArg {
         s: &mut S::SerializeStruct,
     ) -> Result<(), S::Error> {
         use serde::ser::SerializeStruct;
-        s.serialize_field("team_folder_id", &self.team_folder_id)
+        s.serialize_field("team_folder_id", &self.team_folder_id)?;
+        Ok(())
     }
 }
 
@@ -24632,7 +24944,8 @@ impl TeamFolderIdListArg {
         s: &mut S::SerializeStruct,
     ) -> Result<(), S::Error> {
         use serde::ser::SerializeStruct;
-        s.serialize_field("team_folder_ids", &self.team_folder_ids)
+        s.serialize_field("team_folder_ids", &self.team_folder_ids)?;
+        Ok(())
     }
 }
 
@@ -24807,7 +25120,8 @@ impl TeamFolderListArg {
         s: &mut S::SerializeStruct,
     ) -> Result<(), S::Error> {
         use serde::ser::SerializeStruct;
-        s.serialize_field("limit", &self.limit)
+        s.serialize_field("limit", &self.limit)?;
+        Ok(())
     }
 }
 
@@ -24897,7 +25211,8 @@ impl TeamFolderListContinueArg {
         s: &mut S::SerializeStruct,
     ) -> Result<(), S::Error> {
         use serde::ser::SerializeStruct;
-        s.serialize_field("cursor", &self.cursor)
+        s.serialize_field("cursor", &self.cursor)?;
+        Ok(())
     }
 }
 
@@ -25053,7 +25368,8 @@ impl TeamFolderListError {
         s: &mut S::SerializeStruct,
     ) -> Result<(), S::Error> {
         use serde::ser::SerializeStruct;
-        s.serialize_field("access_error", &self.access_error)
+        s.serialize_field("access_error", &self.access_error)?;
+        Ok(())
     }
 }
 
@@ -25182,7 +25498,8 @@ impl TeamFolderListResult {
         use serde::ser::SerializeStruct;
         s.serialize_field("team_folders", &self.team_folders)?;
         s.serialize_field("cursor", &self.cursor)?;
-        s.serialize_field("has_more", &self.has_more)
+        s.serialize_field("has_more", &self.has_more)?;
+        Ok(())
     }
 }
 
@@ -25345,7 +25662,8 @@ impl TeamFolderMetadata {
         s.serialize_field("status", &self.status)?;
         s.serialize_field("is_team_shared_dropbox", &self.is_team_shared_dropbox)?;
         s.serialize_field("sync_setting", &self.sync_setting)?;
-        s.serialize_field("content_sync_settings", &self.content_sync_settings)
+        s.serialize_field("content_sync_settings", &self.content_sync_settings)?;
+        Ok(())
     }
 }
 
@@ -25564,7 +25882,8 @@ impl TeamFolderRenameArg {
     ) -> Result<(), S::Error> {
         use serde::ser::SerializeStruct;
         s.serialize_field("team_folder_id", &self.team_folder_id)?;
-        s.serialize_field("name", &self.name)
+        s.serialize_field("name", &self.name)?;
+        Ok(())
     }
 }
 
@@ -25983,8 +26302,13 @@ impl TeamFolderUpdateSyncSettingsArg {
     ) -> Result<(), S::Error> {
         use serde::ser::SerializeStruct;
         s.serialize_field("team_folder_id", &self.team_folder_id)?;
-        s.serialize_field("sync_setting", &self.sync_setting)?;
-        s.serialize_field("content_sync_settings", &self.content_sync_settings)
+        if let Some(val) = &self.sync_setting {
+            s.serialize_field("sync_setting", val)?;
+        }
+        if let Some(val) = &self.content_sync_settings {
+            s.serialize_field("content_sync_settings", val)?;
+        }
+        Ok(())
     }
 }
 
@@ -26265,7 +26589,8 @@ impl TeamGetInfoResult {
         s.serialize_field("team_id", &self.team_id)?;
         s.serialize_field("num_licensed_users", &self.num_licensed_users)?;
         s.serialize_field("num_provisioned_users", &self.num_provisioned_users)?;
-        s.serialize_field("policies", &self.policies)
+        s.serialize_field("policies", &self.policies)?;
+        Ok(())
     }
 }
 
@@ -26369,7 +26694,8 @@ impl TeamMemberInfo {
     ) -> Result<(), S::Error> {
         use serde::ser::SerializeStruct;
         s.serialize_field("profile", &self.profile)?;
-        s.serialize_field("role", &self.role)
+        s.serialize_field("role", &self.role)?;
+        Ok(())
     }
 }
 
@@ -26478,7 +26804,10 @@ impl TeamMemberInfoV2 {
     ) -> Result<(), S::Error> {
         use serde::ser::SerializeStruct;
         s.serialize_field("profile", &self.profile)?;
-        s.serialize_field("roles", &self.roles)
+        if let Some(val) = &self.roles {
+            s.serialize_field("roles", val)?;
+        }
+        Ok(())
     }
 }
 
@@ -26570,7 +26899,8 @@ impl TeamMemberInfoV2Result {
         s: &mut S::SerializeStruct,
     ) -> Result<(), S::Error> {
         use serde::ser::SerializeStruct;
-        s.serialize_field("member_info", &self.member_info)
+        s.serialize_field("member_info", &self.member_info)?;
+        Ok(())
     }
 }
 
@@ -26923,15 +27253,34 @@ impl TeamMemberProfile {
         s.serialize_field("membership_type", &self.membership_type)?;
         s.serialize_field("groups", &self.groups)?;
         s.serialize_field("member_folder_id", &self.member_folder_id)?;
-        s.serialize_field("external_id", &self.external_id)?;
-        s.serialize_field("account_id", &self.account_id)?;
-        s.serialize_field("secondary_emails", &self.secondary_emails)?;
-        s.serialize_field("invited_on", &self.invited_on)?;
-        s.serialize_field("joined_on", &self.joined_on)?;
-        s.serialize_field("suspended_on", &self.suspended_on)?;
-        s.serialize_field("persistent_id", &self.persistent_id)?;
-        s.serialize_field("is_directory_restricted", &self.is_directory_restricted)?;
-        s.serialize_field("profile_photo_url", &self.profile_photo_url)
+        if let Some(val) = &self.external_id {
+            s.serialize_field("external_id", val)?;
+        }
+        if let Some(val) = &self.account_id {
+            s.serialize_field("account_id", val)?;
+        }
+        if let Some(val) = &self.secondary_emails {
+            s.serialize_field("secondary_emails", val)?;
+        }
+        if let Some(val) = &self.invited_on {
+            s.serialize_field("invited_on", val)?;
+        }
+        if let Some(val) = &self.joined_on {
+            s.serialize_field("joined_on", val)?;
+        }
+        if let Some(val) = &self.suspended_on {
+            s.serialize_field("suspended_on", val)?;
+        }
+        if let Some(val) = &self.persistent_id {
+            s.serialize_field("persistent_id", val)?;
+        }
+        if let Some(val) = &self.is_directory_restricted {
+            s.serialize_field("is_directory_restricted", val)?;
+        }
+        if let Some(val) = &self.profile_photo_url {
+            s.serialize_field("profile_photo_url", val)?;
+        }
+        Ok(())
     }
 }
 
@@ -27050,7 +27399,8 @@ impl TeamMemberRole {
         use serde::ser::SerializeStruct;
         s.serialize_field("role_id", &self.role_id)?;
         s.serialize_field("name", &self.name)?;
-        s.serialize_field("description", &self.description)
+        s.serialize_field("description", &self.description)?;
+        Ok(())
     }
 }
 
@@ -27279,7 +27629,8 @@ impl TeamNamespacesListArg {
         s: &mut S::SerializeStruct,
     ) -> Result<(), S::Error> {
         use serde::ser::SerializeStruct;
-        s.serialize_field("limit", &self.limit)
+        s.serialize_field("limit", &self.limit)?;
+        Ok(())
     }
 }
 
@@ -27369,7 +27720,8 @@ impl TeamNamespacesListContinueArg {
         s: &mut S::SerializeStruct,
     ) -> Result<(), S::Error> {
         use serde::ser::SerializeStruct;
-        s.serialize_field("cursor", &self.cursor)
+        s.serialize_field("cursor", &self.cursor)?;
+        Ok(())
     }
 }
 
@@ -27632,7 +27984,8 @@ impl TeamNamespacesListResult {
         use serde::ser::SerializeStruct;
         s.serialize_field("namespaces", &self.namespaces)?;
         s.serialize_field("cursor", &self.cursor)?;
-        s.serialize_field("has_more", &self.has_more)
+        s.serialize_field("has_more", &self.has_more)?;
+        Ok(())
     }
 }
 
@@ -27882,7 +28235,8 @@ impl TokenGetAuthenticatedAdminResult {
         s: &mut S::SerializeStruct,
     ) -> Result<(), S::Error> {
         use serde::ser::SerializeStruct;
-        s.serialize_field("admin_profile", &self.admin_profile)
+        s.serialize_field("admin_profile", &self.admin_profile)?;
+        Ok(())
     }
 }
 
@@ -28168,7 +28522,8 @@ impl UserCustomQuotaArg {
     ) -> Result<(), S::Error> {
         use serde::ser::SerializeStruct;
         s.serialize_field("user", &self.user)?;
-        s.serialize_field("quota_gb", &self.quota_gb)
+        s.serialize_field("quota_gb", &self.quota_gb)?;
+        Ok(())
     }
 }
 
@@ -28276,7 +28631,10 @@ impl UserCustomQuotaResult {
     ) -> Result<(), S::Error> {
         use serde::ser::SerializeStruct;
         s.serialize_field("user", &self.user)?;
-        s.serialize_field("quota_gb", &self.quota_gb)
+        if let Some(val) = &self.quota_gb {
+            s.serialize_field("quota_gb", val)?;
+        }
+        Ok(())
     }
 }
 
@@ -28377,7 +28735,8 @@ impl UserDeleteEmailsResult {
     ) -> Result<(), S::Error> {
         use serde::ser::SerializeStruct;
         s.serialize_field("user", &self.user)?;
-        s.serialize_field("results", &self.results)
+        s.serialize_field("results", &self.results)?;
+        Ok(())
     }
 }
 
@@ -28554,7 +28913,8 @@ impl UserResendEmailsResult {
     ) -> Result<(), S::Error> {
         use serde::ser::SerializeStruct;
         s.serialize_field("user", &self.user)?;
-        s.serialize_field("results", &self.results)
+        s.serialize_field("results", &self.results)?;
+        Ok(())
     }
 }
 
@@ -28732,7 +29092,8 @@ impl UserSecondaryEmailsArg {
     ) -> Result<(), S::Error> {
         use serde::ser::SerializeStruct;
         s.serialize_field("user", &self.user)?;
-        s.serialize_field("secondary_emails", &self.secondary_emails)
+        s.serialize_field("secondary_emails", &self.secondary_emails)?;
+        Ok(())
     }
 }
 
@@ -28833,7 +29194,8 @@ impl UserSecondaryEmailsResult {
     ) -> Result<(), S::Error> {
         use serde::ser::SerializeStruct;
         s.serialize_field("user", &self.user)?;
-        s.serialize_field("results", &self.results)
+        s.serialize_field("results", &self.results)?;
+        Ok(())
     }
 }
 

--- a/src/generated/team_common.rs
+++ b/src/generated/team_common.rs
@@ -212,8 +212,13 @@ impl GroupSummary {
         s.serialize_field("group_name", &self.group_name)?;
         s.serialize_field("group_id", &self.group_id)?;
         s.serialize_field("group_management_type", &self.group_management_type)?;
-        s.serialize_field("group_external_id", &self.group_external_id)?;
-        s.serialize_field("member_count", &self.member_count)
+        if let Some(val) = &self.group_external_id {
+            s.serialize_field("group_external_id", val)?;
+        }
+        if let Some(val) = &self.member_count {
+            s.serialize_field("member_count", val)?;
+        }
+        Ok(())
     }
 }
 
@@ -462,8 +467,13 @@ impl TimeRange {
         s: &mut S::SerializeStruct,
     ) -> Result<(), S::Error> {
         use serde::ser::SerializeStruct;
-        s.serialize_field("start_time", &self.start_time)?;
-        s.serialize_field("end_time", &self.end_time)
+        if let Some(val) = &self.start_time {
+            s.serialize_field("start_time", val)?;
+        }
+        if let Some(val) = &self.end_time {
+            s.serialize_field("end_time", val)?;
+        }
+        Ok(())
     }
 }
 

--- a/src/generated/team_policies.rs
+++ b/src/generated/team_policies.rs
@@ -1676,7 +1676,8 @@ impl TeamMemberPolicies {
         s.serialize_field("sharing", &self.sharing)?;
         s.serialize_field("emm_state", &self.emm_state)?;
         s.serialize_field("office_addin", &self.office_addin)?;
-        s.serialize_field("suggest_members_policy", &self.suggest_members_policy)
+        s.serialize_field("suggest_members_policy", &self.suggest_members_policy)?;
+        Ok(())
     }
 }
 
@@ -1797,7 +1798,8 @@ impl TeamSharingPolicies {
         use serde::ser::SerializeStruct;
         s.serialize_field("shared_folder_member_policy", &self.shared_folder_member_policy)?;
         s.serialize_field("shared_folder_join_policy", &self.shared_folder_join_policy)?;
-        s.serialize_field("shared_link_create_policy", &self.shared_link_create_policy)
+        s.serialize_field("shared_link_create_policy", &self.shared_link_create_policy)?;
+        Ok(())
     }
 }
 

--- a/src/generated/users.rs
+++ b/src/generated/users.rs
@@ -216,7 +216,10 @@ impl Account {
         s.serialize_field("email", &self.email)?;
         s.serialize_field("email_verified", &self.email_verified)?;
         s.serialize_field("disabled", &self.disabled)?;
-        s.serialize_field("profile_photo_url", &self.profile_photo_url)
+        if let Some(val) = &self.profile_photo_url {
+            s.serialize_field("profile_photo_url", val)?;
+        }
+        Ok(())
     }
 }
 
@@ -417,8 +420,13 @@ impl BasicAccount {
         s.serialize_field("email_verified", &self.email_verified)?;
         s.serialize_field("disabled", &self.disabled)?;
         s.serialize_field("is_teammate", &self.is_teammate)?;
-        s.serialize_field("profile_photo_url", &self.profile_photo_url)?;
-        s.serialize_field("team_member_id", &self.team_member_id)
+        if let Some(val) = &self.profile_photo_url {
+            s.serialize_field("profile_photo_url", val)?;
+        }
+        if let Some(val) = &self.team_member_id {
+            s.serialize_field("team_member_id", val)?;
+        }
+        Ok(())
     }
 }
 
@@ -775,10 +783,19 @@ impl FullAccount {
         s.serialize_field("is_paired", &self.is_paired)?;
         s.serialize_field("account_type", &self.account_type)?;
         s.serialize_field("root_info", &self.root_info)?;
-        s.serialize_field("profile_photo_url", &self.profile_photo_url)?;
-        s.serialize_field("country", &self.country)?;
-        s.serialize_field("team", &self.team)?;
-        s.serialize_field("team_member_id", &self.team_member_id)
+        if let Some(val) = &self.profile_photo_url {
+            s.serialize_field("profile_photo_url", val)?;
+        }
+        if let Some(val) = &self.country {
+            s.serialize_field("country", val)?;
+        }
+        if let Some(val) = &self.team {
+            s.serialize_field("team", val)?;
+        }
+        if let Some(val) = &self.team_member_id {
+            s.serialize_field("team_member_id", val)?;
+        }
+        Ok(())
     }
 }
 
@@ -913,7 +930,8 @@ impl FullTeam {
         s.serialize_field("id", &self.id)?;
         s.serialize_field("name", &self.name)?;
         s.serialize_field("sharing_policies", &self.sharing_policies)?;
-        s.serialize_field("office_addin_policy", &self.office_addin_policy)
+        s.serialize_field("office_addin_policy", &self.office_addin_policy)?;
+        Ok(())
     }
 }
 
@@ -1003,7 +1021,8 @@ impl GetAccountArg {
         s: &mut S::SerializeStruct,
     ) -> Result<(), S::Error> {
         use serde::ser::SerializeStruct;
-        s.serialize_field("account_id", &self.account_id)
+        s.serialize_field("account_id", &self.account_id)?;
+        Ok(())
     }
 }
 
@@ -1093,7 +1112,8 @@ impl GetAccountBatchArg {
         s: &mut S::SerializeStruct,
     ) -> Result<(), S::Error> {
         use serde::ser::SerializeStruct;
-        s.serialize_field("account_ids", &self.account_ids)
+        s.serialize_field("account_ids", &self.account_ids)?;
+        Ok(())
     }
 }
 
@@ -1322,7 +1342,8 @@ impl IndividualSpaceAllocation {
         s: &mut S::SerializeStruct,
     ) -> Result<(), S::Error> {
         use serde::ser::SerializeStruct;
-        s.serialize_field("allocated", &self.allocated)
+        s.serialize_field("allocated", &self.allocated)?;
+        Ok(())
     }
 }
 
@@ -1472,7 +1493,8 @@ impl Name {
         s.serialize_field("surname", &self.surname)?;
         s.serialize_field("familiar_name", &self.familiar_name)?;
         s.serialize_field("display_name", &self.display_name)?;
-        s.serialize_field("abbreviated_name", &self.abbreviated_name)
+        s.serialize_field("abbreviated_name", &self.abbreviated_name)?;
+        Ok(())
     }
 }
 
@@ -1710,7 +1732,8 @@ impl SpaceUsage {
     ) -> Result<(), S::Error> {
         use serde::ser::SerializeStruct;
         s.serialize_field("used", &self.used)?;
-        s.serialize_field("allocation", &self.allocation)
+        s.serialize_field("allocation", &self.allocation)?;
+        Ok(())
     }
 }
 
@@ -1814,7 +1837,8 @@ impl Team {
     ) -> Result<(), S::Error> {
         use serde::ser::SerializeStruct;
         s.serialize_field("id", &self.id)?;
-        s.serialize_field("name", &self.name)
+        s.serialize_field("name", &self.name)?;
+        Ok(())
     }
 }
 
@@ -1963,7 +1987,8 @@ impl TeamSpaceAllocation {
         s.serialize_field("allocated", &self.allocated)?;
         s.serialize_field("user_within_team_space_allocated", &self.user_within_team_space_allocated)?;
         s.serialize_field("user_within_team_space_limit_type", &self.user_within_team_space_limit_type)?;
-        s.serialize_field("user_within_team_space_used_cached", &self.user_within_team_space_used_cached)
+        s.serialize_field("user_within_team_space_used_cached", &self.user_within_team_space_used_cached)?;
+        Ok(())
     }
 }
 
@@ -2198,7 +2223,8 @@ impl UserFeaturesGetValuesBatchArg {
         s: &mut S::SerializeStruct,
     ) -> Result<(), S::Error> {
         use serde::ser::SerializeStruct;
-        s.serialize_field("features", &self.features)
+        s.serialize_field("features", &self.features)?;
+        Ok(())
     }
 }
 
@@ -2352,7 +2378,8 @@ impl UserFeaturesGetValuesBatchResult {
         s: &mut S::SerializeStruct,
     ) -> Result<(), S::Error> {
         use serde::ser::SerializeStruct;
-        s.serialize_field("values", &self.values)
+        s.serialize_field("values", &self.values)?;
+        Ok(())
     }
 }
 


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description below.
-->

This changes how structs with optional fields are serialized. Previously, fields whose value was set to `None` were serialized in the JSON as `null`. This works, but is unnecessarily verbose, but the bigger deal is that it isn't accepted by our deserializer code.

With this change, we skip writing these fields entirely.

Now, we could fix the deserializers to accept `null` for `Option` fields, but for now let's just stop using `null` entirely. We can always add that support later if there's a good reason to.

This also beefs up the tests by adding test cases for structs which omit all the optional fields, which is how I verified this works correctly. These tests will also be good for catching compatibility issues in the future.

## **Checklist**

**General Contributing**
<!-- Change [ ] to [x] if you have: -->
- [x] I have read the Code of Conduct and signed the [CLA](https://opensource.dropbox.com/cla/).
- [x] I have added an entry to the `RELEASE_NOTES.md` file, or believe it's not necessary for this change.

**Validation**
<!-- Describe which tests cover the changes you've made, and any additional manual validation you
     did to ensure the correctness of this change. Does this change warrant addition of new tests?
     Does this change have performance implications? Etc. -->
test change included