### PR TITLE
Fix Authorization Refresh

### DIFF
--- a/src/client_helpers.rs
+++ b/src/client_helpers.rs
@@ -11,7 +11,7 @@ use serde::ser::Serialize;
 /// When Dropbox returns an error with HTTP 409 or 429, it uses an implicit JSON object with the
 /// following structure, which contains the actual error as a field.
 #[derive(Debug, Deserialize)]
-struct TopLevelError<T> {
+pub(crate) struct TopLevelError<T> {
     pub error: T,
 
     // It also has these fields, which we don't expose anywhere:

--- a/src/oauth2.rs
+++ b/src/oauth2.rs
@@ -331,7 +331,7 @@ impl Authorization {
             AuthorizationState::InitialAuth { .. } => None,
             AuthorizationState::AccessToken(access_token) =>
                 Some(format!("1&{}", access_token)),
-            AuthorizationState::Refresh { client_id: _, refresh_token, .. } =>
+            AuthorizationState::Refresh { refresh_token, .. } =>
                 Some(format!("2&{}", refresh_token)),
         }
     }

--- a/src/oauth2.rs
+++ b/src/oauth2.rs
@@ -459,7 +459,6 @@ impl Authorization {
         debug!("OAuth2 response: {:?}", result_json);
 
         let access_token: String;
-        let refresh_token: Option<String>;
 
         match result_json {
             serde_json::Value::Object(mut map) => {
@@ -472,7 +471,7 @@ impl Authorization {
                     Some(_) => {
                         return Err(Error::UnexpectedResponse("refresh token is not a string!"));
                     },
-                    None => refresh_token = None,
+                    _ => {}
                 }
             },
             _ => return Err(Error::UnexpectedResponse("response is not a JSON object")),


### PR DESCRIPTION
## **Checklist**

**General Contributing**
- [x] I have read the Code of Conduct and signed the [CLA](https://opensource.dropbox.com/cla/).
> ~Link to CLA is broken? I got a 403 forbidden trying to visit it~
- [ ] I have added an entry to the `RELEASE_NOTES.md` file, or believe it's not necessary for this change.
> Feature is currently breaking for PKCE workflow

**Validation**
No new tests have been added.

## Fixes

Hey thanks for having this crate available to everyone! 

This PR fixes refresh token flow, with the caveat that it ~currently breaks PKCE flow by always requiring a `client_secret`~ changes the api of `Authorization::from_auth_code`.

Really it fixes two things:

1. As pointed out in #85, the `client_secret` is never set in [`obtain_access_token`](https://github.com/dropbox/dropbox-sdk-rust/blob/4fd0bf64084bbedde54300d5b33d20c72d075848/src/oauth2.rs#L381), causing the request to fail every time. This PR takes the hammer approach by forcing you to have a `client_secret` for the `AuthorizationState::Refresh`. The [`unwrap` here](https://github.com/rusty-jules/dropbox-sdk-rust/blob/559df7c7c399c7ad13fa97c24c27de20cfd60cac/src/oauth2.rs#L484) breaks PKCE flow since a `client_secret` should not be required or sent over the wire for that (that's the whole point, right?). This is really what makes this PR unmergable, so open to suggestions on how to work this out! I haven't been using PKCE myself.

2. As pointed out in #88, the `UserAuthDefaultClient` never actually obtained a new `access_token` when Dropbox returns an `ExpiredAccessToken` error, making `refresh_tokens` moot after expiration of the initial `TokenCache` `access_token`. This was because the error is not actually parsed to the an `AuthError` as expected [from the `$inner.request`](https://github.com/rusty-jules/dropbox-sdk-rust/blob/fae1b5e76ea5f8ee13b70c9a0da8f7dfcb27c537/src/default_client.rs#L67), it always returned `UnexpectedHttpError` only to parse it later. This fix is not actually breaking and should be totally encapsulated in the second commit. Feel free to cherry pick!

~Sorry I couldn't check off the Contribution checklist. More than open to the cla when it's made available.~
Cheers!