### PR TITLE
Fixes for Python 3.11

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ msrv = "1.57.0" # Dec 2, 2021
 [dependencies]
 atty = "0.2.14"
 base64 = "0.21"
-log = "0.4"
+log = "0.4, <0.4.19" # 0.4.19 requires rustc 1.60
 ring = "0.16"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -2,6 +2,7 @@
 xxxx-yy-zz
 * API spec update 2022-06-15, 2022-07-13, 2022-10-11, 2022-11-09
 * Established 1.56.1 as the MSRV (minimum supported Rust version)
+* Fix test generator under Python 3.11
 
 # v0.15.0
 2022-06-14

--- a/examples/demo.rs
+++ b/examples/demo.rs
@@ -181,7 +181,7 @@ impl<'a, T: UserAuthClient> Iterator for DirectoryIterator<'a, T> {
         } else if let Some(cursor) = self.cursor.take() {
             match files::list_folder_continue(self.client, &files::ListFolderContinueArg::new(cursor)) {
                 Ok(Ok(result)) => {
-                    self.buffer.extend(result.entries.into_iter());
+                    self.buffer.extend(result.entries);
                     if result.has_more {
                         self.cursor = Some(result.cursor);
                     }

--- a/generator/test.stoneg.py
+++ b/generator/test.stoneg.py
@@ -4,6 +4,12 @@ import re
 import string
 import sys
 
+try:
+    import re._parser as sre_parse
+except ImportError:    # Python < 3.11
+    import sre_parse
+
+
 from rust import RustHelperBackend, REQUIRED_NAMESPACES
 from stone import ir
 from stone.backends.python_helpers import fmt_class as fmt_py_class
@@ -506,7 +512,7 @@ class Unregex(object):
     def __init__(self, regex_string, min_len=None):
         self._min_len = min_len
         self._group_refs = {}
-        self._tokens = re.sre_parse.parse(regex_string)
+        self._tokens = sre_parse.parse(regex_string)
 
     def generate(self):
         return self._generate(self._tokens)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -103,14 +103,8 @@ pub use generated::*;
 
 /// A special error type for a method that doesn't have any defined error return. You can't
 /// actually encounter a value of this type in real life; it's here to satisfy type requirements.
-#[derive(Copy)]
+#[derive(Copy, Clone)]
 pub enum NoError {}
-
-impl Clone for NoError {
-    fn clone(&self) -> NoError {
-        unreachable(*self)
-    }
-}
 
 impl std::cmp::PartialEq<NoError> for NoError {
     fn eq(&self, _: &NoError) -> bool {


### PR DESCRIPTION
The test generator uses some internals of Python's regex module which got renamed in Python 3.11. Ideally we'd not use this, as apparently it's supposed to be private and may eventually get removed, but replacing it is not trivial and it's pretty important functionality, so for now just adapt to the new name and cross our fingers that it stays around.

While I'm at it, I updated the Stone SDK submodule (it hasn't been updated in a long time), and fixed a couple Clippy lints.

## **Checklist**

**General Contributing**
<!-- Change [ ] to [x] if you have: -->
- [x] I have read the Code of Conduct and signed the [CLA](https://opensource.dropbox.com/cla/).
- [x] I have added an entry to the `RELEASE_NOTES.md` file, or believe it's not necessary for this change.

**Validation**
<!-- Describe which tests cover the changes you've made, and any additional manual validation you
     did to ensure the correctness of this change. Does this change warrant addition of new tests?
     Does this change have performance implications? Etc. -->
Test generator works now, and tests pass.