### PR TITLE
Establish a MSRV (minimum supported Rust version)

### DIFF
--- a/.github/workflows/cargo-test.yml
+++ b/.github/workflows/cargo-test.yml
@@ -28,6 +28,18 @@ jobs:
       - name: Check generated files against repo
         run: if [[ ! -z `git status --porcelain=v1` ]]; then echo "::error::Workspace is dirty after running generator. Did you remember to check in the generated files?"; exit 1; fi
 
+      - name: Install MSRV toolchain
+        uses: actions-rs/toolchain@v1.0.7
+        with:
+          profile: minimal
+          toolchain: 1.56.1
+          override: true
+
+      - name: Run cargo test
+        uses: actions-rs/cargo@v1.0.3
+        with:
+          command: test
+
       - name: Install nightly toolchain
         uses: actions-rs/toolchain@v1.0.7
         with:
@@ -41,15 +53,3 @@ jobs:
         with:
           command: clippy
           args: --all-targets --all-features -- --deny warnings
-
-      - name: Install stable toolchain
-        uses: actions-rs/toolchain@v1.0.7
-        with:
-          profile: minimal
-          toolchain: stable
-          override: true
-
-      - name: Run cargo test
-        uses: actions-rs/cargo@v1.0.3
-        with:
-          command: test

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,11 @@ repository = "https://github.com/dropbox/dropbox-sdk-rust"
 license = "Apache-2.0"
 readme = "README.md"
 
+[package.metadata]
+# Keep this at least 1 year old.
+# 1.56 is the first version with support for 2021 edition
+msrv = "1.56.1" # October 21, 2021
+
 [dependencies]
 atty = "0.2.14"
 base64 = "0.13"

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -4,6 +4,7 @@ xxxx-yy-zz
     * files: SearchOptions has new field account_id
     * sharing, team_log, team_policies additions
     * new namespace: openid
+* Established 1.56.1 as the MSRV (minimum supported Rust version)
 
 # v0.15.0
 2022-06-14

--- a/clippy.toml
+++ b/clippy.toml
@@ -1,2 +1,5 @@
 # Additional words to be allowed without backticks by the `doc_markdown` lint.
 doc-valid-idents = ["OAuth2"]
+
+# Don't warn about things that can't be used in this version.
+msrv = "1.56.1"

--- a/examples/demo.rs
+++ b/examples/demo.rs
@@ -73,7 +73,7 @@ fn main() {
                                 break 'download;
                             }
                             Ok(len) => {
-                                bytes_out += len as u64;
+                                bytes_out += len;
                                 if let Some(total) = download_result.content_length {
                                     eprint!("\r{:.01}%",
                                         bytes_out as f64 / total as f64 * 100.);

--- a/tests/noop_client.rs
+++ b/tests/noop_client.rs
@@ -20,7 +20,7 @@ macro_rules! noop_client {
                     _range_start: Option<u64>,
                     _range_end: Option<u64>,
                 ) -> dropbox_sdk::Result<HttpRequestResultRaw> {
-                    Err(dropbox_sdk::Error::HttpClient(Box::new(super::ErrMsg(format!("noop client called on {function}")))))
+                    Err(dropbox_sdk::Error::HttpClient(Box::new(super::ErrMsg(format!("noop client called on {}", function)))))
                 }
             }
         }


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description below.
-->

I used `cargo-msrv` to figure out what the current oldest rustc able to compile the project is, and it's 1.56.1, from October 2021. Going forward, I think it'd be good to ensure this is buildable using a Rust toolchain that's at least a year old.

This is motivated by Clippy adding lints for things that are only supported on fairly recent Rust. (In this case, it's inline variables in format strings.) We can disable those lints by adding a MSRV. Also it's just a good practice in general to be up-front about compiler support.

## **Checklist**

**General Contributing**
<!-- Change [ ] to [x] if you have: -->
- [x] I have read the Code of Conduct and signed the [CLA](https://opensource.dropbox.com/cla/).
- [x] I have added an entry to the `RELEASE_NOTES.md` file, or believe it's not necessary for this change.

**Validation**
<!-- Describe which tests cover the changes you've made, and any additional manual validation you
     did to ensure the correctness of this change. Does this change warrant addition of new tests?
     Does this change have performance implications? Etc. -->
I changed the GitHub tests to use the MSRV rust instead of the current Stable rust.