### PR TITLE
Omit default values and nulls when serializing, accept nulls when deserializing

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,7 +1,8 @@
 # v0.16.1
 xxxx-yy-zz
 * MSRV raised to 1.63.0
-* Omit fields with null or default value in more places when serializing
+* Omit fields with null or default value in more places when serializing, and accept nulls when
+  deserializing.
 
 # v0.16.0
 2023-08-13

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,6 +1,7 @@
 # v0.16.1
 xxxx-yy-zz
 * MSRV raised to 1.63.0
+* Omit fields with null or default value in more places when serializing
 
 # v0.16.0
 2023-08-13

--- a/generator/rust.stoneg.py
+++ b/generator/rust.stoneg.py
@@ -536,8 +536,7 @@ class RustBackend(RustHelperBackend):
                         self.emit('let mut s = serializer.serialize_struct('
                                   f'"{type_name}", {len(subtype.data_type.all_fields) + 1})?;')
                         self.emit(f's.serialize_field(".tag", "{subtype.name}")?;')
-                        for field in subtype.data_type.all_fields:
-                            self.emit(f's.serialize_field("{field.name}", &x.{self.field_name(field)})?;')
+                        self.emit('x.internal_serialize::<S>(&mut s)?;')
                         self.emit('s.end()')
                 if struct.is_catch_all():
                     self.emit(f'{type_name}::Other => Err(::serde::ser::Error::custom('

--- a/generator/rust.stoneg.py
+++ b/generator/rust.stoneg.py
@@ -409,7 +409,11 @@ class RustBackend(RustHelperBackend):
                         for field in struct.all_fields:
                             field_name = self.field_name(field)
                             if isinstance(field.data_type, ir.Nullable):
-                                self.emit(f'{field_name}: field_{field_name},')
+                                # None -> field is not present
+                                # Some(None) -> field is present with null value
+                                # Some(Some(x)) -> field is present and non-null
+                                # First two are equivalent here, hence Option::flatten().
+                                self.emit(f'{field_name}: field_{field_name}.and_then(Option::flatten),')
                             elif field.has_default:
                                 default_value = self._default_value(field)
                                 if isinstance(field.data_type, ir.String) \

--- a/src/generated/auth.rs
+++ b/src/generated/auth.rs
@@ -505,7 +505,9 @@ impl RateLimitError {
     ) -> Result<(), S::Error> {
         use serde::ser::SerializeStruct;
         s.serialize_field("reason", &self.reason)?;
-        s.serialize_field("retry_after", &self.retry_after)?;
+        if self.retry_after != 1 {
+            s.serialize_field("retry_after", &self.retry_after)?;
+        }
         Ok(())
     }
 }

--- a/src/generated/check.rs
+++ b/src/generated/check.rs
@@ -99,7 +99,9 @@ impl EchoArg {
         s: &mut S::SerializeStruct,
     ) -> Result<(), S::Error> {
         use serde::ser::SerializeStruct;
-        s.serialize_field("query", &self.query)?;
+        if !self.query.is_empty() {
+            s.serialize_field("query", &self.query)?;
+        }
         Ok(())
     }
 }
@@ -179,7 +181,9 @@ impl EchoResult {
         s: &mut S::SerializeStruct,
     ) -> Result<(), S::Error> {
         use serde::ser::SerializeStruct;
-        s.serialize_field("result", &self.result)?;
+        if !self.result.is_empty() {
+            s.serialize_field("result", &self.result)?;
+        }
         Ok(())
     }
 }

--- a/src/generated/common.rs
+++ b/src/generated/common.rs
@@ -249,16 +249,13 @@ impl ::serde::ser::Serialize for RootInfo {
             RootInfo::Team(ref x) => {
                 let mut s = serializer.serialize_struct("RootInfo", 4)?;
                 s.serialize_field(".tag", "team")?;
-                s.serialize_field("root_namespace_id", &x.root_namespace_id)?;
-                s.serialize_field("home_namespace_id", &x.home_namespace_id)?;
-                s.serialize_field("home_path", &x.home_path)?;
+                x.internal_serialize::<S>(&mut s)?;
                 s.end()
             }
             RootInfo::User(ref x) => {
                 let mut s = serializer.serialize_struct("RootInfo", 3)?;
                 s.serialize_field(".tag", "user")?;
-                s.serialize_field("root_namespace_id", &x.root_namespace_id)?;
-                s.serialize_field("home_namespace_id", &x.home_namespace_id)?;
+                x.internal_serialize::<S>(&mut s)?;
                 s.end()
             }
             RootInfo::Other => Err(::serde::ser::Error::custom("cannot serialize unknown variant"))

--- a/src/generated/file_properties.rs
+++ b/src/generated/file_properties.rs
@@ -2559,7 +2559,7 @@ impl PropertiesSearchResult {
         }
         let result = PropertiesSearchResult {
             matches: field_matches.ok_or_else(|| ::serde::de::Error::missing_field("matches"))?,
-            cursor: field_cursor,
+            cursor: field_cursor.and_then(Option::flatten),
         };
         Ok(Some(result))
     }
@@ -3142,8 +3142,8 @@ impl PropertyGroupUpdate {
         }
         let result = PropertyGroupUpdate {
             template_id: field_template_id.ok_or_else(|| ::serde::de::Error::missing_field("template_id"))?,
-            add_or_update_fields: field_add_or_update_fields,
-            remove_fields: field_remove_fields,
+            add_or_update_fields: field_add_or_update_fields.and_then(Option::flatten),
+            remove_fields: field_remove_fields.and_then(Option::flatten),
         };
         Ok(Some(result))
     }
@@ -4243,9 +4243,9 @@ impl UpdateTemplateArg {
         }
         let result = UpdateTemplateArg {
             template_id: field_template_id.ok_or_else(|| ::serde::de::Error::missing_field("template_id"))?,
-            name: field_name,
-            description: field_description,
-            add_fields: field_add_fields,
+            name: field_name.and_then(Option::flatten),
+            description: field_description.and_then(Option::flatten),
+            add_fields: field_add_fields.and_then(Option::flatten),
         };
         Ok(Some(result))
     }

--- a/src/generated/file_properties.rs
+++ b/src/generated/file_properties.rs
@@ -1901,7 +1901,9 @@ impl PropertiesSearchArg {
     ) -> Result<(), S::Error> {
         use serde::ser::SerializeStruct;
         s.serialize_field("queries", &self.queries)?;
-        s.serialize_field("template_filter", &self.template_filter)?;
+        if self.template_filter != TemplateFilter::FilterNone {
+            s.serialize_field("template_filter", &self.template_filter)?;
+        }
         Ok(())
     }
 }
@@ -2456,7 +2458,9 @@ impl PropertiesSearchQuery {
         use serde::ser::SerializeStruct;
         s.serialize_field("query", &self.query)?;
         s.serialize_field("mode", &self.mode)?;
-        s.serialize_field("logical_operator", &self.logical_operator)?;
+        if self.logical_operator != LogicalOperator::OrOperator {
+            s.serialize_field("logical_operator", &self.logical_operator)?;
+        }
         Ok(())
     }
 }

--- a/src/generated/file_requests.rs
+++ b/src/generated/file_requests.rs
@@ -430,7 +430,9 @@ impl CreateFileRequestArgs {
         if let Some(val) = &self.deadline {
             s.serialize_field("deadline", val)?;
         }
-        s.serialize_field("open", &self.open)?;
+        if !self.open {
+            s.serialize_field("open", &self.open)?;
+        }
         if let Some(val) = &self.description {
             s.serialize_field("description", val)?;
         }
@@ -2106,7 +2108,9 @@ impl ListFileRequestsArg {
         s: &mut S::SerializeStruct,
     ) -> Result<(), S::Error> {
         use serde::ser::SerializeStruct;
-        s.serialize_field("limit", &self.limit)?;
+        if self.limit != 1000 {
+            s.serialize_field("limit", &self.limit)?;
+        }
         Ok(())
     }
 }
@@ -2743,7 +2747,9 @@ impl UpdateFileRequestArgs {
         if let Some(val) = &self.destination {
             s.serialize_field("destination", val)?;
         }
-        s.serialize_field("deadline", &self.deadline)?;
+        if self.deadline != UpdateFileRequestDeadline::NoUpdate {
+            s.serialize_field("deadline", &self.deadline)?;
+        }
         if let Some(val) = &self.open {
             s.serialize_field("open", val)?;
         }

--- a/src/generated/file_requests.rs
+++ b/src/generated/file_requests.rs
@@ -413,9 +413,9 @@ impl CreateFileRequestArgs {
         let result = CreateFileRequestArgs {
             title: field_title.ok_or_else(|| ::serde::de::Error::missing_field("title"))?,
             destination: field_destination.ok_or_else(|| ::serde::de::Error::missing_field("destination"))?,
-            deadline: field_deadline,
+            deadline: field_deadline.and_then(Option::flatten),
             open: field_open.unwrap_or(true),
-            description: field_description,
+            description: field_description.and_then(Option::flatten),
         };
         Ok(Some(result))
     }
@@ -1358,9 +1358,9 @@ impl FileRequest {
             created: field_created.ok_or_else(|| ::serde::de::Error::missing_field("created"))?,
             is_open: field_is_open.ok_or_else(|| ::serde::de::Error::missing_field("is_open"))?,
             file_count: field_file_count.ok_or_else(|| ::serde::de::Error::missing_field("file_count"))?,
-            destination: field_destination,
-            deadline: field_deadline,
-            description: field_description,
+            destination: field_destination.and_then(Option::flatten),
+            deadline: field_deadline.and_then(Option::flatten),
+            description: field_description.and_then(Option::flatten),
         };
         Ok(Some(result))
     }
@@ -1483,7 +1483,7 @@ impl FileRequestDeadline {
         }
         let result = FileRequestDeadline {
             deadline: field_deadline.ok_or_else(|| ::serde::de::Error::missing_field("deadline"))?,
-            allow_late_uploads: field_allow_late_uploads,
+            allow_late_uploads: field_allow_late_uploads.and_then(Option::flatten),
         };
         Ok(Some(result))
     }
@@ -2726,11 +2726,11 @@ impl UpdateFileRequestArgs {
         }
         let result = UpdateFileRequestArgs {
             id: field_id.ok_or_else(|| ::serde::de::Error::missing_field("id"))?,
-            title: field_title,
-            destination: field_destination,
+            title: field_title.and_then(Option::flatten),
+            destination: field_destination.and_then(Option::flatten),
             deadline: field_deadline.unwrap_or(UpdateFileRequestDeadline::NoUpdate),
-            open: field_open,
-            description: field_description,
+            open: field_open.and_then(Option::flatten),
+            description: field_description.and_then(Option::flatten),
         };
         Ok(Some(result))
     }

--- a/src/generated/files.rs
+++ b/src/generated/files.rs
@@ -1730,9 +1730,15 @@ impl AlphaGetMetadataArg {
     ) -> Result<(), S::Error> {
         use serde::ser::SerializeStruct;
         s.serialize_field("path", &self.path)?;
-        s.serialize_field("include_media_info", &self.include_media_info)?;
-        s.serialize_field("include_deleted", &self.include_deleted)?;
-        s.serialize_field("include_has_explicit_shared_members", &self.include_has_explicit_shared_members)?;
+        if self.include_media_info {
+            s.serialize_field("include_media_info", &self.include_media_info)?;
+        }
+        if self.include_deleted {
+            s.serialize_field("include_deleted", &self.include_deleted)?;
+        }
+        if self.include_has_explicit_shared_members {
+            s.serialize_field("include_has_explicit_shared_members", &self.include_has_explicit_shared_members)?;
+        }
         if let Some(val) = &self.include_property_groups {
             s.serialize_field("include_property_groups", val)?;
         }
@@ -2113,16 +2119,24 @@ impl CommitInfo {
     ) -> Result<(), S::Error> {
         use serde::ser::SerializeStruct;
         s.serialize_field("path", &self.path)?;
-        s.serialize_field("mode", &self.mode)?;
-        s.serialize_field("autorename", &self.autorename)?;
+        if self.mode != WriteMode::Add {
+            s.serialize_field("mode", &self.mode)?;
+        }
+        if self.autorename {
+            s.serialize_field("autorename", &self.autorename)?;
+        }
         if let Some(val) = &self.client_modified {
             s.serialize_field("client_modified", val)?;
         }
-        s.serialize_field("mute", &self.mute)?;
+        if self.mute {
+            s.serialize_field("mute", &self.mute)?;
+        }
         if let Some(val) = &self.property_groups {
             s.serialize_field("property_groups", val)?;
         }
-        s.serialize_field("strict_conflict", &self.strict_conflict)?;
+        if self.strict_conflict {
+            s.serialize_field("strict_conflict", &self.strict_conflict)?;
+        }
         Ok(())
     }
 }
@@ -2440,7 +2454,9 @@ impl CreateFolderArg {
     ) -> Result<(), S::Error> {
         use serde::ser::SerializeStruct;
         s.serialize_field("path", &self.path)?;
-        s.serialize_field("autorename", &self.autorename)?;
+        if self.autorename {
+            s.serialize_field("autorename", &self.autorename)?;
+        }
         Ok(())
     }
 }
@@ -2568,8 +2584,12 @@ impl CreateFolderBatchArg {
     ) -> Result<(), S::Error> {
         use serde::ser::SerializeStruct;
         s.serialize_field("paths", &self.paths)?;
-        s.serialize_field("autorename", &self.autorename)?;
-        s.serialize_field("force_async", &self.force_async)?;
+        if self.autorename {
+            s.serialize_field("autorename", &self.autorename)?;
+        }
+        if self.force_async {
+            s.serialize_field("force_async", &self.force_async)?;
+        }
         Ok(())
     }
 }
@@ -6381,7 +6401,9 @@ impl FileMetadata {
         if let Some(val) = &self.sharing_info {
             s.serialize_field("sharing_info", val)?;
         }
-        s.serialize_field("is_downloadable", &self.is_downloadable)?;
+        if !self.is_downloadable {
+            s.serialize_field("is_downloadable", &self.is_downloadable)?;
+        }
         if let Some(val) = &self.export_info {
             s.serialize_field("export_info", val)?;
         }
@@ -7055,8 +7077,12 @@ impl FolderSharingInfo {
         if let Some(val) = &self.shared_folder_id {
             s.serialize_field("shared_folder_id", val)?;
         }
-        s.serialize_field("traverse_only", &self.traverse_only)?;
-        s.serialize_field("no_access", &self.no_access)?;
+        if self.traverse_only {
+            s.serialize_field("traverse_only", &self.traverse_only)?;
+        }
+        if self.no_access {
+            s.serialize_field("no_access", &self.no_access)?;
+        }
         Ok(())
     }
 }
@@ -7514,9 +7540,15 @@ impl GetMetadataArg {
     ) -> Result<(), S::Error> {
         use serde::ser::SerializeStruct;
         s.serialize_field("path", &self.path)?;
-        s.serialize_field("include_media_info", &self.include_media_info)?;
-        s.serialize_field("include_deleted", &self.include_deleted)?;
-        s.serialize_field("include_has_explicit_shared_members", &self.include_has_explicit_shared_members)?;
+        if self.include_media_info {
+            s.serialize_field("include_media_info", &self.include_media_info)?;
+        }
+        if self.include_deleted {
+            s.serialize_field("include_deleted", &self.include_deleted)?;
+        }
+        if self.include_has_explicit_shared_members {
+            s.serialize_field("include_has_explicit_shared_members", &self.include_has_explicit_shared_members)?;
+        }
         if let Some(val) = &self.include_property_groups {
             s.serialize_field("include_property_groups", val)?;
         }
@@ -8191,7 +8223,9 @@ impl GetTemporaryUploadLinkArg {
     ) -> Result<(), S::Error> {
         use serde::ser::SerializeStruct;
         s.serialize_field("commit_info", &self.commit_info)?;
-        s.serialize_field("duration", &self.duration)?;
+        if self.duration != 14400.0 {
+            s.serialize_field("duration", &self.duration)?;
+        }
         Ok(())
     }
 }
@@ -9249,11 +9283,21 @@ impl ListFolderArg {
     ) -> Result<(), S::Error> {
         use serde::ser::SerializeStruct;
         s.serialize_field("path", &self.path)?;
-        s.serialize_field("recursive", &self.recursive)?;
-        s.serialize_field("include_media_info", &self.include_media_info)?;
-        s.serialize_field("include_deleted", &self.include_deleted)?;
-        s.serialize_field("include_has_explicit_shared_members", &self.include_has_explicit_shared_members)?;
-        s.serialize_field("include_mounted_folders", &self.include_mounted_folders)?;
+        if self.recursive {
+            s.serialize_field("recursive", &self.recursive)?;
+        }
+        if self.include_media_info {
+            s.serialize_field("include_media_info", &self.include_media_info)?;
+        }
+        if self.include_deleted {
+            s.serialize_field("include_deleted", &self.include_deleted)?;
+        }
+        if self.include_has_explicit_shared_members {
+            s.serialize_field("include_has_explicit_shared_members", &self.include_has_explicit_shared_members)?;
+        }
+        if !self.include_mounted_folders {
+            s.serialize_field("include_mounted_folders", &self.include_mounted_folders)?;
+        }
         if let Some(val) = &self.limit {
             s.serialize_field("limit", val)?;
         }
@@ -9263,7 +9307,9 @@ impl ListFolderArg {
         if let Some(val) = &self.include_property_groups {
             s.serialize_field("include_property_groups", val)?;
         }
-        s.serialize_field("include_non_downloadable_files", &self.include_non_downloadable_files)?;
+        if !self.include_non_downloadable_files {
+            s.serialize_field("include_non_downloadable_files", &self.include_non_downloadable_files)?;
+        }
         Ok(())
     }
 }
@@ -9747,7 +9793,9 @@ impl ListFolderLongpollArg {
     ) -> Result<(), S::Error> {
         use serde::ser::SerializeStruct;
         s.serialize_field("cursor", &self.cursor)?;
-        s.serialize_field("timeout", &self.timeout)?;
+        if self.timeout != 30 {
+            s.serialize_field("timeout", &self.timeout)?;
+        }
         Ok(())
     }
 }
@@ -10170,8 +10218,12 @@ impl ListRevisionsArg {
     ) -> Result<(), S::Error> {
         use serde::ser::SerializeStruct;
         s.serialize_field("path", &self.path)?;
-        s.serialize_field("mode", &self.mode)?;
-        s.serialize_field("limit", &self.limit)?;
+        if self.mode != ListRevisionsMode::Path {
+            s.serialize_field("mode", &self.mode)?;
+        }
+        if self.limit != 10 {
+            s.serialize_field("limit", &self.limit)?;
+        }
         Ok(())
     }
 }
@@ -11804,8 +11856,12 @@ impl MoveBatchArg {
     ) -> Result<(), S::Error> {
         use serde::ser::SerializeStruct;
         s.serialize_field("entries", &self.entries)?;
-        s.serialize_field("autorename", &self.autorename)?;
-        s.serialize_field("allow_ownership_transfer", &self.allow_ownership_transfer)?;
+        if self.autorename {
+            s.serialize_field("autorename", &self.autorename)?;
+        }
+        if self.allow_ownership_transfer {
+            s.serialize_field("allow_ownership_transfer", &self.allow_ownership_transfer)?;
+        }
         Ok(())
     }
 }
@@ -13669,9 +13725,15 @@ impl RelocationArg {
         use serde::ser::SerializeStruct;
         s.serialize_field("from_path", &self.from_path)?;
         s.serialize_field("to_path", &self.to_path)?;
-        s.serialize_field("allow_shared_folder", &self.allow_shared_folder)?;
-        s.serialize_field("autorename", &self.autorename)?;
-        s.serialize_field("allow_ownership_transfer", &self.allow_ownership_transfer)?;
+        if self.allow_shared_folder {
+            s.serialize_field("allow_shared_folder", &self.allow_shared_folder)?;
+        }
+        if self.autorename {
+            s.serialize_field("autorename", &self.autorename)?;
+        }
+        if self.allow_ownership_transfer {
+            s.serialize_field("allow_ownership_transfer", &self.allow_ownership_transfer)?;
+        }
         Ok(())
     }
 }
@@ -13816,9 +13878,15 @@ impl RelocationBatchArg {
     ) -> Result<(), S::Error> {
         use serde::ser::SerializeStruct;
         s.serialize_field("entries", &self.entries)?;
-        s.serialize_field("autorename", &self.autorename)?;
-        s.serialize_field("allow_shared_folder", &self.allow_shared_folder)?;
-        s.serialize_field("allow_ownership_transfer", &self.allow_ownership_transfer)?;
+        if self.autorename {
+            s.serialize_field("autorename", &self.autorename)?;
+        }
+        if self.allow_shared_folder {
+            s.serialize_field("allow_shared_folder", &self.allow_shared_folder)?;
+        }
+        if self.allow_ownership_transfer {
+            s.serialize_field("allow_ownership_transfer", &self.allow_ownership_transfer)?;
+        }
         Ok(())
     }
 }
@@ -13928,7 +13996,9 @@ impl RelocationBatchArgBase {
     ) -> Result<(), S::Error> {
         use serde::ser::SerializeStruct;
         s.serialize_field("entries", &self.entries)?;
-        s.serialize_field("autorename", &self.autorename)?;
+        if self.autorename {
+            s.serialize_field("autorename", &self.autorename)?;
+        }
         Ok(())
     }
 }
@@ -16617,9 +16687,15 @@ impl SearchArg {
         use serde::ser::SerializeStruct;
         s.serialize_field("path", &self.path)?;
         s.serialize_field("query", &self.query)?;
-        s.serialize_field("start", &self.start)?;
-        s.serialize_field("max_results", &self.max_results)?;
-        s.serialize_field("mode", &self.mode)?;
+        if self.start != 0 {
+            s.serialize_field("start", &self.start)?;
+        }
+        if self.max_results != 100 {
+            s.serialize_field("max_results", &self.max_results)?;
+        }
+        if self.mode != SearchMode::Filename {
+            s.serialize_field("mode", &self.mode)?;
+        }
         Ok(())
     }
 }
@@ -16913,7 +16989,9 @@ impl SearchMatchFieldOptions {
         s: &mut S::SerializeStruct,
     ) -> Result<(), S::Error> {
         use serde::ser::SerializeStruct;
-        s.serialize_field("include_highlights", &self.include_highlights)?;
+        if self.include_highlights {
+            s.serialize_field("include_highlights", &self.include_highlights)?;
+        }
         Ok(())
     }
 }
@@ -17481,12 +17559,18 @@ impl SearchOptions {
         if let Some(val) = &self.path {
             s.serialize_field("path", val)?;
         }
-        s.serialize_field("max_results", &self.max_results)?;
+        if self.max_results != 100 {
+            s.serialize_field("max_results", &self.max_results)?;
+        }
         if let Some(val) = &self.order_by {
             s.serialize_field("order_by", val)?;
         }
-        s.serialize_field("file_status", &self.file_status)?;
-        s.serialize_field("filename_only", &self.filename_only)?;
+        if self.file_status != FileStatus::Active {
+            s.serialize_field("file_status", &self.file_status)?;
+        }
+        if self.filename_only {
+            s.serialize_field("filename_only", &self.filename_only)?;
+        }
         if let Some(val) = &self.file_extensions {
             s.serialize_field("file_extensions", val)?;
         }
@@ -19049,9 +19133,15 @@ impl ThumbnailArg {
     ) -> Result<(), S::Error> {
         use serde::ser::SerializeStruct;
         s.serialize_field("path", &self.path)?;
-        s.serialize_field("format", &self.format)?;
-        s.serialize_field("size", &self.size)?;
-        s.serialize_field("mode", &self.mode)?;
+        if self.format != ThumbnailFormat::Jpeg {
+            s.serialize_field("format", &self.format)?;
+        }
+        if self.size != ThumbnailSize::W64h64 {
+            s.serialize_field("size", &self.size)?;
+        }
+        if self.mode != ThumbnailMode::Strict {
+            s.serialize_field("mode", &self.mode)?;
+        }
         Ok(())
     }
 }
@@ -19557,9 +19647,15 @@ impl ThumbnailV2Arg {
     ) -> Result<(), S::Error> {
         use serde::ser::SerializeStruct;
         s.serialize_field("resource", &self.resource)?;
-        s.serialize_field("format", &self.format)?;
-        s.serialize_field("size", &self.size)?;
-        s.serialize_field("mode", &self.mode)?;
+        if self.format != ThumbnailFormat::Jpeg {
+            s.serialize_field("format", &self.format)?;
+        }
+        if self.size != ThumbnailSize::W64h64 {
+            s.serialize_field("size", &self.size)?;
+        }
+        if self.mode != ThumbnailMode::Strict {
+            s.serialize_field("mode", &self.mode)?;
+        }
         Ok(())
     }
 }
@@ -20103,16 +20199,24 @@ impl UploadArg {
     ) -> Result<(), S::Error> {
         use serde::ser::SerializeStruct;
         s.serialize_field("path", &self.path)?;
-        s.serialize_field("mode", &self.mode)?;
-        s.serialize_field("autorename", &self.autorename)?;
+        if self.mode != WriteMode::Add {
+            s.serialize_field("mode", &self.mode)?;
+        }
+        if self.autorename {
+            s.serialize_field("autorename", &self.autorename)?;
+        }
         if let Some(val) = &self.client_modified {
             s.serialize_field("client_modified", val)?;
         }
-        s.serialize_field("mute", &self.mute)?;
+        if self.mute {
+            s.serialize_field("mute", &self.mute)?;
+        }
         if let Some(val) = &self.property_groups {
             s.serialize_field("property_groups", val)?;
         }
-        s.serialize_field("strict_conflict", &self.strict_conflict)?;
+        if self.strict_conflict {
+            s.serialize_field("strict_conflict", &self.strict_conflict)?;
+        }
         if let Some(val) = &self.content_hash {
             s.serialize_field("content_hash", val)?;
         }
@@ -20359,7 +20463,9 @@ impl UploadSessionAppendArg {
     ) -> Result<(), S::Error> {
         use serde::ser::SerializeStruct;
         s.serialize_field("cursor", &self.cursor)?;
-        s.serialize_field("close", &self.close)?;
+        if self.close {
+            s.serialize_field("close", &self.close)?;
+        }
         if let Some(val) = &self.content_hash {
             s.serialize_field("content_hash", val)?;
         }
@@ -21694,7 +21800,9 @@ impl UploadSessionStartArg {
         s: &mut S::SerializeStruct,
     ) -> Result<(), S::Error> {
         use serde::ser::SerializeStruct;
-        s.serialize_field("close", &self.close)?;
+        if self.close {
+            s.serialize_field("close", &self.close)?;
+        }
         if let Some(val) = &self.session_type {
             s.serialize_field("session_type", val)?;
         }

--- a/src/generated/files.rs
+++ b/src/generated/files.rs
@@ -11423,18 +11423,13 @@ impl ::serde::ser::Serialize for MediaMetadata {
             MediaMetadata::Photo(ref x) => {
                 let mut s = serializer.serialize_struct("MediaMetadata", 4)?;
                 s.serialize_field(".tag", "photo")?;
-                s.serialize_field("dimensions", &x.dimensions)?;
-                s.serialize_field("location", &x.location)?;
-                s.serialize_field("time_taken", &x.time_taken)?;
+                x.internal_serialize::<S>(&mut s)?;
                 s.end()
             }
             MediaMetadata::Video(ref x) => {
                 let mut s = serializer.serialize_struct("MediaMetadata", 5)?;
                 s.serialize_field(".tag", "video")?;
-                s.serialize_field("dimensions", &x.dimensions)?;
-                s.serialize_field("location", &x.location)?;
-                s.serialize_field("time_taken", &x.time_taken)?;
-                s.serialize_field("duration", &x.duration)?;
+                x.internal_serialize::<S>(&mut s)?;
                 s.end()
             }
         }
@@ -11487,49 +11482,19 @@ impl ::serde::ser::Serialize for Metadata {
             Metadata::File(ref x) => {
                 let mut s = serializer.serialize_struct("Metadata", 20)?;
                 s.serialize_field(".tag", "file")?;
-                s.serialize_field("name", &x.name)?;
-                s.serialize_field("id", &x.id)?;
-                s.serialize_field("client_modified", &x.client_modified)?;
-                s.serialize_field("server_modified", &x.server_modified)?;
-                s.serialize_field("rev", &x.rev)?;
-                s.serialize_field("size", &x.size)?;
-                s.serialize_field("path_lower", &x.path_lower)?;
-                s.serialize_field("path_display", &x.path_display)?;
-                s.serialize_field("parent_shared_folder_id", &x.parent_shared_folder_id)?;
-                s.serialize_field("preview_url", &x.preview_url)?;
-                s.serialize_field("media_info", &x.media_info)?;
-                s.serialize_field("symlink_info", &x.symlink_info)?;
-                s.serialize_field("sharing_info", &x.sharing_info)?;
-                s.serialize_field("is_downloadable", &x.is_downloadable)?;
-                s.serialize_field("export_info", &x.export_info)?;
-                s.serialize_field("property_groups", &x.property_groups)?;
-                s.serialize_field("has_explicit_shared_members", &x.has_explicit_shared_members)?;
-                s.serialize_field("content_hash", &x.content_hash)?;
-                s.serialize_field("file_lock_info", &x.file_lock_info)?;
+                x.internal_serialize::<S>(&mut s)?;
                 s.end()
             }
             Metadata::Folder(ref x) => {
                 let mut s = serializer.serialize_struct("Metadata", 10)?;
                 s.serialize_field(".tag", "folder")?;
-                s.serialize_field("name", &x.name)?;
-                s.serialize_field("id", &x.id)?;
-                s.serialize_field("path_lower", &x.path_lower)?;
-                s.serialize_field("path_display", &x.path_display)?;
-                s.serialize_field("parent_shared_folder_id", &x.parent_shared_folder_id)?;
-                s.serialize_field("preview_url", &x.preview_url)?;
-                s.serialize_field("shared_folder_id", &x.shared_folder_id)?;
-                s.serialize_field("sharing_info", &x.sharing_info)?;
-                s.serialize_field("property_groups", &x.property_groups)?;
+                x.internal_serialize::<S>(&mut s)?;
                 s.end()
             }
             Metadata::Deleted(ref x) => {
                 let mut s = serializer.serialize_struct("Metadata", 6)?;
                 s.serialize_field(".tag", "deleted")?;
-                s.serialize_field("name", &x.name)?;
-                s.serialize_field("path_lower", &x.path_lower)?;
-                s.serialize_field("path_display", &x.path_display)?;
-                s.serialize_field("parent_shared_folder_id", &x.parent_shared_folder_id)?;
-                s.serialize_field("preview_url", &x.preview_url)?;
+                x.internal_serialize::<S>(&mut s)?;
                 s.end()
             }
         }

--- a/src/generated/files.rs
+++ b/src/generated/files.rs
@@ -1718,8 +1718,8 @@ impl AlphaGetMetadataArg {
             include_media_info: field_include_media_info.unwrap_or(false),
             include_deleted: field_include_deleted.unwrap_or(false),
             include_has_explicit_shared_members: field_include_has_explicit_shared_members.unwrap_or(false),
-            include_property_groups: field_include_property_groups,
-            include_property_templates: field_include_property_templates,
+            include_property_groups: field_include_property_groups.and_then(Option::flatten),
+            include_property_templates: field_include_property_templates.and_then(Option::flatten),
         };
         Ok(Some(result))
     }
@@ -2105,9 +2105,9 @@ impl CommitInfo {
             path: field_path.ok_or_else(|| ::serde::de::Error::missing_field("path"))?,
             mode: field_mode.unwrap_or(WriteMode::Add),
             autorename: field_autorename.unwrap_or(false),
-            client_modified: field_client_modified,
+            client_modified: field_client_modified.and_then(Option::flatten),
             mute: field_mute.unwrap_or(false),
-            property_groups: field_property_groups,
+            property_groups: field_property_groups.and_then(Option::flatten),
             strict_conflict: field_strict_conflict.unwrap_or(false),
         };
         Ok(Some(result))
@@ -3402,7 +3402,7 @@ impl DeleteArg {
         }
         let result = DeleteArg {
             path: field_path.ok_or_else(|| ::serde::de::Error::missing_field("path"))?,
-            parent_rev: field_parent_rev,
+            parent_rev: field_parent_rev.and_then(Option::flatten),
         };
         Ok(Some(result))
     }
@@ -4341,10 +4341,10 @@ impl DeletedMetadata {
         }
         let result = DeletedMetadata {
             name: field_name.ok_or_else(|| ::serde::de::Error::missing_field("name"))?,
-            path_lower: field_path_lower,
-            path_display: field_path_display,
-            parent_shared_folder_id: field_parent_shared_folder_id,
-            preview_url: field_preview_url,
+            path_lower: field_path_lower.and_then(Option::flatten),
+            path_display: field_path_display.and_then(Option::flatten),
+            parent_shared_folder_id: field_parent_shared_folder_id.and_then(Option::flatten),
+            preview_url: field_preview_url.and_then(Option::flatten),
         };
         Ok(Some(result))
     }
@@ -4569,7 +4569,7 @@ impl DownloadArg {
         }
         let result = DownloadArg {
             path: field_path.ok_or_else(|| ::serde::de::Error::missing_field("path"))?,
-            rev: field_rev,
+            rev: field_rev.and_then(Option::flatten),
         };
         Ok(Some(result))
     }
@@ -5053,7 +5053,7 @@ impl ExportArg {
         }
         let result = ExportArg {
             path: field_path.ok_or_else(|| ::serde::de::Error::missing_field("path"))?,
-            export_format: field_export_format,
+            export_format: field_export_format.and_then(Option::flatten),
         };
         Ok(Some(result))
     }
@@ -5263,8 +5263,8 @@ impl ExportInfo {
             }
         }
         let result = ExportInfo {
-            export_as: field_export_as,
-            export_options: field_export_options,
+            export_as: field_export_as.and_then(Option::flatten),
+            export_options: field_export_options.and_then(Option::flatten),
         };
         Ok(result)
     }
@@ -5408,8 +5408,8 @@ impl ExportMetadata {
         let result = ExportMetadata {
             name: field_name.ok_or_else(|| ::serde::de::Error::missing_field("name"))?,
             size: field_size.ok_or_else(|| ::serde::de::Error::missing_field("size"))?,
-            export_hash: field_export_hash,
-            paper_revision: field_paper_revision,
+            export_hash: field_export_hash.and_then(Option::flatten),
+            paper_revision: field_paper_revision.and_then(Option::flatten),
         };
         Ok(Some(result))
     }
@@ -5946,10 +5946,10 @@ impl FileLockMetadata {
             }
         }
         let result = FileLockMetadata {
-            is_lockholder: field_is_lockholder,
-            lockholder_name: field_lockholder_name,
-            lockholder_account_id: field_lockholder_account_id,
-            created: field_created,
+            is_lockholder: field_is_lockholder.and_then(Option::flatten),
+            lockholder_name: field_lockholder_name.and_then(Option::flatten),
+            lockholder_account_id: field_lockholder_account_id.and_then(Option::flatten),
+            created: field_created.and_then(Option::flatten),
         };
         Ok(result)
     }
@@ -6352,19 +6352,19 @@ impl FileMetadata {
             server_modified: field_server_modified.ok_or_else(|| ::serde::de::Error::missing_field("server_modified"))?,
             rev: field_rev.ok_or_else(|| ::serde::de::Error::missing_field("rev"))?,
             size: field_size.ok_or_else(|| ::serde::de::Error::missing_field("size"))?,
-            path_lower: field_path_lower,
-            path_display: field_path_display,
-            parent_shared_folder_id: field_parent_shared_folder_id,
-            preview_url: field_preview_url,
-            media_info: field_media_info,
-            symlink_info: field_symlink_info,
-            sharing_info: field_sharing_info,
+            path_lower: field_path_lower.and_then(Option::flatten),
+            path_display: field_path_display.and_then(Option::flatten),
+            parent_shared_folder_id: field_parent_shared_folder_id.and_then(Option::flatten),
+            preview_url: field_preview_url.and_then(Option::flatten),
+            media_info: field_media_info.and_then(Option::flatten),
+            symlink_info: field_symlink_info.and_then(Option::flatten),
+            sharing_info: field_sharing_info.and_then(Option::flatten),
             is_downloadable: field_is_downloadable.unwrap_or(true),
-            export_info: field_export_info,
-            property_groups: field_property_groups,
-            has_explicit_shared_members: field_has_explicit_shared_members,
-            content_hash: field_content_hash,
-            file_lock_info: field_file_lock_info,
+            export_info: field_export_info.and_then(Option::flatten),
+            property_groups: field_property_groups.and_then(Option::flatten),
+            has_explicit_shared_members: field_has_explicit_shared_members.and_then(Option::flatten),
+            content_hash: field_content_hash.and_then(Option::flatten),
+            file_lock_info: field_file_lock_info.and_then(Option::flatten),
         };
         Ok(Some(result))
     }
@@ -6573,7 +6573,7 @@ impl FileSharingInfo {
         let result = FileSharingInfo {
             read_only: field_read_only.ok_or_else(|| ::serde::de::Error::missing_field("read_only"))?,
             parent_shared_folder_id: field_parent_shared_folder_id.ok_or_else(|| ::serde::de::Error::missing_field("parent_shared_folder_id"))?,
-            modified_by: field_modified_by,
+            modified_by: field_modified_by.and_then(Option::flatten),
         };
         Ok(Some(result))
     }
@@ -6868,13 +6868,13 @@ impl FolderMetadata {
         let result = FolderMetadata {
             name: field_name.ok_or_else(|| ::serde::de::Error::missing_field("name"))?,
             id: field_id.ok_or_else(|| ::serde::de::Error::missing_field("id"))?,
-            path_lower: field_path_lower,
-            path_display: field_path_display,
-            parent_shared_folder_id: field_parent_shared_folder_id,
-            preview_url: field_preview_url,
-            shared_folder_id: field_shared_folder_id,
-            sharing_info: field_sharing_info,
-            property_groups: field_property_groups,
+            path_lower: field_path_lower.and_then(Option::flatten),
+            path_display: field_path_display.and_then(Option::flatten),
+            parent_shared_folder_id: field_parent_shared_folder_id.and_then(Option::flatten),
+            preview_url: field_preview_url.and_then(Option::flatten),
+            shared_folder_id: field_shared_folder_id.and_then(Option::flatten),
+            sharing_info: field_sharing_info.and_then(Option::flatten),
+            property_groups: field_property_groups.and_then(Option::flatten),
         };
         Ok(Some(result))
     }
@@ -7057,8 +7057,8 @@ impl FolderSharingInfo {
         }
         let result = FolderSharingInfo {
             read_only: field_read_only.ok_or_else(|| ::serde::de::Error::missing_field("read_only"))?,
-            parent_shared_folder_id: field_parent_shared_folder_id,
-            shared_folder_id: field_shared_folder_id,
+            parent_shared_folder_id: field_parent_shared_folder_id.and_then(Option::flatten),
+            shared_folder_id: field_shared_folder_id.and_then(Option::flatten),
             traverse_only: field_traverse_only.unwrap_or(false),
             no_access: field_no_access.unwrap_or(false),
         };
@@ -7529,7 +7529,7 @@ impl GetMetadataArg {
             include_media_info: field_include_media_info.unwrap_or(false),
             include_deleted: field_include_deleted.unwrap_or(false),
             include_has_explicit_shared_members: field_include_has_explicit_shared_members.unwrap_or(false),
-            include_property_groups: field_include_property_groups,
+            include_property_groups: field_include_property_groups.and_then(Option::flatten),
         };
         Ok(Some(result))
     }
@@ -9269,9 +9269,9 @@ impl ListFolderArg {
             include_deleted: field_include_deleted.unwrap_or(false),
             include_has_explicit_shared_members: field_include_has_explicit_shared_members.unwrap_or(false),
             include_mounted_folders: field_include_mounted_folders.unwrap_or(true),
-            limit: field_limit,
-            shared_link: field_shared_link,
-            include_property_groups: field_include_property_groups,
+            limit: field_limit.and_then(Option::flatten),
+            shared_link: field_shared_link.and_then(Option::flatten),
+            include_property_groups: field_include_property_groups.and_then(Option::flatten),
             include_non_downloadable_files: field_include_non_downloadable_files.unwrap_or(true),
         };
         Ok(Some(result))
@@ -9960,7 +9960,7 @@ impl ListFolderLongpollResult {
         }
         let result = ListFolderLongpollResult {
             changes: field_changes.ok_or_else(|| ::serde::de::Error::missing_field("changes"))?,
-            backoff: field_backoff,
+            backoff: field_backoff.and_then(Option::flatten),
         };
         Ok(Some(result))
     }
@@ -10479,7 +10479,7 @@ impl ListRevisionsResult {
         let result = ListRevisionsResult {
             is_deleted: field_is_deleted.ok_or_else(|| ::serde::de::Error::missing_field("is_deleted"))?,
             entries: field_entries.ok_or_else(|| ::serde::de::Error::missing_field("entries"))?,
-            server_deleted: field_server_deleted,
+            server_deleted: field_server_deleted.and_then(Option::flatten),
         };
         Ok(Some(result))
     }
@@ -11710,8 +11710,8 @@ impl MinimalFileLinkMetadata {
         let result = MinimalFileLinkMetadata {
             url: field_url.ok_or_else(|| ::serde::de::Error::missing_field("url"))?,
             rev: field_rev.ok_or_else(|| ::serde::de::Error::missing_field("rev"))?,
-            id: field_id,
-            path: field_path,
+            id: field_id.and_then(Option::flatten),
+            path: field_path.and_then(Option::flatten),
         };
         Ok(Some(result))
     }
@@ -12690,7 +12690,7 @@ impl PaperUpdateArg {
             path: field_path.ok_or_else(|| ::serde::de::Error::missing_field("path"))?,
             import_format: field_import_format.ok_or_else(|| ::serde::de::Error::missing_field("import_format"))?,
             doc_update_policy: field_doc_update_policy.ok_or_else(|| ::serde::de::Error::missing_field("doc_update_policy"))?,
-            paper_revision: field_paper_revision,
+            paper_revision: field_paper_revision.and_then(Option::flatten),
         };
         Ok(Some(result))
     }
@@ -13228,9 +13228,9 @@ impl PhotoMetadata {
             }
         }
         let result = PhotoMetadata {
-            dimensions: field_dimensions,
-            location: field_location,
-            time_taken: field_time_taken,
+            dimensions: field_dimensions.and_then(Option::flatten),
+            location: field_location.and_then(Option::flatten),
+            time_taken: field_time_taken.and_then(Option::flatten),
         };
         Ok(result)
     }
@@ -13346,7 +13346,7 @@ impl PreviewArg {
         }
         let result = PreviewArg {
             path: field_path.ok_or_else(|| ::serde::de::Error::missing_field("path"))?,
-            rev: field_rev,
+            rev: field_rev.and_then(Option::flatten),
         };
         Ok(Some(result))
     }
@@ -13551,8 +13551,8 @@ impl PreviewResult {
             }
         }
         let result = PreviewResult {
-            file_metadata: field_file_metadata,
-            link_metadata: field_link_metadata,
+            file_metadata: field_file_metadata.and_then(Option::flatten),
+            link_metadata: field_link_metadata.and_then(Option::flatten),
         };
         Ok(result)
     }
@@ -17261,8 +17261,8 @@ impl SearchMatchV2 {
         }
         let result = SearchMatchV2 {
             metadata: field_metadata.ok_or_else(|| ::serde::de::Error::missing_field("metadata"))?,
-            match_type: field_match_type,
-            highlight_spans: field_highlight_spans,
+            match_type: field_match_type.and_then(Option::flatten),
+            highlight_spans: field_highlight_spans.and_then(Option::flatten),
         };
         Ok(Some(result))
     }
@@ -17539,14 +17539,14 @@ impl SearchOptions {
             }
         }
         let result = SearchOptions {
-            path: field_path,
+            path: field_path.and_then(Option::flatten),
             max_results: field_max_results.unwrap_or(100),
-            order_by: field_order_by,
+            order_by: field_order_by.and_then(Option::flatten),
             file_status: field_file_status.unwrap_or(FileStatus::Active),
             filename_only: field_filename_only.unwrap_or(false),
-            file_extensions: field_file_extensions,
-            file_categories: field_file_categories,
-            account_id: field_account_id,
+            file_extensions: field_file_extensions.and_then(Option::flatten),
+            file_categories: field_file_categories.and_then(Option::flatten),
+            account_id: field_account_id.and_then(Option::flatten),
         };
         Ok(result)
     }
@@ -17891,9 +17891,9 @@ impl SearchV2Arg {
         }
         let result = SearchV2Arg {
             query: field_query.ok_or_else(|| ::serde::de::Error::missing_field("query"))?,
-            options: field_options,
-            match_field_options: field_match_field_options,
-            include_highlights: field_include_highlights,
+            options: field_options.and_then(Option::flatten),
+            match_field_options: field_match_field_options.and_then(Option::flatten),
+            include_highlights: field_include_highlights.and_then(Option::flatten),
         };
         Ok(Some(result))
     }
@@ -18116,7 +18116,7 @@ impl SearchV2Result {
         let result = SearchV2Result {
             matches: field_matches.ok_or_else(|| ::serde::de::Error::missing_field("matches"))?,
             has_more: field_has_more.ok_or_else(|| ::serde::de::Error::missing_field("has_more"))?,
-            cursor: field_cursor,
+            cursor: field_cursor.and_then(Option::flatten),
         };
         Ok(Some(result))
     }
@@ -18228,7 +18228,7 @@ impl SharedLink {
         }
         let result = SharedLink {
             url: field_url.ok_or_else(|| ::serde::de::Error::missing_field("url"))?,
-            password: field_password,
+            password: field_password.and_then(Option::flatten),
         };
         Ok(Some(result))
     }
@@ -18359,8 +18359,8 @@ impl SharedLinkFileInfo {
         }
         let result = SharedLinkFileInfo {
             url: field_url.ok_or_else(|| ::serde::de::Error::missing_field("url"))?,
-            path: field_path,
-            password: field_password,
+            path: field_path.and_then(Option::flatten),
+            password: field_password.and_then(Option::flatten),
         };
         Ok(Some(result))
     }
@@ -18581,7 +18581,7 @@ impl SingleUserLock {
         let result = SingleUserLock {
             created: field_created.ok_or_else(|| ::serde::de::Error::missing_field("created"))?,
             lock_holder_account_id: field_lock_holder_account_id.ok_or_else(|| ::serde::de::Error::missing_field("lock_holder_account_id"))?,
-            lock_holder_team_id: field_lock_holder_team_id,
+            lock_holder_team_id: field_lock_holder_team_id.and_then(Option::flatten),
         };
         Ok(Some(result))
     }
@@ -20184,11 +20184,11 @@ impl UploadArg {
             path: field_path.ok_or_else(|| ::serde::de::Error::missing_field("path"))?,
             mode: field_mode.unwrap_or(WriteMode::Add),
             autorename: field_autorename.unwrap_or(false),
-            client_modified: field_client_modified,
+            client_modified: field_client_modified.and_then(Option::flatten),
             mute: field_mute.unwrap_or(false),
-            property_groups: field_property_groups,
+            property_groups: field_property_groups.and_then(Option::flatten),
             strict_conflict: field_strict_conflict.unwrap_or(false),
-            content_hash: field_content_hash,
+            content_hash: field_content_hash.and_then(Option::flatten),
         };
         Ok(Some(result))
     }
@@ -20452,7 +20452,7 @@ impl UploadSessionAppendArg {
         let result = UploadSessionAppendArg {
             cursor: field_cursor.ok_or_else(|| ::serde::de::Error::missing_field("cursor"))?,
             close: field_close.unwrap_or(false),
-            content_hash: field_content_hash,
+            content_hash: field_content_hash.and_then(Option::flatten),
         };
         Ok(Some(result))
     }
@@ -20847,7 +20847,7 @@ impl UploadSessionFinishArg {
         let result = UploadSessionFinishArg {
             cursor: field_cursor.ok_or_else(|| ::serde::de::Error::missing_field("cursor"))?,
             commit: field_commit.ok_or_else(|| ::serde::de::Error::missing_field("commit"))?,
-            content_hash: field_content_hash,
+            content_hash: field_content_hash.and_then(Option::flatten),
         };
         Ok(Some(result))
     }
@@ -21789,8 +21789,8 @@ impl UploadSessionStartArg {
         }
         let result = UploadSessionStartArg {
             close: field_close.unwrap_or(false),
-            session_type: field_session_type,
-            content_hash: field_content_hash,
+            session_type: field_session_type.and_then(Option::flatten),
+            content_hash: field_content_hash.and_then(Option::flatten),
         };
         Ok(result)
     }
@@ -21907,7 +21907,7 @@ impl UploadSessionStartBatchArg {
         }
         let result = UploadSessionStartBatchArg {
             num_sessions: field_num_sessions.ok_or_else(|| ::serde::de::Error::missing_field("num_sessions"))?,
-            session_type: field_session_type,
+            session_type: field_session_type.and_then(Option::flatten),
         };
         Ok(Some(result))
     }
@@ -22583,10 +22583,10 @@ impl VideoMetadata {
             }
         }
         let result = VideoMetadata {
-            dimensions: field_dimensions,
-            location: field_location,
-            time_taken: field_time_taken,
-            duration: field_duration,
+            dimensions: field_dimensions.and_then(Option::flatten),
+            location: field_location.and_then(Option::flatten),
+            time_taken: field_time_taken.and_then(Option::flatten),
+            duration: field_duration.and_then(Option::flatten),
         };
         Ok(result)
     }

--- a/src/generated/openid.rs
+++ b/src/generated/openid.rs
@@ -330,10 +330,10 @@ impl UserInfoResult {
             }
         }
         let result = UserInfoResult {
-            family_name: field_family_name,
-            given_name: field_given_name,
-            email: field_email,
-            email_verified: field_email_verified,
+            family_name: field_family_name.and_then(Option::flatten),
+            given_name: field_given_name.and_then(Option::flatten),
+            email: field_email.and_then(Option::flatten),
+            email_verified: field_email_verified.and_then(Option::flatten),
             iss: field_iss.unwrap_or_default(),
             sub: field_sub.unwrap_or_default(),
         };

--- a/src/generated/openid.rs
+++ b/src/generated/openid.rs
@@ -357,8 +357,12 @@ impl UserInfoResult {
         if let Some(val) = &self.email_verified {
             s.serialize_field("email_verified", val)?;
         }
-        s.serialize_field("iss", &self.iss)?;
-        s.serialize_field("sub", &self.sub)?;
+        if !self.iss.is_empty() {
+            s.serialize_field("iss", &self.iss)?;
+        }
+        if !self.sub.is_empty() {
+            s.serialize_field("sub", &self.sub)?;
+        }
         Ok(())
     }
 }

--- a/src/generated/paper.rs
+++ b/src/generated/paper.rs
@@ -463,7 +463,9 @@ impl AddMember {
     ) -> Result<(), S::Error> {
         use serde::ser::SerializeStruct;
         s.serialize_field("member", &self.member)?;
-        s.serialize_field("permission_level", &self.permission_level)?;
+        if self.permission_level != PaperDocPermissionLevel::Edit {
+            s.serialize_field("permission_level", &self.permission_level)?;
+        }
         Ok(())
     }
 }
@@ -606,7 +608,9 @@ impl AddPaperDocUser {
         if let Some(val) = &self.custom_message {
             s.serialize_field("custom_message", val)?;
         }
-        s.serialize_field("quiet", &self.quiet)?;
+        if self.quiet {
+            s.serialize_field("quiet", &self.quiet)?;
+        }
         Ok(())
     }
 }
@@ -1922,10 +1926,18 @@ impl ListPaperDocsArgs {
         s: &mut S::SerializeStruct,
     ) -> Result<(), S::Error> {
         use serde::ser::SerializeStruct;
-        s.serialize_field("filter_by", &self.filter_by)?;
-        s.serialize_field("sort_by", &self.sort_by)?;
-        s.serialize_field("sort_order", &self.sort_order)?;
-        s.serialize_field("limit", &self.limit)?;
+        if self.filter_by != ListPaperDocsFilterBy::DocsAccessed {
+            s.serialize_field("filter_by", &self.filter_by)?;
+        }
+        if self.sort_by != ListPaperDocsSortBy::Accessed {
+            s.serialize_field("sort_by", &self.sort_by)?;
+        }
+        if self.sort_order != ListPaperDocsSortOrder::Ascending {
+            s.serialize_field("sort_order", &self.sort_order)?;
+        }
+        if self.limit != 1000 {
+            s.serialize_field("limit", &self.limit)?;
+        }
         Ok(())
     }
 }
@@ -2559,7 +2571,9 @@ impl ListUsersOnFolderArgs {
     ) -> Result<(), S::Error> {
         use serde::ser::SerializeStruct;
         s.serialize_field("doc_id", &self.doc_id)?;
-        s.serialize_field("limit", &self.limit)?;
+        if self.limit != 1000 {
+            s.serialize_field("limit", &self.limit)?;
+        }
         Ok(())
     }
 }
@@ -2932,8 +2946,12 @@ impl ListUsersOnPaperDocArgs {
     ) -> Result<(), S::Error> {
         use serde::ser::SerializeStruct;
         s.serialize_field("doc_id", &self.doc_id)?;
-        s.serialize_field("limit", &self.limit)?;
-        s.serialize_field("filter_by", &self.filter_by)?;
+        if self.limit != 1000 {
+            s.serialize_field("limit", &self.limit)?;
+        }
+        if self.filter_by != UserOnPaperDocFilter::Shared {
+            s.serialize_field("filter_by", &self.filter_by)?;
+        }
         Ok(())
     }
 }

--- a/src/generated/paper.rs
+++ b/src/generated/paper.rs
@@ -592,7 +592,7 @@ impl AddPaperDocUser {
         let result = AddPaperDocUser {
             doc_id: field_doc_id.ok_or_else(|| ::serde::de::Error::missing_field("doc_id"))?,
             members: field_members.ok_or_else(|| ::serde::de::Error::missing_field("members"))?,
-            custom_message: field_custom_message,
+            custom_message: field_custom_message.and_then(Option::flatten),
             quiet: field_quiet.unwrap_or(false),
         };
         Ok(Some(result))
@@ -937,7 +937,7 @@ impl Cursor {
         }
         let result = Cursor {
             value: field_value.ok_or_else(|| ::serde::de::Error::missing_field("value"))?,
-            expiration: field_expiration,
+            expiration: field_expiration.and_then(Option::flatten),
         };
         Ok(Some(result))
     }
@@ -1507,8 +1507,8 @@ impl FoldersContainingPaperDoc {
             }
         }
         let result = FoldersContainingPaperDoc {
-            folder_sharing_policy_type: field_folder_sharing_policy_type,
-            folders: field_folders,
+            folder_sharing_policy_type: field_folder_sharing_policy_type.and_then(Option::flatten),
+            folders: field_folders.and_then(Option::flatten),
         };
         Ok(result)
     }
@@ -3478,7 +3478,7 @@ impl PaperDocCreateArgs {
         }
         let result = PaperDocCreateArgs {
             import_format: field_import_format.ok_or_else(|| ::serde::de::Error::missing_field("import_format"))?,
-            parent_folder_id: field_parent_folder_id,
+            parent_folder_id: field_parent_folder_id.and_then(Option::flatten),
         };
         Ok(Some(result))
     }
@@ -4602,8 +4602,8 @@ impl PaperFolderCreateArg {
         }
         let result = PaperFolderCreateArg {
             name: field_name.ok_or_else(|| ::serde::de::Error::missing_field("name"))?,
-            parent_folder_id: field_parent_folder_id,
-            is_team_folder: field_is_team_folder,
+            parent_folder_id: field_parent_folder_id.and_then(Option::flatten),
+            is_team_folder: field_is_team_folder.and_then(Option::flatten),
         };
         Ok(Some(result))
     }
@@ -5082,8 +5082,8 @@ impl SharingPolicy {
             }
         }
         let result = SharingPolicy {
-            public_sharing_policy: field_public_sharing_policy,
-            team_sharing_policy: field_team_sharing_policy,
+            public_sharing_policy: field_public_sharing_policy.and_then(Option::flatten),
+            team_sharing_policy: field_team_sharing_policy.and_then(Option::flatten),
         };
         Ok(result)
     }

--- a/src/generated/sharing.rs
+++ b/src/generated/sharing.rs
@@ -1076,9 +1076,15 @@ impl AddFileMemberArgs {
         if let Some(val) = &self.custom_message {
             s.serialize_field("custom_message", val)?;
         }
-        s.serialize_field("quiet", &self.quiet)?;
-        s.serialize_field("access_level", &self.access_level)?;
-        s.serialize_field("add_message_as_comment", &self.add_message_as_comment)?;
+        if self.quiet {
+            s.serialize_field("quiet", &self.quiet)?;
+        }
+        if self.access_level != AccessLevel::Viewer {
+            s.serialize_field("access_level", &self.access_level)?;
+        }
+        if self.add_message_as_comment {
+            s.serialize_field("add_message_as_comment", &self.add_message_as_comment)?;
+        }
         Ok(())
     }
 }
@@ -1338,7 +1344,9 @@ impl AddFolderMemberArg {
         use serde::ser::SerializeStruct;
         s.serialize_field("shared_folder_id", &self.shared_folder_id)?;
         s.serialize_field("members", &self.members)?;
-        s.serialize_field("quiet", &self.quiet)?;
+        if self.quiet {
+            s.serialize_field("quiet", &self.quiet)?;
+        }
         if let Some(val) = &self.custom_message {
             s.serialize_field("custom_message", val)?;
         }
@@ -1689,7 +1697,9 @@ impl AddMember {
     ) -> Result<(), S::Error> {
         use serde::ser::SerializeStruct;
         s.serialize_field("member", &self.member)?;
-        s.serialize_field("access_level", &self.access_level)?;
+        if self.access_level != AccessLevel::Viewer {
+            s.serialize_field("access_level", &self.access_level)?;
+        }
         Ok(())
     }
 }
@@ -2528,7 +2538,9 @@ impl CreateSharedLinkArg {
     ) -> Result<(), S::Error> {
         use serde::ser::SerializeStruct;
         s.serialize_field("path", &self.path)?;
-        s.serialize_field("short_url", &self.short_url)?;
+        if self.short_url {
+            s.serialize_field("short_url", &self.short_url)?;
+        }
         if let Some(val) = &self.pending_upload {
             s.serialize_field("pending_upload", val)?;
         }
@@ -6327,7 +6339,9 @@ impl GroupMembershipInfo {
         if let Some(val) = &self.initials {
             s.serialize_field("initials", val)?;
         }
-        s.serialize_field("is_inherited", &self.is_inherited)?;
+        if self.is_inherited {
+            s.serialize_field("is_inherited", &self.is_inherited)?;
+        }
         Ok(())
     }
 }
@@ -6801,7 +6815,9 @@ impl InviteeMembershipInfo {
         if let Some(val) = &self.initials {
             s.serialize_field("initials", val)?;
         }
-        s.serialize_field("is_inherited", &self.is_inherited)?;
+        if self.is_inherited {
+            s.serialize_field("is_inherited", &self.is_inherited)?;
+        }
         if let Some(val) = &self.user {
             s.serialize_field("user", val)?;
         }
@@ -8543,8 +8559,12 @@ impl ListFileMembersArg {
         if let Some(val) = &self.actions {
             s.serialize_field("actions", val)?;
         }
-        s.serialize_field("include_inherited", &self.include_inherited)?;
-        s.serialize_field("limit", &self.limit)?;
+        if !self.include_inherited {
+            s.serialize_field("include_inherited", &self.include_inherited)?;
+        }
+        if self.limit != 100 {
+            s.serialize_field("limit", &self.limit)?;
+        }
         Ok(())
     }
 }
@@ -8654,7 +8674,9 @@ impl ListFileMembersBatchArg {
     ) -> Result<(), S::Error> {
         use serde::ser::SerializeStruct;
         s.serialize_field("files", &self.files)?;
-        s.serialize_field("limit", &self.limit)?;
+        if self.limit != 10 {
+            s.serialize_field("limit", &self.limit)?;
+        }
         Ok(())
     }
 }
@@ -9343,7 +9365,9 @@ impl ListFilesArg {
         s: &mut S::SerializeStruct,
     ) -> Result<(), S::Error> {
         use serde::ser::SerializeStruct;
-        s.serialize_field("limit", &self.limit)?;
+        if self.limit != 100 {
+            s.serialize_field("limit", &self.limit)?;
+        }
         if let Some(val) = &self.actions {
             s.serialize_field("actions", val)?;
         }
@@ -9773,7 +9797,9 @@ impl ListFolderMembersArgs {
         if let Some(val) = &self.actions {
             s.serialize_field("actions", val)?;
         }
-        s.serialize_field("limit", &self.limit)?;
+        if self.limit != 1000 {
+            s.serialize_field("limit", &self.limit)?;
+        }
         Ok(())
     }
 }
@@ -10064,7 +10090,9 @@ impl ListFolderMembersCursorArg {
         if let Some(val) = &self.actions {
             s.serialize_field("actions", val)?;
         }
-        s.serialize_field("limit", &self.limit)?;
+        if self.limit != 1000 {
+            s.serialize_field("limit", &self.limit)?;
+        }
         Ok(())
     }
 }
@@ -10170,7 +10198,9 @@ impl ListFoldersArgs {
         s: &mut S::SerializeStruct,
     ) -> Result<(), S::Error> {
         use serde::ser::SerializeStruct;
-        s.serialize_field("limit", &self.limit)?;
+        if self.limit != 1000 {
+            s.serialize_field("limit", &self.limit)?;
+        }
         if let Some(val) = &self.actions {
             s.serialize_field("actions", val)?;
         }
@@ -11434,7 +11464,9 @@ impl MembershipInfo {
         if let Some(val) = &self.initials {
             s.serialize_field("initials", val)?;
         }
-        s.serialize_field("is_inherited", &self.is_inherited)?;
+        if self.is_inherited {
+            s.serialize_field("is_inherited", &self.is_inherited)?;
+        }
         Ok(())
     }
 }
@@ -11556,7 +11588,9 @@ impl ModifySharedLinkSettingsArgs {
         use serde::ser::SerializeStruct;
         s.serialize_field("url", &self.url)?;
         s.serialize_field("settings", &self.settings)?;
-        s.serialize_field("remove_expiration", &self.remove_expiration)?;
+        if self.remove_expiration {
+            s.serialize_field("remove_expiration", &self.remove_expiration)?;
+        }
         Ok(())
     }
 }
@@ -12740,7 +12774,9 @@ impl RelinquishFolderMembershipArg {
     ) -> Result<(), S::Error> {
         use serde::ser::SerializeStruct;
         s.serialize_field("shared_folder_id", &self.shared_folder_id)?;
-        s.serialize_field("leave_a_copy", &self.leave_a_copy)?;
+        if self.leave_a_copy {
+            s.serialize_field("leave_a_copy", &self.leave_a_copy)?;
+        }
         Ok(())
     }
 }
@@ -14041,7 +14077,9 @@ impl SetAccessInheritanceArg {
     ) -> Result<(), S::Error> {
         use serde::ser::SerializeStruct;
         s.serialize_field("shared_folder_id", &self.shared_folder_id)?;
-        s.serialize_field("access_inheritance", &self.access_inheritance)?;
+        if self.access_inheritance != AccessInheritance::Inherit {
+            s.serialize_field("access_inheritance", &self.access_inheritance)?;
+        }
         Ok(())
     }
 }
@@ -14368,7 +14406,9 @@ impl ShareFolderArg {
         if let Some(val) = &self.acl_update_policy {
             s.serialize_field("acl_update_policy", val)?;
         }
-        s.serialize_field("force_async", &self.force_async)?;
+        if self.force_async {
+            s.serialize_field("force_async", &self.force_async)?;
+        }
         if let Some(val) = &self.member_policy {
             s.serialize_field("member_policy", val)?;
         }
@@ -14378,7 +14418,9 @@ impl ShareFolderArg {
         if let Some(val) = &self.viewer_info_policy {
             s.serialize_field("viewer_info_policy", val)?;
         }
-        s.serialize_field("access_inheritance", &self.access_inheritance)?;
+        if self.access_inheritance != AccessInheritance::Inherit {
+            s.serialize_field("access_inheritance", &self.access_inheritance)?;
+        }
         if let Some(val) = &self.actions {
             s.serialize_field("actions", val)?;
         }
@@ -14584,7 +14626,9 @@ impl ShareFolderArgBase {
         if let Some(val) = &self.acl_update_policy {
             s.serialize_field("acl_update_policy", val)?;
         }
-        s.serialize_field("force_async", &self.force_async)?;
+        if self.force_async {
+            s.serialize_field("force_async", &self.force_async)?;
+        }
         if let Some(val) = &self.member_policy {
             s.serialize_field("member_policy", val)?;
         }
@@ -14594,7 +14638,9 @@ impl ShareFolderArgBase {
         if let Some(val) = &self.viewer_info_policy {
             s.serialize_field("viewer_info_policy", val)?;
         }
-        s.serialize_field("access_inheritance", &self.access_inheritance)?;
+        if self.access_inheritance != AccessInheritance::Inherit {
+            s.serialize_field("access_inheritance", &self.access_inheritance)?;
+        }
         Ok(())
     }
 }
@@ -16849,7 +16895,9 @@ impl SharedFolderMetadata {
         if let Some(val) = &self.permissions {
             s.serialize_field("permissions", val)?;
         }
-        s.serialize_field("access_inheritance", &self.access_inheritance)?;
+        if self.access_inheritance != AccessInheritance::Inherit {
+            s.serialize_field("access_inheritance", &self.access_inheritance)?;
+        }
         Ok(())
     }
 }
@@ -18804,7 +18852,9 @@ impl UnshareFolderArg {
     ) -> Result<(), S::Error> {
         use serde::ser::SerializeStruct;
         s.serialize_field("shared_folder_id", &self.shared_folder_id)?;
-        s.serialize_field("leave_a_copy", &self.leave_a_copy)?;
+        if self.leave_a_copy {
+            s.serialize_field("leave_a_copy", &self.leave_a_copy)?;
+        }
         Ok(())
     }
 }
@@ -19846,7 +19896,9 @@ impl UserFileMembershipInfo {
         if let Some(val) = &self.initials {
             s.serialize_field("initials", val)?;
         }
-        s.serialize_field("is_inherited", &self.is_inherited)?;
+        if self.is_inherited {
+            s.serialize_field("is_inherited", &self.is_inherited)?;
+        }
         if let Some(val) = &self.time_last_seen {
             s.serialize_field("time_last_seen", val)?;
         }
@@ -20175,7 +20227,9 @@ impl UserMembershipInfo {
         if let Some(val) = &self.initials {
             s.serialize_field("initials", val)?;
         }
-        s.serialize_field("is_inherited", &self.is_inherited)?;
+        if self.is_inherited {
+            s.serialize_field("is_inherited", &self.is_inherited)?;
+        }
         Ok(())
     }
 }

--- a/src/generated/sharing.rs
+++ b/src/generated/sharing.rs
@@ -7658,18 +7658,13 @@ impl ::serde::ser::Serialize for LinkMetadata {
             LinkMetadata::Path(ref x) => {
                 let mut s = serializer.serialize_struct("LinkMetadata", 5)?;
                 s.serialize_field(".tag", "path")?;
-                s.serialize_field("url", &x.url)?;
-                s.serialize_field("visibility", &x.visibility)?;
-                s.serialize_field("path", &x.path)?;
-                s.serialize_field("expires", &x.expires)?;
+                x.internal_serialize::<S>(&mut s)?;
                 s.end()
             }
             LinkMetadata::Collection(ref x) => {
                 let mut s = serializer.serialize_struct("LinkMetadata", 4)?;
                 s.serialize_field(".tag", "collection")?;
-                s.serialize_field("url", &x.url)?;
-                s.serialize_field("visibility", &x.visibility)?;
-                s.serialize_field("expires", &x.expires)?;
+                x.internal_serialize::<S>(&mut s)?;
                 s.end()
             }
             LinkMetadata::Other => Err(::serde::ser::Error::custom("cannot serialize unknown variant"))
@@ -17430,31 +17425,13 @@ impl ::serde::ser::Serialize for SharedLinkMetadata {
             SharedLinkMetadata::File(ref x) => {
                 let mut s = serializer.serialize_struct("SharedLinkMetadata", 13)?;
                 s.serialize_field(".tag", "file")?;
-                s.serialize_field("url", &x.url)?;
-                s.serialize_field("name", &x.name)?;
-                s.serialize_field("link_permissions", &x.link_permissions)?;
-                s.serialize_field("client_modified", &x.client_modified)?;
-                s.serialize_field("server_modified", &x.server_modified)?;
-                s.serialize_field("rev", &x.rev)?;
-                s.serialize_field("size", &x.size)?;
-                s.serialize_field("id", &x.id)?;
-                s.serialize_field("expires", &x.expires)?;
-                s.serialize_field("path_lower", &x.path_lower)?;
-                s.serialize_field("team_member_info", &x.team_member_info)?;
-                s.serialize_field("content_owner_team_info", &x.content_owner_team_info)?;
+                x.internal_serialize::<S>(&mut s)?;
                 s.end()
             }
             SharedLinkMetadata::Folder(ref x) => {
                 let mut s = serializer.serialize_struct("SharedLinkMetadata", 9)?;
                 s.serialize_field(".tag", "folder")?;
-                s.serialize_field("url", &x.url)?;
-                s.serialize_field("name", &x.name)?;
-                s.serialize_field("link_permissions", &x.link_permissions)?;
-                s.serialize_field("id", &x.id)?;
-                s.serialize_field("expires", &x.expires)?;
-                s.serialize_field("path_lower", &x.path_lower)?;
-                s.serialize_field("team_member_info", &x.team_member_info)?;
-                s.serialize_field("content_owner_team_info", &x.content_owner_team_info)?;
+                x.internal_serialize::<S>(&mut s)?;
                 s.end()
             }
             SharedLinkMetadata::Other => Err(::serde::ser::Error::custom("cannot serialize unknown variant"))

--- a/src/generated/sharing.rs
+++ b/src/generated/sharing.rs
@@ -1058,7 +1058,7 @@ impl AddFileMemberArgs {
         let result = AddFileMemberArgs {
             file: field_file.ok_or_else(|| ::serde::de::Error::missing_field("file"))?,
             members: field_members.ok_or_else(|| ::serde::de::Error::missing_field("members"))?,
-            custom_message: field_custom_message,
+            custom_message: field_custom_message.and_then(Option::flatten),
             quiet: field_quiet.unwrap_or(false),
             access_level: field_access_level.unwrap_or(AccessLevel::Viewer),
             add_message_as_comment: field_add_message_as_comment.unwrap_or(false),
@@ -1332,7 +1332,7 @@ impl AddFolderMemberArg {
             shared_folder_id: field_shared_folder_id.ok_or_else(|| ::serde::de::Error::missing_field("shared_folder_id"))?,
             members: field_members.ok_or_else(|| ::serde::de::Error::missing_field("members"))?,
             quiet: field_quiet.unwrap_or(false),
-            custom_message: field_custom_message,
+            custom_message: field_custom_message.and_then(Option::flatten),
         };
         Ok(Some(result))
     }
@@ -2396,7 +2396,7 @@ impl CollectionLinkMetadata {
         let result = CollectionLinkMetadata {
             url: field_url.ok_or_else(|| ::serde::de::Error::missing_field("url"))?,
             visibility: field_visibility.ok_or_else(|| ::serde::de::Error::missing_field("visibility"))?,
-            expires: field_expires,
+            expires: field_expires.and_then(Option::flatten),
         };
         Ok(Some(result))
     }
@@ -2527,7 +2527,7 @@ impl CreateSharedLinkArg {
         let result = CreateSharedLinkArg {
             path: field_path.ok_or_else(|| ::serde::de::Error::missing_field("path"))?,
             short_url: field_short_url.unwrap_or(false),
-            pending_upload: field_pending_upload,
+            pending_upload: field_pending_upload.and_then(Option::flatten),
         };
         Ok(Some(result))
     }
@@ -2720,7 +2720,7 @@ impl CreateSharedLinkWithSettingsArg {
         }
         let result = CreateSharedLinkWithSettingsArg {
             path: field_path.ok_or_else(|| ::serde::de::Error::missing_field("path"))?,
-            settings: field_settings,
+            settings: field_settings.and_then(Option::flatten),
         };
         Ok(Some(result))
     }
@@ -3049,9 +3049,9 @@ impl ExpectedSharedContentLinkMetadata {
             current_audience: field_current_audience.ok_or_else(|| ::serde::de::Error::missing_field("current_audience"))?,
             link_permissions: field_link_permissions.ok_or_else(|| ::serde::de::Error::missing_field("link_permissions"))?,
             password_protected: field_password_protected.ok_or_else(|| ::serde::de::Error::missing_field("password_protected"))?,
-            access_level: field_access_level,
-            audience_restricting_shared_folder: field_audience_restricting_shared_folder,
-            expiry: field_expiry,
+            access_level: field_access_level.and_then(Option::flatten),
+            audience_restricting_shared_folder: field_audience_restricting_shared_folder.and_then(Option::flatten),
+            expiry: field_expiry.and_then(Option::flatten),
         };
         Ok(Some(result))
     }
@@ -3586,11 +3586,11 @@ impl FileLinkMetadata {
             server_modified: field_server_modified.ok_or_else(|| ::serde::de::Error::missing_field("server_modified"))?,
             rev: field_rev.ok_or_else(|| ::serde::de::Error::missing_field("rev"))?,
             size: field_size.ok_or_else(|| ::serde::de::Error::missing_field("size"))?,
-            id: field_id,
-            expires: field_expires,
-            path_lower: field_path_lower,
-            team_member_info: field_team_member_info,
-            content_owner_team_info: field_content_owner_team_info,
+            id: field_id.and_then(Option::flatten),
+            expires: field_expires.and_then(Option::flatten),
+            path_lower: field_path_lower.and_then(Option::flatten),
+            team_member_info: field_team_member_info.and_then(Option::flatten),
+            content_owner_team_info: field_content_owner_team_info.and_then(Option::flatten),
         };
         Ok(Some(result))
     }
@@ -3941,8 +3941,8 @@ impl FileMemberActionResult {
         let result = FileMemberActionResult {
             member: field_member.ok_or_else(|| ::serde::de::Error::missing_field("member"))?,
             result: field_result.ok_or_else(|| ::serde::de::Error::missing_field("result"))?,
-            sckey_sha1: field_sckey_sha1,
-            invitation_signature: field_invitation_signature,
+            sckey_sha1: field_sckey_sha1.and_then(Option::flatten),
+            invitation_signature: field_invitation_signature.and_then(Option::flatten),
         };
         Ok(Some(result))
     }
@@ -4143,7 +4143,7 @@ impl FilePermission {
         let result = FilePermission {
             action: field_action.ok_or_else(|| ::serde::de::Error::missing_field("action"))?,
             allow: field_allow.ok_or_else(|| ::serde::de::Error::missing_field("allow"))?,
-            reason: field_reason,
+            reason: field_reason.and_then(Option::flatten),
         };
         Ok(Some(result))
     }
@@ -4534,11 +4534,11 @@ impl FolderLinkMetadata {
             url: field_url.ok_or_else(|| ::serde::de::Error::missing_field("url"))?,
             name: field_name.ok_or_else(|| ::serde::de::Error::missing_field("name"))?,
             link_permissions: field_link_permissions.ok_or_else(|| ::serde::de::Error::missing_field("link_permissions"))?,
-            id: field_id,
-            expires: field_expires,
-            path_lower: field_path_lower,
-            team_member_info: field_team_member_info,
-            content_owner_team_info: field_content_owner_team_info,
+            id: field_id.and_then(Option::flatten),
+            expires: field_expires.and_then(Option::flatten),
+            path_lower: field_path_lower.and_then(Option::flatten),
+            team_member_info: field_team_member_info.and_then(Option::flatten),
+            content_owner_team_info: field_content_owner_team_info.and_then(Option::flatten),
         };
         Ok(Some(result))
     }
@@ -4677,7 +4677,7 @@ impl FolderPermission {
         let result = FolderPermission {
             action: field_action.ok_or_else(|| ::serde::de::Error::missing_field("action"))?,
             allow: field_allow.ok_or_else(|| ::serde::de::Error::missing_field("allow"))?,
-            reason: field_reason,
+            reason: field_reason.and_then(Option::flatten),
         };
         Ok(Some(result))
     }
@@ -4838,9 +4838,9 @@ impl FolderPolicy {
         let result = FolderPolicy {
             acl_update_policy: field_acl_update_policy.ok_or_else(|| ::serde::de::Error::missing_field("acl_update_policy"))?,
             shared_link_policy: field_shared_link_policy.ok_or_else(|| ::serde::de::Error::missing_field("shared_link_policy"))?,
-            member_policy: field_member_policy,
-            resolved_member_policy: field_resolved_member_policy,
-            viewer_info_policy: field_viewer_info_policy,
+            member_policy: field_member_policy.and_then(Option::flatten),
+            resolved_member_policy: field_resolved_member_policy.and_then(Option::flatten),
+            viewer_info_policy: field_viewer_info_policy.and_then(Option::flatten),
         };
         Ok(Some(result))
     }
@@ -4961,7 +4961,7 @@ impl GetFileMetadataArg {
         }
         let result = GetFileMetadataArg {
             file: field_file.ok_or_else(|| ::serde::de::Error::missing_field("file"))?,
-            actions: field_actions,
+            actions: field_actions.and_then(Option::flatten),
         };
         Ok(Some(result))
     }
@@ -5075,7 +5075,7 @@ impl GetFileMetadataBatchArg {
         }
         let result = GetFileMetadataBatchArg {
             files: field_files.ok_or_else(|| ::serde::de::Error::missing_field("files"))?,
-            actions: field_actions,
+            actions: field_actions.and_then(Option::flatten),
         };
         Ok(Some(result))
     }
@@ -5465,7 +5465,7 @@ impl GetMetadataArgs {
         }
         let result = GetMetadataArgs {
             shared_folder_id: field_shared_folder_id.ok_or_else(|| ::serde::de::Error::missing_field("shared_folder_id"))?,
-            actions: field_actions,
+            actions: field_actions.and_then(Option::flatten),
         };
         Ok(Some(result))
     }
@@ -5692,8 +5692,8 @@ impl GetSharedLinkMetadataArg {
         }
         let result = GetSharedLinkMetadataArg {
             url: field_url.ok_or_else(|| ::serde::de::Error::missing_field("url"))?,
-            path: field_path,
-            link_password: field_link_password,
+            path: field_path.and_then(Option::flatten),
+            link_password: field_link_password.and_then(Option::flatten),
         };
         Ok(Some(result))
     }
@@ -5778,7 +5778,7 @@ impl GetSharedLinksArg {
             }
         }
         let result = GetSharedLinksArg {
-            path: field_path,
+            path: field_path.and_then(Option::flatten),
         };
         Ok(result)
     }
@@ -6151,8 +6151,8 @@ impl GroupInfo {
             is_member: field_is_member.ok_or_else(|| ::serde::de::Error::missing_field("is_member"))?,
             is_owner: field_is_owner.ok_or_else(|| ::serde::de::Error::missing_field("is_owner"))?,
             same_team: field_same_team.ok_or_else(|| ::serde::de::Error::missing_field("same_team"))?,
-            group_external_id: field_group_external_id,
-            member_count: field_member_count,
+            group_external_id: field_group_external_id.and_then(Option::flatten),
+            member_count: field_member_count.and_then(Option::flatten),
         };
         Ok(Some(result))
     }
@@ -6319,8 +6319,8 @@ impl GroupMembershipInfo {
         let result = GroupMembershipInfo {
             access_type: field_access_type.ok_or_else(|| ::serde::de::Error::missing_field("access_type"))?,
             group: field_group.ok_or_else(|| ::serde::de::Error::missing_field("group"))?,
-            permissions: field_permissions,
-            initials: field_initials,
+            permissions: field_permissions.and_then(Option::flatten),
+            initials: field_initials.and_then(Option::flatten),
             is_inherited: field_is_inherited.unwrap_or(false),
         };
         Ok(Some(result))
@@ -6440,7 +6440,7 @@ impl InsufficientPlan {
         }
         let result = InsufficientPlan {
             message: field_message.ok_or_else(|| ::serde::de::Error::missing_field("message"))?,
-            upsell_url: field_upsell_url,
+            upsell_url: field_upsell_url.and_then(Option::flatten),
         };
         Ok(Some(result))
     }
@@ -6794,10 +6794,10 @@ impl InviteeMembershipInfo {
         let result = InviteeMembershipInfo {
             access_type: field_access_type.ok_or_else(|| ::serde::de::Error::missing_field("access_type"))?,
             invitee: field_invitee.ok_or_else(|| ::serde::de::Error::missing_field("invitee"))?,
-            permissions: field_permissions,
-            initials: field_initials,
+            permissions: field_permissions.and_then(Option::flatten),
+            initials: field_initials.and_then(Option::flatten),
             is_inherited: field_is_inherited.unwrap_or(false),
-            user: field_user,
+            user: field_user.and_then(Option::flatten),
         };
         Ok(Some(result))
     }
@@ -7504,7 +7504,7 @@ impl LinkAudienceOption {
         let result = LinkAudienceOption {
             audience: field_audience.ok_or_else(|| ::serde::de::Error::missing_field("audience"))?,
             allowed: field_allowed.ok_or_else(|| ::serde::de::Error::missing_field("allowed"))?,
-            disallowed_reason: field_disallowed_reason,
+            disallowed_reason: field_disallowed_reason.and_then(Option::flatten),
         };
         Ok(Some(result))
     }
@@ -7835,7 +7835,7 @@ impl LinkPermission {
         let result = LinkPermission {
             action: field_action.ok_or_else(|| ::serde::de::Error::missing_field("action"))?,
             allow: field_allow.ok_or_else(|| ::serde::de::Error::missing_field("allow"))?,
-            reason: field_reason,
+            reason: field_reason.and_then(Option::flatten),
         };
         Ok(Some(result))
     }
@@ -8215,16 +8215,16 @@ impl LinkPermissions {
             can_disallow_download: field_can_disallow_download.ok_or_else(|| ::serde::de::Error::missing_field("can_disallow_download"))?,
             allow_comments: field_allow_comments.ok_or_else(|| ::serde::de::Error::missing_field("allow_comments"))?,
             team_restricts_comments: field_team_restricts_comments.ok_or_else(|| ::serde::de::Error::missing_field("team_restricts_comments"))?,
-            resolved_visibility: field_resolved_visibility,
-            requested_visibility: field_requested_visibility,
-            revoke_failure_reason: field_revoke_failure_reason,
-            effective_audience: field_effective_audience,
-            link_access_level: field_link_access_level,
-            audience_options: field_audience_options,
-            can_set_password: field_can_set_password,
-            can_remove_password: field_can_remove_password,
-            require_password: field_require_password,
-            can_use_extended_sharing_controls: field_can_use_extended_sharing_controls,
+            resolved_visibility: field_resolved_visibility.and_then(Option::flatten),
+            requested_visibility: field_requested_visibility.and_then(Option::flatten),
+            revoke_failure_reason: field_revoke_failure_reason.and_then(Option::flatten),
+            effective_audience: field_effective_audience.and_then(Option::flatten),
+            link_access_level: field_link_access_level.and_then(Option::flatten),
+            audience_options: field_audience_options.and_then(Option::flatten),
+            can_set_password: field_can_set_password.and_then(Option::flatten),
+            can_remove_password: field_can_remove_password.and_then(Option::flatten),
+            require_password: field_require_password.and_then(Option::flatten),
+            can_use_extended_sharing_controls: field_can_use_extended_sharing_controls.and_then(Option::flatten),
         };
         Ok(Some(result))
     }
@@ -8388,10 +8388,10 @@ impl LinkSettings {
             }
         }
         let result = LinkSettings {
-            access_level: field_access_level,
-            audience: field_audience,
-            expiry: field_expiry,
-            password: field_password,
+            access_level: field_access_level.and_then(Option::flatten),
+            audience: field_audience.and_then(Option::flatten),
+            expiry: field_expiry.and_then(Option::flatten),
+            password: field_password.and_then(Option::flatten),
         };
         Ok(result)
     }
@@ -8543,7 +8543,7 @@ impl ListFileMembersArg {
         }
         let result = ListFileMembersArg {
             file: field_file.ok_or_else(|| ::serde::de::Error::missing_field("file"))?,
-            actions: field_actions,
+            actions: field_actions.and_then(Option::flatten),
             include_inherited: field_include_inherited.unwrap_or(true),
             limit: field_limit.unwrap_or(100),
         };
@@ -9355,7 +9355,7 @@ impl ListFilesArg {
         }
         let result = ListFilesArg {
             limit: field_limit.unwrap_or(100),
-            actions: field_actions,
+            actions: field_actions.and_then(Option::flatten),
         };
         Ok(result)
     }
@@ -9652,7 +9652,7 @@ impl ListFilesResult {
         }
         let result = ListFilesResult {
             entries: field_entries.ok_or_else(|| ::serde::de::Error::missing_field("entries"))?,
-            cursor: field_cursor,
+            cursor: field_cursor.and_then(Option::flatten),
         };
         Ok(Some(result))
     }
@@ -9782,7 +9782,7 @@ impl ListFolderMembersArgs {
         }
         let result = ListFolderMembersArgs {
             shared_folder_id: field_shared_folder_id.ok_or_else(|| ::serde::de::Error::missing_field("shared_folder_id"))?,
-            actions: field_actions,
+            actions: field_actions.and_then(Option::flatten),
             limit: field_limit.unwrap_or(1000),
         };
         Ok(Some(result))
@@ -10076,7 +10076,7 @@ impl ListFolderMembersCursorArg {
             }
         }
         let result = ListFolderMembersCursorArg {
-            actions: field_actions,
+            actions: field_actions.and_then(Option::flatten),
             limit: field_limit.unwrap_or(1000),
         };
         Ok(result)
@@ -10188,7 +10188,7 @@ impl ListFoldersArgs {
         }
         let result = ListFoldersArgs {
             limit: field_limit.unwrap_or(1000),
-            actions: field_actions,
+            actions: field_actions.and_then(Option::flatten),
         };
         Ok(result)
     }
@@ -10464,7 +10464,7 @@ impl ListFoldersResult {
         }
         let result = ListFoldersResult {
             entries: field_entries.ok_or_else(|| ::serde::de::Error::missing_field("entries"))?,
-            cursor: field_cursor,
+            cursor: field_cursor.and_then(Option::flatten),
         };
         Ok(Some(result))
     }
@@ -10576,9 +10576,9 @@ impl ListSharedLinksArg {
             }
         }
         let result = ListSharedLinksArg {
-            path: field_path,
-            cursor: field_cursor,
-            direct_only: field_direct_only,
+            path: field_path.and_then(Option::flatten),
+            cursor: field_cursor.and_then(Option::flatten),
+            direct_only: field_direct_only.and_then(Option::flatten),
         };
         Ok(result)
     }
@@ -10798,7 +10798,7 @@ impl ListSharedLinksResult {
         let result = ListSharedLinksResult {
             links: field_links.ok_or_else(|| ::serde::de::Error::missing_field("links"))?,
             has_more: field_has_more.ok_or_else(|| ::serde::de::Error::missing_field("has_more"))?,
-            cursor: field_cursor,
+            cursor: field_cursor.and_then(Option::flatten),
         };
         Ok(Some(result))
     }
@@ -10914,9 +10914,9 @@ impl MemberAccessLevelResult {
             }
         }
         let result = MemberAccessLevelResult {
-            access_level: field_access_level,
-            warning: field_warning,
-            access_details: field_access_details,
+            access_level: field_access_level.and_then(Option::flatten),
+            warning: field_warning.and_then(Option::flatten),
+            access_details: field_access_details.and_then(Option::flatten),
         };
         Ok(result)
     }
@@ -11151,7 +11151,7 @@ impl MemberPermission {
         let result = MemberPermission {
             action: field_action.ok_or_else(|| ::serde::de::Error::missing_field("action"))?,
             allow: field_allow.ok_or_else(|| ::serde::de::Error::missing_field("allow"))?,
-            reason: field_reason,
+            reason: field_reason.and_then(Option::flatten),
         };
         Ok(Some(result))
     }
@@ -11445,8 +11445,8 @@ impl MembershipInfo {
         }
         let result = MembershipInfo {
             access_type: field_access_type.ok_or_else(|| ::serde::de::Error::missing_field("access_type"))?,
-            permissions: field_permissions,
-            initials: field_initials,
+            permissions: field_permissions.and_then(Option::flatten),
+            initials: field_initials.and_then(Option::flatten),
             is_inherited: field_is_inherited.unwrap_or(false),
         };
         Ok(Some(result))
@@ -12200,7 +12200,7 @@ impl PathLinkMetadata {
             url: field_url.ok_or_else(|| ::serde::de::Error::missing_field("url"))?,
             visibility: field_visibility.ok_or_else(|| ::serde::de::Error::missing_field("visibility"))?,
             path: field_path.ok_or_else(|| ::serde::de::Error::missing_field("path"))?,
-            expires: field_expires,
+            expires: field_expires.and_then(Option::flatten),
         };
         Ok(Some(result))
     }
@@ -14385,14 +14385,14 @@ impl ShareFolderArg {
         }
         let result = ShareFolderArg {
             path: field_path.ok_or_else(|| ::serde::de::Error::missing_field("path"))?,
-            acl_update_policy: field_acl_update_policy,
+            acl_update_policy: field_acl_update_policy.and_then(Option::flatten),
             force_async: field_force_async.unwrap_or(false),
-            member_policy: field_member_policy,
-            shared_link_policy: field_shared_link_policy,
-            viewer_info_policy: field_viewer_info_policy,
+            member_policy: field_member_policy.and_then(Option::flatten),
+            shared_link_policy: field_shared_link_policy.and_then(Option::flatten),
+            viewer_info_policy: field_viewer_info_policy.and_then(Option::flatten),
             access_inheritance: field_access_inheritance.unwrap_or(AccessInheritance::Inherit),
-            actions: field_actions,
-            link_settings: field_link_settings,
+            actions: field_actions.and_then(Option::flatten),
+            link_settings: field_link_settings.and_then(Option::flatten),
         };
         Ok(Some(result))
     }
@@ -14607,11 +14607,11 @@ impl ShareFolderArgBase {
         }
         let result = ShareFolderArgBase {
             path: field_path.ok_or_else(|| ::serde::de::Error::missing_field("path"))?,
-            acl_update_policy: field_acl_update_policy,
+            acl_update_policy: field_acl_update_policy.and_then(Option::flatten),
             force_async: field_force_async.unwrap_or(false),
-            member_policy: field_member_policy,
-            shared_link_policy: field_shared_link_policy,
-            viewer_info_policy: field_viewer_info_policy,
+            member_policy: field_member_policy.and_then(Option::flatten),
+            shared_link_policy: field_shared_link_policy.and_then(Option::flatten),
+            viewer_info_policy: field_viewer_info_policy.and_then(Option::flatten),
             access_inheritance: field_access_inheritance.unwrap_or(AccessInheritance::Inherit),
         };
         Ok(Some(result))
@@ -15445,10 +15445,10 @@ impl SharedContentLinkMetadata {
             link_permissions: field_link_permissions.ok_or_else(|| ::serde::de::Error::missing_field("link_permissions"))?,
             password_protected: field_password_protected.ok_or_else(|| ::serde::de::Error::missing_field("password_protected"))?,
             url: field_url.ok_or_else(|| ::serde::de::Error::missing_field("url"))?,
-            access_level: field_access_level,
-            audience_restricting_shared_folder: field_audience_restricting_shared_folder,
-            expiry: field_expiry,
-            audience_exceptions: field_audience_exceptions,
+            access_level: field_access_level.and_then(Option::flatten),
+            audience_restricting_shared_folder: field_audience_restricting_shared_folder.and_then(Option::flatten),
+            expiry: field_expiry.and_then(Option::flatten),
+            audience_exceptions: field_audience_exceptions.and_then(Option::flatten),
         };
         Ok(Some(result))
     }
@@ -15652,9 +15652,9 @@ impl SharedContentLinkMetadataBase {
             current_audience: field_current_audience.ok_or_else(|| ::serde::de::Error::missing_field("current_audience"))?,
             link_permissions: field_link_permissions.ok_or_else(|| ::serde::de::Error::missing_field("link_permissions"))?,
             password_protected: field_password_protected.ok_or_else(|| ::serde::de::Error::missing_field("password_protected"))?,
-            access_level: field_access_level,
-            audience_restricting_shared_folder: field_audience_restricting_shared_folder,
-            expiry: field_expiry,
+            access_level: field_access_level.and_then(Option::flatten),
+            audience_restricting_shared_folder: field_audience_restricting_shared_folder.and_then(Option::flatten),
+            expiry: field_expiry.and_then(Option::flatten),
         };
         Ok(Some(result))
     }
@@ -15808,7 +15808,7 @@ impl SharedFileMembers {
             users: field_users.ok_or_else(|| ::serde::de::Error::missing_field("users"))?,
             groups: field_groups.ok_or_else(|| ::serde::de::Error::missing_field("groups"))?,
             invitees: field_invitees.ok_or_else(|| ::serde::de::Error::missing_field("invitees"))?,
-            cursor: field_cursor,
+            cursor: field_cursor.and_then(Option::flatten),
         };
         Ok(Some(result))
     }
@@ -16121,16 +16121,16 @@ impl SharedFileMetadata {
             name: field_name.ok_or_else(|| ::serde::de::Error::missing_field("name"))?,
             policy: field_policy.ok_or_else(|| ::serde::de::Error::missing_field("policy"))?,
             preview_url: field_preview_url.ok_or_else(|| ::serde::de::Error::missing_field("preview_url"))?,
-            access_type: field_access_type,
-            expected_link_metadata: field_expected_link_metadata,
-            link_metadata: field_link_metadata,
-            owner_display_names: field_owner_display_names,
-            owner_team: field_owner_team,
-            parent_shared_folder_id: field_parent_shared_folder_id,
-            path_display: field_path_display,
-            path_lower: field_path_lower,
-            permissions: field_permissions,
-            time_invited: field_time_invited,
+            access_type: field_access_type.and_then(Option::flatten),
+            expected_link_metadata: field_expected_link_metadata.and_then(Option::flatten),
+            link_metadata: field_link_metadata.and_then(Option::flatten),
+            owner_display_names: field_owner_display_names.and_then(Option::flatten),
+            owner_team: field_owner_team.and_then(Option::flatten),
+            parent_shared_folder_id: field_parent_shared_folder_id.and_then(Option::flatten),
+            path_display: field_path_display.and_then(Option::flatten),
+            path_lower: field_path_lower.and_then(Option::flatten),
+            permissions: field_permissions.and_then(Option::flatten),
+            time_invited: field_time_invited.and_then(Option::flatten),
         };
         Ok(Some(result))
     }
@@ -16504,7 +16504,7 @@ impl SharedFolderMembers {
             users: field_users.ok_or_else(|| ::serde::de::Error::missing_field("users"))?,
             groups: field_groups.ok_or_else(|| ::serde::de::Error::missing_field("groups"))?,
             invitees: field_invitees.ok_or_else(|| ::serde::de::Error::missing_field("invitees"))?,
-            cursor: field_cursor,
+            cursor: field_cursor.and_then(Option::flatten),
         };
         Ok(Some(result))
     }
@@ -16845,14 +16845,14 @@ impl SharedFolderMetadata {
             preview_url: field_preview_url.ok_or_else(|| ::serde::de::Error::missing_field("preview_url"))?,
             shared_folder_id: field_shared_folder_id.ok_or_else(|| ::serde::de::Error::missing_field("shared_folder_id"))?,
             time_invited: field_time_invited.ok_or_else(|| ::serde::de::Error::missing_field("time_invited"))?,
-            owner_display_names: field_owner_display_names,
-            owner_team: field_owner_team,
-            parent_shared_folder_id: field_parent_shared_folder_id,
-            path_display: field_path_display,
-            path_lower: field_path_lower,
-            parent_folder_name: field_parent_folder_name,
-            link_metadata: field_link_metadata,
-            permissions: field_permissions,
+            owner_display_names: field_owner_display_names.and_then(Option::flatten),
+            owner_team: field_owner_team.and_then(Option::flatten),
+            parent_shared_folder_id: field_parent_shared_folder_id.and_then(Option::flatten),
+            path_display: field_path_display.and_then(Option::flatten),
+            path_lower: field_path_lower.and_then(Option::flatten),
+            parent_folder_name: field_parent_folder_name.and_then(Option::flatten),
+            link_metadata: field_link_metadata.and_then(Option::flatten),
+            permissions: field_permissions.and_then(Option::flatten),
             access_inheritance: field_access_inheritance.unwrap_or(AccessInheritance::Inherit),
         };
         Ok(Some(result))
@@ -17108,12 +17108,12 @@ impl SharedFolderMetadataBase {
             access_type: field_access_type.ok_or_else(|| ::serde::de::Error::missing_field("access_type"))?,
             is_inside_team_folder: field_is_inside_team_folder.ok_or_else(|| ::serde::de::Error::missing_field("is_inside_team_folder"))?,
             is_team_folder: field_is_team_folder.ok_or_else(|| ::serde::de::Error::missing_field("is_team_folder"))?,
-            owner_display_names: field_owner_display_names,
-            owner_team: field_owner_team,
-            parent_shared_folder_id: field_parent_shared_folder_id,
-            path_display: field_path_display,
-            path_lower: field_path_lower,
-            parent_folder_name: field_parent_folder_name,
+            owner_display_names: field_owner_display_names.and_then(Option::flatten),
+            owner_team: field_owner_team.and_then(Option::flatten),
+            parent_shared_folder_id: field_parent_shared_folder_id.and_then(Option::flatten),
+            path_display: field_path_display.and_then(Option::flatten),
+            path_lower: field_path_lower.and_then(Option::flatten),
+            parent_folder_name: field_parent_folder_name.and_then(Option::flatten),
         };
         Ok(Some(result))
     }
@@ -17693,13 +17693,13 @@ impl SharedLinkSettings {
             }
         }
         let result = SharedLinkSettings {
-            require_password: field_require_password,
-            link_password: field_link_password,
-            expires: field_expires,
-            audience: field_audience,
-            access: field_access,
-            requested_visibility: field_requested_visibility,
-            allow_download: field_allow_download,
+            require_password: field_require_password.and_then(Option::flatten),
+            link_password: field_link_password.and_then(Option::flatten),
+            expires: field_expires.and_then(Option::flatten),
+            audience: field_audience.and_then(Option::flatten),
+            access: field_access.and_then(Option::flatten),
+            requested_visibility: field_requested_visibility.and_then(Option::flatten),
+            allow_download: field_allow_download.and_then(Option::flatten),
         };
         Ok(result)
     }
@@ -18095,7 +18095,7 @@ impl TeamMemberInfo {
         let result = TeamMemberInfo {
             team_info: field_team_info.ok_or_else(|| ::serde::de::Error::missing_field("team_info"))?,
             display_name: field_display_name.ok_or_else(|| ::serde::de::Error::missing_field("display_name"))?,
-            member_id: field_member_id,
+            member_id: field_member_id.and_then(Option::flatten),
         };
         Ok(Some(result))
     }
@@ -19530,12 +19530,12 @@ impl UpdateFolderPolicyArg {
         }
         let result = UpdateFolderPolicyArg {
             shared_folder_id: field_shared_folder_id.ok_or_else(|| ::serde::de::Error::missing_field("shared_folder_id"))?,
-            member_policy: field_member_policy,
-            acl_update_policy: field_acl_update_policy,
-            viewer_info_policy: field_viewer_info_policy,
-            shared_link_policy: field_shared_link_policy,
-            link_settings: field_link_settings,
-            actions: field_actions,
+            member_policy: field_member_policy.and_then(Option::flatten),
+            acl_update_policy: field_acl_update_policy.and_then(Option::flatten),
+            viewer_info_policy: field_viewer_info_policy.and_then(Option::flatten),
+            shared_link_policy: field_shared_link_policy.and_then(Option::flatten),
+            link_settings: field_link_settings.and_then(Option::flatten),
+            actions: field_actions.and_then(Option::flatten),
         };
         Ok(Some(result))
     }
@@ -19874,11 +19874,11 @@ impl UserFileMembershipInfo {
         let result = UserFileMembershipInfo {
             access_type: field_access_type.ok_or_else(|| ::serde::de::Error::missing_field("access_type"))?,
             user: field_user.ok_or_else(|| ::serde::de::Error::missing_field("user"))?,
-            permissions: field_permissions,
-            initials: field_initials,
+            permissions: field_permissions.and_then(Option::flatten),
+            initials: field_initials.and_then(Option::flatten),
             is_inherited: field_is_inherited.unwrap_or(false),
-            time_last_seen: field_time_last_seen,
-            platform_type: field_platform_type,
+            time_last_seen: field_time_last_seen.and_then(Option::flatten),
+            platform_type: field_platform_type.and_then(Option::flatten),
         };
         Ok(Some(result))
     }
@@ -20046,7 +20046,7 @@ impl UserInfo {
             email: field_email.ok_or_else(|| ::serde::de::Error::missing_field("email"))?,
             display_name: field_display_name.ok_or_else(|| ::serde::de::Error::missing_field("display_name"))?,
             same_team: field_same_team.ok_or_else(|| ::serde::de::Error::missing_field("same_team"))?,
-            team_member_id: field_team_member_id,
+            team_member_id: field_team_member_id.and_then(Option::flatten),
         };
         Ok(Some(result))
     }
@@ -20207,8 +20207,8 @@ impl UserMembershipInfo {
         let result = UserMembershipInfo {
             access_type: field_access_type.ok_or_else(|| ::serde::de::Error::missing_field("access_type"))?,
             user: field_user.ok_or_else(|| ::serde::de::Error::missing_field("user"))?,
-            permissions: field_permissions,
-            initials: field_initials,
+            permissions: field_permissions.and_then(Option::flatten),
+            initials: field_initials.and_then(Option::flatten),
             is_inherited: field_is_inherited.unwrap_or(false),
         };
         Ok(Some(result))
@@ -20521,7 +20521,7 @@ impl VisibilityPolicy {
             policy: field_policy.ok_or_else(|| ::serde::de::Error::missing_field("policy"))?,
             resolved_policy: field_resolved_policy.ok_or_else(|| ::serde::de::Error::missing_field("resolved_policy"))?,
             allowed: field_allowed.ok_or_else(|| ::serde::de::Error::missing_field("allowed"))?,
-            disallowed_reason: field_disallowed_reason,
+            disallowed_reason: field_disallowed_reason.and_then(Option::flatten),
         };
         Ok(Some(result))
     }

--- a/src/generated/team.rs
+++ b/src/generated/team.rs
@@ -1626,11 +1626,11 @@ impl ActiveWebSession {
             user_agent: field_user_agent.ok_or_else(|| ::serde::de::Error::missing_field("user_agent"))?,
             os: field_os.ok_or_else(|| ::serde::de::Error::missing_field("os"))?,
             browser: field_browser.ok_or_else(|| ::serde::de::Error::missing_field("browser"))?,
-            ip_address: field_ip_address,
-            country: field_country,
-            created: field_created,
-            updated: field_updated,
-            expires: field_expires,
+            ip_address: field_ip_address.and_then(Option::flatten),
+            country: field_country.and_then(Option::flatten),
+            created: field_created.and_then(Option::flatten),
+            updated: field_updated.and_then(Option::flatten),
+            expires: field_expires.and_then(Option::flatten),
         };
         Ok(Some(result))
     }
@@ -2350,9 +2350,9 @@ impl ApiApp {
             app_id: field_app_id.ok_or_else(|| ::serde::de::Error::missing_field("app_id"))?,
             app_name: field_app_name.ok_or_else(|| ::serde::de::Error::missing_field("app_name"))?,
             is_app_folder: field_is_app_folder.ok_or_else(|| ::serde::de::Error::missing_field("is_app_folder"))?,
-            publisher: field_publisher,
-            publisher_url: field_publisher_url,
-            linked: field_linked,
+            publisher: field_publisher.and_then(Option::flatten),
+            publisher_url: field_publisher_url.and_then(Option::flatten),
+            linked: field_linked.and_then(Option::flatten),
         };
         Ok(Some(result))
     }
@@ -2900,8 +2900,8 @@ impl DateRange {
             }
         }
         let result = DateRange {
-            start_date: field_start_date,
-            end_date: field_end_date,
+            start_date: field_start_date.and_then(Option::flatten),
+            end_date: field_end_date.and_then(Option::flatten),
         };
         Ok(result)
     }
@@ -3462,10 +3462,10 @@ impl DesktopClientSession {
             client_version: field_client_version.ok_or_else(|| ::serde::de::Error::missing_field("client_version"))?,
             platform: field_platform.ok_or_else(|| ::serde::de::Error::missing_field("platform"))?,
             is_delete_on_unlink_supported: field_is_delete_on_unlink_supported.ok_or_else(|| ::serde::de::Error::missing_field("is_delete_on_unlink_supported"))?,
-            ip_address: field_ip_address,
-            country: field_country,
-            created: field_created,
-            updated: field_updated,
+            ip_address: field_ip_address.and_then(Option::flatten),
+            country: field_country.and_then(Option::flatten),
+            created: field_created.and_then(Option::flatten),
+            updated: field_updated.and_then(Option::flatten),
         };
         Ok(Some(result))
     }
@@ -3713,10 +3713,10 @@ impl DeviceSession {
         }
         let result = DeviceSession {
             session_id: field_session_id.ok_or_else(|| ::serde::de::Error::missing_field("session_id"))?,
-            ip_address: field_ip_address,
-            country: field_country,
-            created: field_created,
-            updated: field_updated,
+            ip_address: field_ip_address.and_then(Option::flatten),
+            country: field_country.and_then(Option::flatten),
+            created: field_created.and_then(Option::flatten),
+            updated: field_updated.and_then(Option::flatten),
         };
         Ok(Some(result))
     }
@@ -4455,7 +4455,7 @@ impl ExcludedUsersListResult {
         let result = ExcludedUsersListResult {
             users: field_users.ok_or_else(|| ::serde::de::Error::missing_field("users"))?,
             has_more: field_has_more.ok_or_else(|| ::serde::de::Error::missing_field("has_more"))?,
-            cursor: field_cursor,
+            cursor: field_cursor.and_then(Option::flatten),
         };
         Ok(Some(result))
     }
@@ -4540,7 +4540,7 @@ impl ExcludedUsersUpdateArg {
             }
         }
         let result = ExcludedUsersUpdateArg {
-            users: field_users,
+            users: field_users.and_then(Option::flatten),
         };
         Ok(result)
     }
@@ -6181,8 +6181,8 @@ impl GroupCreateArg {
         let result = GroupCreateArg {
             group_name: field_group_name.ok_or_else(|| ::serde::de::Error::missing_field("group_name"))?,
             add_creator_as_owner: field_add_creator_as_owner.unwrap_or(false),
-            group_external_id: field_group_external_id,
-            group_management_type: field_group_management_type,
+            group_external_id: field_group_external_id.and_then(Option::flatten),
+            group_management_type: field_group_management_type.and_then(Option::flatten),
         };
         Ok(Some(result))
     }
@@ -6560,9 +6560,9 @@ impl GroupFullInfo {
             group_id: field_group_id.ok_or_else(|| ::serde::de::Error::missing_field("group_id"))?,
             group_management_type: field_group_management_type.ok_or_else(|| ::serde::de::Error::missing_field("group_management_type"))?,
             created: field_created.ok_or_else(|| ::serde::de::Error::missing_field("created"))?,
-            group_external_id: field_group_external_id,
-            member_count: field_member_count,
-            members: field_members,
+            group_external_id: field_group_external_id.and_then(Option::flatten),
+            member_count: field_member_count.and_then(Option::flatten),
+            members: field_members.and_then(Option::flatten),
         };
         Ok(Some(result))
     }
@@ -8363,9 +8363,9 @@ impl GroupUpdateArgs {
         let result = GroupUpdateArgs {
             group: field_group.ok_or_else(|| ::serde::de::Error::missing_field("group"))?,
             return_members: field_return_members.unwrap_or(true),
-            new_group_name: field_new_group_name,
-            new_group_external_id: field_new_group_external_id,
-            new_group_management_type: field_new_group_management_type,
+            new_group_name: field_new_group_name.and_then(Option::flatten),
+            new_group_external_id: field_new_group_external_id.and_then(Option::flatten),
+            new_group_management_type: field_new_group_management_type.and_then(Option::flatten),
         };
         Ok(Some(result))
     }
@@ -10239,9 +10239,9 @@ impl LegalHoldPolicy {
             members: field_members.ok_or_else(|| ::serde::de::Error::missing_field("members"))?,
             status: field_status.ok_or_else(|| ::serde::de::Error::missing_field("status"))?,
             start_date: field_start_date.ok_or_else(|| ::serde::de::Error::missing_field("start_date"))?,
-            description: field_description,
-            activation_time: field_activation_time,
-            end_date: field_end_date,
+            description: field_description.and_then(Option::flatten),
+            activation_time: field_activation_time.and_then(Option::flatten),
+            end_date: field_end_date.and_then(Option::flatten),
         };
         Ok(Some(result))
     }
@@ -10739,7 +10739,7 @@ impl LegalHoldsListHeldRevisionResult {
         let result = LegalHoldsListHeldRevisionResult {
             entries: field_entries.ok_or_else(|| ::serde::de::Error::missing_field("entries"))?,
             has_more: field_has_more.ok_or_else(|| ::serde::de::Error::missing_field("has_more"))?,
-            cursor: field_cursor,
+            cursor: field_cursor.and_then(Option::flatten),
         };
         Ok(Some(result))
     }
@@ -10943,7 +10943,7 @@ impl LegalHoldsListHeldRevisionsContinueArg {
         }
         let result = LegalHoldsListHeldRevisionsContinueArg {
             id: field_id.ok_or_else(|| ::serde::de::Error::missing_field("id"))?,
-            cursor: field_cursor,
+            cursor: field_cursor.and_then(Option::flatten),
         };
         Ok(Some(result))
     }
@@ -11559,9 +11559,9 @@ impl LegalHoldsPolicyCreateArg {
         let result = LegalHoldsPolicyCreateArg {
             name: field_name.ok_or_else(|| ::serde::de::Error::missing_field("name"))?,
             members: field_members.ok_or_else(|| ::serde::de::Error::missing_field("members"))?,
-            description: field_description,
-            start_date: field_start_date,
-            end_date: field_end_date,
+            description: field_description.and_then(Option::flatten),
+            start_date: field_start_date.and_then(Option::flatten),
+            end_date: field_end_date.and_then(Option::flatten),
         };
         Ok(Some(result))
     }
@@ -12079,9 +12079,9 @@ impl LegalHoldsPolicyUpdateArg {
         }
         let result = LegalHoldsPolicyUpdateArg {
             id: field_id.ok_or_else(|| ::serde::de::Error::missing_field("id"))?,
-            name: field_name,
-            description: field_description,
-            members: field_members,
+            name: field_name.and_then(Option::flatten),
+            description: field_description.and_then(Option::flatten),
+            members: field_members.and_then(Option::flatten),
         };
         Ok(Some(result))
     }
@@ -12834,9 +12834,9 @@ impl ListMemberDevicesResult {
             }
         }
         let result = ListMemberDevicesResult {
-            active_web_sessions: field_active_web_sessions,
-            desktop_client_sessions: field_desktop_client_sessions,
-            mobile_client_sessions: field_mobile_client_sessions,
+            active_web_sessions: field_active_web_sessions.and_then(Option::flatten),
+            desktop_client_sessions: field_desktop_client_sessions.and_then(Option::flatten),
+            mobile_client_sessions: field_mobile_client_sessions.and_then(Option::flatten),
         };
         Ok(result)
     }
@@ -12928,7 +12928,7 @@ impl ListMembersAppsArg {
             }
         }
         let result = ListMembersAppsArg {
-            cursor: field_cursor,
+            cursor: field_cursor.and_then(Option::flatten),
         };
         Ok(result)
     }
@@ -13124,7 +13124,7 @@ impl ListMembersAppsResult {
         let result = ListMembersAppsResult {
             apps: field_apps.ok_or_else(|| ::serde::de::Error::missing_field("apps"))?,
             has_more: field_has_more.ok_or_else(|| ::serde::de::Error::missing_field("has_more"))?,
-            cursor: field_cursor,
+            cursor: field_cursor.and_then(Option::flatten),
         };
         Ok(Some(result))
     }
@@ -13266,7 +13266,7 @@ impl ListMembersDevicesArg {
             }
         }
         let result = ListMembersDevicesArg {
-            cursor: field_cursor,
+            cursor: field_cursor.and_then(Option::flatten),
             include_web_sessions: field_include_web_sessions.unwrap_or(true),
             include_desktop_clients: field_include_desktop_clients.unwrap_or(true),
             include_mobile_clients: field_include_mobile_clients.unwrap_or(true),
@@ -13468,7 +13468,7 @@ impl ListMembersDevicesResult {
         let result = ListMembersDevicesResult {
             devices: field_devices.ok_or_else(|| ::serde::de::Error::missing_field("devices"))?,
             has_more: field_has_more.ok_or_else(|| ::serde::de::Error::missing_field("has_more"))?,
-            cursor: field_cursor,
+            cursor: field_cursor.and_then(Option::flatten),
         };
         Ok(Some(result))
     }
@@ -13556,7 +13556,7 @@ impl ListTeamAppsArg {
             }
         }
         let result = ListTeamAppsArg {
-            cursor: field_cursor,
+            cursor: field_cursor.and_then(Option::flatten),
         };
         Ok(result)
     }
@@ -13751,7 +13751,7 @@ impl ListTeamAppsResult {
         let result = ListTeamAppsResult {
             apps: field_apps.ok_or_else(|| ::serde::de::Error::missing_field("apps"))?,
             has_more: field_has_more.ok_or_else(|| ::serde::de::Error::missing_field("has_more"))?,
-            cursor: field_cursor,
+            cursor: field_cursor.and_then(Option::flatten),
         };
         Ok(Some(result))
     }
@@ -13893,7 +13893,7 @@ impl ListTeamDevicesArg {
             }
         }
         let result = ListTeamDevicesArg {
-            cursor: field_cursor,
+            cursor: field_cursor.and_then(Option::flatten),
             include_web_sessions: field_include_web_sessions.unwrap_or(true),
             include_desktop_clients: field_include_desktop_clients.unwrap_or(true),
             include_mobile_clients: field_include_mobile_clients.unwrap_or(true),
@@ -14095,7 +14095,7 @@ impl ListTeamDevicesResult {
         let result = ListTeamDevicesResult {
             devices: field_devices.ok_or_else(|| ::serde::de::Error::missing_field("devices"))?,
             has_more: field_has_more.ok_or_else(|| ::serde::de::Error::missing_field("has_more"))?,
-            cursor: field_cursor,
+            cursor: field_cursor.and_then(Option::flatten),
         };
         Ok(Some(result))
     }
@@ -14409,12 +14409,12 @@ impl MemberAddArg {
         }
         let result = MemberAddArg {
             member_email: field_member_email.ok_or_else(|| ::serde::de::Error::missing_field("member_email"))?,
-            member_given_name: field_member_given_name,
-            member_surname: field_member_surname,
-            member_external_id: field_member_external_id,
-            member_persistent_id: field_member_persistent_id,
+            member_given_name: field_member_given_name.and_then(Option::flatten),
+            member_surname: field_member_surname.and_then(Option::flatten),
+            member_external_id: field_member_external_id.and_then(Option::flatten),
+            member_persistent_id: field_member_persistent_id.and_then(Option::flatten),
             send_welcome_email: field_send_welcome_email.unwrap_or(true),
-            is_directory_restricted: field_is_directory_restricted,
+            is_directory_restricted: field_is_directory_restricted.and_then(Option::flatten),
             role: field_role.unwrap_or(AdminTier::MemberOnly),
         };
         Ok(Some(result))
@@ -14626,12 +14626,12 @@ impl MemberAddArgBase {
         }
         let result = MemberAddArgBase {
             member_email: field_member_email.ok_or_else(|| ::serde::de::Error::missing_field("member_email"))?,
-            member_given_name: field_member_given_name,
-            member_surname: field_member_surname,
-            member_external_id: field_member_external_id,
-            member_persistent_id: field_member_persistent_id,
+            member_given_name: field_member_given_name.and_then(Option::flatten),
+            member_surname: field_member_surname.and_then(Option::flatten),
+            member_external_id: field_member_external_id.and_then(Option::flatten),
+            member_persistent_id: field_member_persistent_id.and_then(Option::flatten),
             send_welcome_email: field_send_welcome_email.unwrap_or(true),
-            is_directory_restricted: field_is_directory_restricted,
+            is_directory_restricted: field_is_directory_restricted.and_then(Option::flatten),
         };
         Ok(Some(result))
     }
@@ -15296,13 +15296,13 @@ impl MemberAddV2Arg {
         }
         let result = MemberAddV2Arg {
             member_email: field_member_email.ok_or_else(|| ::serde::de::Error::missing_field("member_email"))?,
-            member_given_name: field_member_given_name,
-            member_surname: field_member_surname,
-            member_external_id: field_member_external_id,
-            member_persistent_id: field_member_persistent_id,
+            member_given_name: field_member_given_name.and_then(Option::flatten),
+            member_surname: field_member_surname.and_then(Option::flatten),
+            member_external_id: field_member_external_id.and_then(Option::flatten),
+            member_persistent_id: field_member_persistent_id.and_then(Option::flatten),
             send_welcome_email: field_send_welcome_email.unwrap_or(true),
-            is_directory_restricted: field_is_directory_restricted,
-            role_ids: field_role_ids,
+            is_directory_restricted: field_is_directory_restricted.and_then(Option::flatten),
+            role_ids: field_role_ids.and_then(Option::flatten),
         };
         Ok(Some(result))
     }
@@ -15698,9 +15698,9 @@ impl MemberDevices {
         }
         let result = MemberDevices {
             team_member_id: field_team_member_id.ok_or_else(|| ::serde::de::Error::missing_field("team_member_id"))?,
-            web_sessions: field_web_sessions,
-            desktop_clients: field_desktop_clients,
-            mobile_clients: field_mobile_clients,
+            web_sessions: field_web_sessions.and_then(Option::flatten),
+            desktop_clients: field_desktop_clients.and_then(Option::flatten),
+            mobile_clients: field_mobile_clients.and_then(Option::flatten),
         };
         Ok(Some(result))
     }
@@ -16126,15 +16126,15 @@ impl MemberProfile {
             status: field_status.ok_or_else(|| ::serde::de::Error::missing_field("status"))?,
             name: field_name.ok_or_else(|| ::serde::de::Error::missing_field("name"))?,
             membership_type: field_membership_type.ok_or_else(|| ::serde::de::Error::missing_field("membership_type"))?,
-            external_id: field_external_id,
-            account_id: field_account_id,
-            secondary_emails: field_secondary_emails,
-            invited_on: field_invited_on,
-            joined_on: field_joined_on,
-            suspended_on: field_suspended_on,
-            persistent_id: field_persistent_id,
-            is_directory_restricted: field_is_directory_restricted,
-            profile_photo_url: field_profile_photo_url,
+            external_id: field_external_id.and_then(Option::flatten),
+            account_id: field_account_id.and_then(Option::flatten),
+            secondary_emails: field_secondary_emails.and_then(Option::flatten),
+            invited_on: field_invited_on.and_then(Option::flatten),
+            joined_on: field_joined_on.and_then(Option::flatten),
+            suspended_on: field_suspended_on.and_then(Option::flatten),
+            persistent_id: field_persistent_id.and_then(Option::flatten),
+            is_directory_restricted: field_is_directory_restricted.and_then(Option::flatten),
+            profile_photo_url: field_profile_photo_url.and_then(Option::flatten),
         };
         Ok(Some(result))
     }
@@ -19119,8 +19119,8 @@ impl MembersRemoveArg {
         let result = MembersRemoveArg {
             user: field_user.ok_or_else(|| ::serde::de::Error::missing_field("user"))?,
             wipe_data: field_wipe_data.unwrap_or(true),
-            transfer_dest_id: field_transfer_dest_id,
-            transfer_admin_id: field_transfer_admin_id,
+            transfer_dest_id: field_transfer_dest_id.and_then(Option::flatten),
+            transfer_admin_id: field_transfer_admin_id.and_then(Option::flatten),
             keep_account: field_keep_account.unwrap_or(false),
             retain_team_shares: field_retain_team_shares.unwrap_or(false),
         };
@@ -19630,7 +19630,7 @@ impl MembersSetPermissions2Arg {
         }
         let result = MembersSetPermissions2Arg {
             user: field_user.ok_or_else(|| ::serde::de::Error::missing_field("user"))?,
-            new_roles: field_new_roles,
+            new_roles: field_new_roles.and_then(Option::flatten),
         };
         Ok(Some(result))
     }
@@ -19853,7 +19853,7 @@ impl MembersSetPermissions2Result {
         }
         let result = MembersSetPermissions2Result {
             team_member_id: field_team_member_id.ok_or_else(|| ::serde::de::Error::missing_field("team_member_id"))?,
-            roles: field_roles,
+            roles: field_roles.and_then(Option::flatten),
         };
         Ok(Some(result))
     }
@@ -20370,12 +20370,12 @@ impl MembersSetProfileArg {
         }
         let result = MembersSetProfileArg {
             user: field_user.ok_or_else(|| ::serde::de::Error::missing_field("user"))?,
-            new_email: field_new_email,
-            new_external_id: field_new_external_id,
-            new_given_name: field_new_given_name,
-            new_surname: field_new_surname,
-            new_persistent_id: field_new_persistent_id,
-            new_is_directory_restricted: field_new_is_directory_restricted,
+            new_email: field_new_email.and_then(Option::flatten),
+            new_external_id: field_new_external_id.and_then(Option::flatten),
+            new_given_name: field_new_given_name.and_then(Option::flatten),
+            new_surname: field_new_surname.and_then(Option::flatten),
+            new_persistent_id: field_new_persistent_id.and_then(Option::flatten),
+            new_is_directory_restricted: field_new_is_directory_restricted.and_then(Option::flatten),
         };
         Ok(Some(result))
     }
@@ -21823,13 +21823,13 @@ impl MobileClientSession {
             session_id: field_session_id.ok_or_else(|| ::serde::de::Error::missing_field("session_id"))?,
             device_name: field_device_name.ok_or_else(|| ::serde::de::Error::missing_field("device_name"))?,
             client_type: field_client_type.ok_or_else(|| ::serde::de::Error::missing_field("client_type"))?,
-            ip_address: field_ip_address,
-            country: field_country,
-            created: field_created,
-            updated: field_updated,
-            client_version: field_client_version,
-            os_version: field_os_version,
-            last_carrier: field_last_carrier,
+            ip_address: field_ip_address.and_then(Option::flatten),
+            country: field_country.and_then(Option::flatten),
+            created: field_created.and_then(Option::flatten),
+            updated: field_updated.and_then(Option::flatten),
+            client_version: field_client_version.and_then(Option::flatten),
+            os_version: field_os_version.and_then(Option::flatten),
+            last_carrier: field_last_carrier.and_then(Option::flatten),
         };
         Ok(Some(result))
     }
@@ -21990,7 +21990,7 @@ impl NamespaceMetadata {
             name: field_name.ok_or_else(|| ::serde::de::Error::missing_field("name"))?,
             namespace_id: field_namespace_id.ok_or_else(|| ::serde::de::Error::missing_field("namespace_id"))?,
             namespace_type: field_namespace_type.ok_or_else(|| ::serde::de::Error::missing_field("namespace_type"))?,
-            team_member_id: field_team_member_id,
+            team_member_id: field_team_member_id.and_then(Option::flatten),
         };
         Ok(Some(result))
     }
@@ -23160,7 +23160,7 @@ impl RevokeDeviceSessionStatus {
         }
         let result = RevokeDeviceSessionStatus {
             success: field_success.ok_or_else(|| ::serde::de::Error::missing_field("success"))?,
-            error_type: field_error_type,
+            error_type: field_error_type.and_then(Option::flatten),
         };
         Ok(Some(result))
     }
@@ -23719,7 +23719,7 @@ impl RevokeLinkedAppStatus {
         }
         let result = RevokeLinkedAppStatus {
             success: field_success.ok_or_else(|| ::serde::de::Error::missing_field("success"))?,
-            error_type: field_error_type,
+            error_type: field_error_type.and_then(Option::flatten),
         };
         Ok(Some(result))
     }
@@ -23988,8 +23988,8 @@ impl SharingAllowlistAddArgs {
             }
         }
         let result = SharingAllowlistAddArgs {
-            domains: field_domains,
-            emails: field_emails,
+            domains: field_domains.and_then(Option::flatten),
+            emails: field_emails.and_then(Option::flatten),
         };
         Ok(result)
     }
@@ -24718,8 +24718,8 @@ impl SharingAllowlistRemoveArgs {
             }
         }
         let result = SharingAllowlistRemoveArgs {
-            domains: field_domains,
-            emails: field_emails,
+            domains: field_domains.and_then(Option::flatten),
+            emails: field_emails.and_then(Option::flatten),
         };
         Ok(result)
     }
@@ -25675,7 +25675,7 @@ impl TeamFolderCreateArg {
         }
         let result = TeamFolderCreateArg {
             name: field_name.ok_or_else(|| ::serde::de::Error::missing_field("name"))?,
-            sync_setting: field_sync_setting,
+            sync_setting: field_sync_setting.and_then(Option::flatten),
         };
         Ok(Some(result))
     }
@@ -27399,8 +27399,8 @@ impl TeamFolderUpdateSyncSettingsArg {
         }
         let result = TeamFolderUpdateSyncSettingsArg {
             team_folder_id: field_team_folder_id.ok_or_else(|| ::serde::de::Error::missing_field("team_folder_id"))?,
-            sync_setting: field_sync_setting,
-            content_sync_settings: field_content_sync_settings,
+            sync_setting: field_sync_setting.and_then(Option::flatten),
+            content_sync_settings: field_content_sync_settings.and_then(Option::flatten),
         };
         Ok(Some(result))
     }
@@ -27922,7 +27922,7 @@ impl TeamMemberInfoV2 {
         }
         let result = TeamMemberInfoV2 {
             profile: field_profile.ok_or_else(|| ::serde::de::Error::missing_field("profile"))?,
-            roles: field_roles,
+            roles: field_roles.and_then(Option::flatten),
         };
         Ok(Some(result))
     }
@@ -28356,15 +28356,15 @@ impl TeamMemberProfile {
             membership_type: field_membership_type.ok_or_else(|| ::serde::de::Error::missing_field("membership_type"))?,
             groups: field_groups.ok_or_else(|| ::serde::de::Error::missing_field("groups"))?,
             member_folder_id: field_member_folder_id.ok_or_else(|| ::serde::de::Error::missing_field("member_folder_id"))?,
-            external_id: field_external_id,
-            account_id: field_account_id,
-            secondary_emails: field_secondary_emails,
-            invited_on: field_invited_on,
-            joined_on: field_joined_on,
-            suspended_on: field_suspended_on,
-            persistent_id: field_persistent_id,
-            is_directory_restricted: field_is_directory_restricted,
-            profile_photo_url: field_profile_photo_url,
+            external_id: field_external_id.and_then(Option::flatten),
+            account_id: field_account_id.and_then(Option::flatten),
+            secondary_emails: field_secondary_emails.and_then(Option::flatten),
+            invited_on: field_invited_on.and_then(Option::flatten),
+            joined_on: field_joined_on.and_then(Option::flatten),
+            suspended_on: field_suspended_on.and_then(Option::flatten),
+            persistent_id: field_persistent_id.and_then(Option::flatten),
+            is_directory_restricted: field_is_directory_restricted.and_then(Option::flatten),
+            profile_photo_url: field_profile_photo_url.and_then(Option::flatten),
         };
         Ok(Some(result))
     }
@@ -29751,7 +29751,7 @@ impl UserCustomQuotaResult {
         }
         let result = UserCustomQuotaResult {
             user: field_user.ok_or_else(|| ::serde::de::Error::missing_field("user"))?,
-            quota_gb: field_quota_gb,
+            quota_gb: field_quota_gb.and_then(Option::flatten),
         };
         Ok(Some(result))
     }

--- a/src/generated/team.rs
+++ b/src/generated/team.rs
@@ -4110,7 +4110,9 @@ impl ExcludedUsersListArg {
         s: &mut S::SerializeStruct,
     ) -> Result<(), S::Error> {
         use serde::ser::SerializeStruct;
-        s.serialize_field("limit", &self.limit)?;
+        if self.limit != 1000 {
+            s.serialize_field("limit", &self.limit)?;
+        }
         Ok(())
     }
 }
@@ -6191,7 +6193,9 @@ impl GroupCreateArg {
     ) -> Result<(), S::Error> {
         use serde::ser::SerializeStruct;
         s.serialize_field("group_name", &self.group_name)?;
-        s.serialize_field("add_creator_as_owner", &self.add_creator_as_owner)?;
+        if self.add_creator_as_owner {
+            s.serialize_field("add_creator_as_owner", &self.add_creator_as_owner)?;
+        }
         if let Some(val) = &self.group_external_id {
             s.serialize_field("group_external_id", val)?;
         }
@@ -7105,7 +7109,9 @@ impl GroupMembersAddArg {
         use serde::ser::SerializeStruct;
         s.serialize_field("group", &self.group)?;
         s.serialize_field("members", &self.members)?;
-        s.serialize_field("return_members", &self.return_members)?;
+        if !self.return_members {
+            s.serialize_field("return_members", &self.return_members)?;
+        }
         Ok(())
     }
 }
@@ -7505,7 +7511,9 @@ impl GroupMembersRemoveArg {
         use serde::ser::SerializeStruct;
         s.serialize_field("group", &self.group)?;
         s.serialize_field("users", &self.users)?;
-        s.serialize_field("return_members", &self.return_members)?;
+        if !self.return_members {
+            s.serialize_field("return_members", &self.return_members)?;
+        }
         Ok(())
     }
 }
@@ -7975,7 +7983,9 @@ impl GroupMembersSetAccessTypeArg {
         s.serialize_field("group", &self.group)?;
         s.serialize_field("user", &self.user)?;
         s.serialize_field("access_type", &self.access_type)?;
-        s.serialize_field("return_members", &self.return_members)?;
+        if !self.return_members {
+            s.serialize_field("return_members", &self.return_members)?;
+        }
         Ok(())
     }
 }
@@ -8366,7 +8376,9 @@ impl GroupUpdateArgs {
     ) -> Result<(), S::Error> {
         use serde::ser::SerializeStruct;
         s.serialize_field("group", &self.group)?;
-        s.serialize_field("return_members", &self.return_members)?;
+        if !self.return_members {
+            s.serialize_field("return_members", &self.return_members)?;
+        }
         if let Some(val) = &self.new_group_name {
             s.serialize_field("new_group_name", val)?;
         }
@@ -8709,7 +8721,9 @@ impl GroupsListArg {
         s: &mut S::SerializeStruct,
     ) -> Result<(), S::Error> {
         use serde::ser::SerializeStruct;
-        s.serialize_field("limit", &self.limit)?;
+        if self.limit != 1000 {
+            s.serialize_field("limit", &self.limit)?;
+        }
         Ok(())
     }
 }
@@ -9098,7 +9112,9 @@ impl GroupsMembersListArg {
     ) -> Result<(), S::Error> {
         use serde::ser::SerializeStruct;
         s.serialize_field("group", &self.group)?;
-        s.serialize_field("limit", &self.limit)?;
+        if self.limit != 1000 {
+            s.serialize_field("limit", &self.limit)?;
+        }
         Ok(())
     }
 }
@@ -9816,7 +9832,9 @@ impl IncludeMembersArg {
         s: &mut S::SerializeStruct,
     ) -> Result<(), S::Error> {
         use serde::ser::SerializeStruct;
-        s.serialize_field("return_members", &self.return_members)?;
+        if !self.return_members {
+            s.serialize_field("return_members", &self.return_members)?;
+        }
         Ok(())
     }
 }
@@ -11218,7 +11236,9 @@ impl LegalHoldsListPoliciesArg {
         s: &mut S::SerializeStruct,
     ) -> Result<(), S::Error> {
         use serde::ser::SerializeStruct;
-        s.serialize_field("include_released", &self.include_released)?;
+        if self.include_released {
+            s.serialize_field("include_released", &self.include_released)?;
+        }
         Ok(())
     }
 }
@@ -12640,9 +12660,15 @@ impl ListMemberDevicesArg {
     ) -> Result<(), S::Error> {
         use serde::ser::SerializeStruct;
         s.serialize_field("team_member_id", &self.team_member_id)?;
-        s.serialize_field("include_web_sessions", &self.include_web_sessions)?;
-        s.serialize_field("include_desktop_clients", &self.include_desktop_clients)?;
-        s.serialize_field("include_mobile_clients", &self.include_mobile_clients)?;
+        if !self.include_web_sessions {
+            s.serialize_field("include_web_sessions", &self.include_web_sessions)?;
+        }
+        if !self.include_desktop_clients {
+            s.serialize_field("include_desktop_clients", &self.include_desktop_clients)?;
+        }
+        if !self.include_mobile_clients {
+            s.serialize_field("include_mobile_clients", &self.include_mobile_clients)?;
+        }
         Ok(())
     }
 }
@@ -13256,9 +13282,15 @@ impl ListMembersDevicesArg {
         if let Some(val) = &self.cursor {
             s.serialize_field("cursor", val)?;
         }
-        s.serialize_field("include_web_sessions", &self.include_web_sessions)?;
-        s.serialize_field("include_desktop_clients", &self.include_desktop_clients)?;
-        s.serialize_field("include_mobile_clients", &self.include_mobile_clients)?;
+        if !self.include_web_sessions {
+            s.serialize_field("include_web_sessions", &self.include_web_sessions)?;
+        }
+        if !self.include_desktop_clients {
+            s.serialize_field("include_desktop_clients", &self.include_desktop_clients)?;
+        }
+        if !self.include_mobile_clients {
+            s.serialize_field("include_mobile_clients", &self.include_mobile_clients)?;
+        }
         Ok(())
     }
 }
@@ -13877,9 +13909,15 @@ impl ListTeamDevicesArg {
         if let Some(val) = &self.cursor {
             s.serialize_field("cursor", val)?;
         }
-        s.serialize_field("include_web_sessions", &self.include_web_sessions)?;
-        s.serialize_field("include_desktop_clients", &self.include_desktop_clients)?;
-        s.serialize_field("include_mobile_clients", &self.include_mobile_clients)?;
+        if !self.include_web_sessions {
+            s.serialize_field("include_web_sessions", &self.include_web_sessions)?;
+        }
+        if !self.include_desktop_clients {
+            s.serialize_field("include_desktop_clients", &self.include_desktop_clients)?;
+        }
+        if !self.include_mobile_clients {
+            s.serialize_field("include_mobile_clients", &self.include_mobile_clients)?;
+        }
         Ok(())
     }
 }
@@ -14400,11 +14438,15 @@ impl MemberAddArg {
         if let Some(val) = &self.member_persistent_id {
             s.serialize_field("member_persistent_id", val)?;
         }
-        s.serialize_field("send_welcome_email", &self.send_welcome_email)?;
+        if !self.send_welcome_email {
+            s.serialize_field("send_welcome_email", &self.send_welcome_email)?;
+        }
         if let Some(val) = &self.is_directory_restricted {
             s.serialize_field("is_directory_restricted", val)?;
         }
-        s.serialize_field("role", &self.role)?;
+        if self.role != AdminTier::MemberOnly {
+            s.serialize_field("role", &self.role)?;
+        }
         Ok(())
     }
 }
@@ -14612,7 +14654,9 @@ impl MemberAddArgBase {
         if let Some(val) = &self.member_persistent_id {
             s.serialize_field("member_persistent_id", val)?;
         }
-        s.serialize_field("send_welcome_email", &self.send_welcome_email)?;
+        if !self.send_welcome_email {
+            s.serialize_field("send_welcome_email", &self.send_welcome_email)?;
+        }
         if let Some(val) = &self.is_directory_restricted {
             s.serialize_field("is_directory_restricted", val)?;
         }
@@ -15281,7 +15325,9 @@ impl MemberAddV2Arg {
         if let Some(val) = &self.member_persistent_id {
             s.serialize_field("member_persistent_id", val)?;
         }
-        s.serialize_field("send_welcome_email", &self.send_welcome_email)?;
+        if !self.send_welcome_email {
+            s.serialize_field("send_welcome_email", &self.send_welcome_email)?;
+        }
         if let Some(val) = &self.is_directory_restricted {
             s.serialize_field("is_directory_restricted", val)?;
         }
@@ -16311,7 +16357,9 @@ impl MembersAddArg {
     ) -> Result<(), S::Error> {
         use serde::ser::SerializeStruct;
         s.serialize_field("new_members", &self.new_members)?;
-        s.serialize_field("force_async", &self.force_async)?;
+        if self.force_async {
+            s.serialize_field("force_async", &self.force_async)?;
+        }
         Ok(())
     }
 }
@@ -16390,7 +16438,9 @@ impl MembersAddArgBase {
         s: &mut S::SerializeStruct,
     ) -> Result<(), S::Error> {
         use serde::ser::SerializeStruct;
-        s.serialize_field("force_async", &self.force_async)?;
+        if self.force_async {
+            s.serialize_field("force_async", &self.force_async)?;
+        }
         Ok(())
     }
 }
@@ -16827,7 +16877,9 @@ impl MembersAddV2Arg {
     ) -> Result<(), S::Error> {
         use serde::ser::SerializeStruct;
         s.serialize_field("new_members", &self.new_members)?;
-        s.serialize_field("force_async", &self.force_async)?;
+        if self.force_async {
+            s.serialize_field("force_async", &self.force_async)?;
+        }
         Ok(())
     }
 }
@@ -17057,7 +17109,9 @@ impl MembersDeactivateArg {
     ) -> Result<(), S::Error> {
         use serde::ser::SerializeStruct;
         s.serialize_field("user", &self.user)?;
-        s.serialize_field("wipe_data", &self.wipe_data)?;
+        if !self.wipe_data {
+            s.serialize_field("wipe_data", &self.wipe_data)?;
+        }
         Ok(())
     }
 }
@@ -18248,8 +18302,12 @@ impl MembersListArg {
         s: &mut S::SerializeStruct,
     ) -> Result<(), S::Error> {
         use serde::ser::SerializeStruct;
-        s.serialize_field("limit", &self.limit)?;
-        s.serialize_field("include_removed", &self.include_removed)?;
+        if self.limit != 1000 {
+            s.serialize_field("limit", &self.limit)?;
+        }
+        if self.include_removed {
+            s.serialize_field("include_removed", &self.include_removed)?;
+        }
         Ok(())
     }
 }
@@ -19075,15 +19133,21 @@ impl MembersRemoveArg {
     ) -> Result<(), S::Error> {
         use serde::ser::SerializeStruct;
         s.serialize_field("user", &self.user)?;
-        s.serialize_field("wipe_data", &self.wipe_data)?;
+        if !self.wipe_data {
+            s.serialize_field("wipe_data", &self.wipe_data)?;
+        }
         if let Some(val) = &self.transfer_dest_id {
             s.serialize_field("transfer_dest_id", val)?;
         }
         if let Some(val) = &self.transfer_admin_id {
             s.serialize_field("transfer_admin_id", val)?;
         }
-        s.serialize_field("keep_account", &self.keep_account)?;
-        s.serialize_field("retain_team_shares", &self.retain_team_shares)?;
+        if self.keep_account {
+            s.serialize_field("keep_account", &self.keep_account)?;
+        }
+        if self.retain_team_shares {
+            s.serialize_field("retain_team_shares", &self.retain_team_shares)?;
+        }
         Ok(())
     }
 }
@@ -22614,7 +22678,9 @@ impl RevokeDesktopClientArg {
         use serde::ser::SerializeStruct;
         s.serialize_field("session_id", &self.session_id)?;
         s.serialize_field("team_member_id", &self.team_member_id)?;
-        s.serialize_field("delete_on_unlink", &self.delete_on_unlink)?;
+        if self.delete_on_unlink {
+            s.serialize_field("delete_on_unlink", &self.delete_on_unlink)?;
+        }
         Ok(())
     }
 }
@@ -23230,7 +23296,9 @@ impl RevokeLinkedApiAppArg {
         use serde::ser::SerializeStruct;
         s.serialize_field("app_id", &self.app_id)?;
         s.serialize_field("team_member_id", &self.team_member_id)?;
-        s.serialize_field("keep_app_folder", &self.keep_app_folder)?;
+        if !self.keep_app_folder {
+            s.serialize_field("keep_app_folder", &self.keep_app_folder)?;
+        }
         Ok(())
     }
 }
@@ -24204,7 +24272,9 @@ impl SharingAllowlistListArg {
         s: &mut S::SerializeStruct,
     ) -> Result<(), S::Error> {
         use serde::ser::SerializeStruct;
-        s.serialize_field("limit", &self.limit)?;
+        if self.limit != 1000 {
+            s.serialize_field("limit", &self.limit)?;
+        }
         Ok(())
     }
 }
@@ -24559,8 +24629,12 @@ impl SharingAllowlistListResponse {
         use serde::ser::SerializeStruct;
         s.serialize_field("domains", &self.domains)?;
         s.serialize_field("emails", &self.emails)?;
-        s.serialize_field("cursor", &self.cursor)?;
-        s.serialize_field("has_more", &self.has_more)?;
+        if !self.cursor.is_empty() {
+            s.serialize_field("cursor", &self.cursor)?;
+        }
+        if self.has_more {
+            s.serialize_field("has_more", &self.has_more)?;
+        }
         Ok(())
     }
 }
@@ -25239,7 +25313,9 @@ impl TeamFolderArchiveArg {
     ) -> Result<(), S::Error> {
         use serde::ser::SerializeStruct;
         s.serialize_field("team_folder_id", &self.team_folder_id)?;
-        s.serialize_field("force_async_off", &self.force_async_off)?;
+        if self.force_async_off {
+            s.serialize_field("force_async_off", &self.force_async_off)?;
+        }
         Ok(())
     }
 }
@@ -26151,7 +26227,9 @@ impl TeamFolderListArg {
         s: &mut S::SerializeStruct,
     ) -> Result<(), S::Error> {
         use serde::ser::SerializeStruct;
-        s.serialize_field("limit", &self.limit)?;
+        if self.limit != 1000 {
+            s.serialize_field("limit", &self.limit)?;
+        }
         Ok(())
     }
 }
@@ -27638,7 +27716,9 @@ impl TeamGetInfoResult {
         s.serialize_field("num_licensed_users", &self.num_licensed_users)?;
         s.serialize_field("num_provisioned_users", &self.num_provisioned_users)?;
         s.serialize_field("policies", &self.policies)?;
-        s.serialize_field("num_used_licenses", &self.num_used_licenses)?;
+        if self.num_used_licenses != 0 {
+            s.serialize_field("num_used_licenses", &self.num_used_licenses)?;
+        }
         Ok(())
     }
 }
@@ -28678,7 +28758,9 @@ impl TeamNamespacesListArg {
         s: &mut S::SerializeStruct,
     ) -> Result<(), S::Error> {
         use serde::ser::SerializeStruct;
-        s.serialize_field("limit", &self.limit)?;
+        if self.limit != 1000 {
+            s.serialize_field("limit", &self.limit)?;
+        }
         Ok(())
     }
 }

--- a/src/generated/team_common.rs
+++ b/src/generated/team_common.rs
@@ -198,8 +198,8 @@ impl GroupSummary {
             group_name: field_group_name.ok_or_else(|| ::serde::de::Error::missing_field("group_name"))?,
             group_id: field_group_id.ok_or_else(|| ::serde::de::Error::missing_field("group_id"))?,
             group_management_type: field_group_management_type.ok_or_else(|| ::serde::de::Error::missing_field("group_management_type"))?,
-            group_external_id: field_group_external_id,
-            member_count: field_member_count,
+            group_external_id: field_group_external_id.and_then(Option::flatten),
+            member_count: field_member_count.and_then(Option::flatten),
         };
         Ok(Some(result))
     }
@@ -447,8 +447,8 @@ impl TimeRange {
             }
         }
         let result = TimeRange {
-            start_time: field_start_time,
-            end_time: field_end_time,
+            start_time: field_start_time.and_then(Option::flatten),
+            end_time: field_end_time.and_then(Option::flatten),
         };
         Ok(result)
     }

--- a/src/generated/users.rs
+++ b/src/generated/users.rs
@@ -201,7 +201,7 @@ impl Account {
             email: field_email.ok_or_else(|| ::serde::de::Error::missing_field("email"))?,
             email_verified: field_email_verified.ok_or_else(|| ::serde::de::Error::missing_field("email_verified"))?,
             disabled: field_disabled.ok_or_else(|| ::serde::de::Error::missing_field("disabled"))?,
-            profile_photo_url: field_profile_photo_url,
+            profile_photo_url: field_profile_photo_url.and_then(Option::flatten),
         };
         Ok(Some(result))
     }
@@ -403,8 +403,8 @@ impl BasicAccount {
             email_verified: field_email_verified.ok_or_else(|| ::serde::de::Error::missing_field("email_verified"))?,
             disabled: field_disabled.ok_or_else(|| ::serde::de::Error::missing_field("disabled"))?,
             is_teammate: field_is_teammate.ok_or_else(|| ::serde::de::Error::missing_field("is_teammate"))?,
-            profile_photo_url: field_profile_photo_url,
-            team_member_id: field_team_member_id,
+            profile_photo_url: field_profile_photo_url.and_then(Option::flatten),
+            team_member_id: field_team_member_id.and_then(Option::flatten),
         };
         Ok(Some(result))
     }
@@ -760,10 +760,10 @@ impl FullAccount {
             is_paired: field_is_paired.ok_or_else(|| ::serde::de::Error::missing_field("is_paired"))?,
             account_type: field_account_type.ok_or_else(|| ::serde::de::Error::missing_field("account_type"))?,
             root_info: field_root_info.ok_or_else(|| ::serde::de::Error::missing_field("root_info"))?,
-            profile_photo_url: field_profile_photo_url,
-            country: field_country,
-            team: field_team,
-            team_member_id: field_team_member_id,
+            profile_photo_url: field_profile_photo_url.and_then(Option::flatten),
+            country: field_country.and_then(Option::flatten),
+            team: field_team.and_then(Option::flatten),
+            team_member_id: field_team_member_id.and_then(Option::flatten),
         };
         Ok(Some(result))
     }

--- a/tests/compatibility.rs
+++ b/tests/compatibility.rs
@@ -100,38 +100,3 @@ fn test_open_polymorphic_struct() {
         panic!("wrong variant");
     }
 }
-
-#[test]
-fn test_null_fields_elided() {
-    // This isn't really a compatibility test, but...
-    // Struct fields with optional or default values don't need to be serialized.
-    let value = dropbox_sdk::files::Metadata::File(
-        dropbox_sdk::files::FileMetadata::new(
-            "name".to_owned(),
-            "id".to_owned(),
-            "client_modified".to_owned(),
-            "server_modified".to_owned(),
-            "rev".to_owned(),
-            1337)
-        // Many other optional fields not populated.
-    );
-
-    // Serialized value should only contain these fields, and should not have the optional fields
-    // included, like `"media_info": null`.
-    let expected = serde_json::json!({
-        ".tag": "file",
-        "name": "name",
-        "id": "id",
-        "client_modified": "client_modified",
-        "server_modified": "server_modified",
-        "rev": "rev",
-        "size": 1337,
-    });
-    let s = serde_json::to_string_pretty(&value).unwrap();
-    let deser = serde_json::from_str::<serde_json::Value>(&s).unwrap();
-    assert_eq!(expected, deser);
-
-    // Make sure deserializing it also works and we get our starting value back.
-    let roundtrip = serde_json::from_str::<dropbox_sdk::files::Metadata>(&s).unwrap();
-    assert_eq!(roundtrip, value);
-}

--- a/tests/compatibility.rs
+++ b/tests/compatibility.rs
@@ -100,3 +100,40 @@ fn test_open_polymorphic_struct() {
         panic!("wrong variant");
     }
 }
+
+#[test]
+fn test_null_fields_elided() {
+    // This isn't really a compatibility test, but...
+    // Struct fields with optional or default values don't need to be serialized.
+    let value = dropbox_sdk::files::Metadata::File(
+        dropbox_sdk::files::FileMetadata::new(
+            "name".to_owned(),
+            "id".to_owned(),
+            "client_modified".to_owned(),
+            "server_modified".to_owned(),
+            "rev".to_owned(),
+            1337)
+        // Many other optional fields not populated.
+    );
+
+    // Serialized value should only contain these fields, and should not have the optional fields
+    // included, like `"media_info": null`.
+    let expected = serde_json::json!({
+        ".tag": "file",
+        "name": "name",
+        "id": "id",
+        "client_modified": "client_modified",
+        "server_modified": "server_modified",
+        "rev": "rev",
+        "size": 1337,
+        // FIXME(wfraser): this field is a default, it should not be included either
+        "is_downloadable": true,
+    });
+    let s = serde_json::to_string_pretty(&value).unwrap();
+    let deser = serde_json::from_str::<serde_json::Value>(&s).unwrap();
+    assert_eq!(expected, deser);
+
+    // Make sure deserializing it also works and we get our starting value back.
+    let roundtrip = serde_json::from_str::<dropbox_sdk::files::Metadata>(&s).unwrap();
+    assert_eq!(roundtrip, value);
+}

--- a/tests/compatibility.rs
+++ b/tests/compatibility.rs
@@ -126,8 +126,6 @@ fn test_null_fields_elided() {
         "server_modified": "server_modified",
         "rev": "rev",
         "size": 1337,
-        // FIXME(wfraser): this field is a default, it should not be included either
-        "is_downloadable": true,
     });
     let s = serde_json::to_string_pretty(&value).unwrap();
     let deser = serde_json::from_str::<serde_json::Value>(&s).unwrap();

--- a/tests/json.rs
+++ b/tests/json.rs
@@ -32,3 +32,38 @@ fn test_null_fields_elided() {
     let roundtrip = serde_json::from_str::<dropbox_sdk::files::Metadata>(&s).unwrap();
     assert_eq!(roundtrip, value);
 }
+
+#[test]
+fn test_missing_null_and_default() {
+    use dropbox_sdk::files::Metadata;
+
+    let a = r#"{
+        ".tag": "file",
+        "name": "name",
+        "id": "id",
+        "client_modified": "client_modified",
+        "server_modified": "server_modified",
+        "rev": "rev",
+        "size": 1337
+    }"#;
+
+    // Same as above, but add two more fields
+    // path_lower, set to null
+    // is_downloadable, set to the default value specified for this field
+    let b = r#"{
+        ".tag": "file",
+        "name": "name",
+        "id": "id",
+        "client_modified": "client_modified",
+        "server_modified": "server_modified",
+        "rev": "rev",
+        "size": 1337,
+        "path_lower": null,
+        "is_downloadable": true
+    }"#;
+
+    // These should both deserialize to the same value.
+    let a_de = serde_json::from_str::<Metadata>(a).unwrap();
+    let b_de = serde_json::from_str::<Metadata>(b).unwrap();
+    assert_eq!(a_de, b_de);
+}

--- a/tests/json.rs
+++ b/tests/json.rs
@@ -1,0 +1,34 @@
+#[test]
+fn test_null_fields_elided() {
+    // Struct fields with optional or default values don't need to be serialized.
+    let value = dropbox_sdk::files::Metadata::File(
+        dropbox_sdk::files::FileMetadata::new(
+            "name".to_owned(),
+            "id".to_owned(),
+            "client_modified".to_owned(),
+            "server_modified".to_owned(),
+            "rev".to_owned(),
+            1337)
+        // Many other optional fields not populated.
+    );
+
+    // Serialized value should only contain these fields, and should not have the optional fields
+    // included, like `"media_info": null`.
+    let expected = serde_json::json!({
+        ".tag": "file",
+        "name": "name",
+        "id": "id",
+        "client_modified": "client_modified",
+        "server_modified": "server_modified",
+        "rev": "rev",
+        "size": 1337,
+    });
+
+    let s = serde_json::to_string_pretty(&value).unwrap();
+    let deser = serde_json::from_str::<serde_json::Value>(&s).unwrap();
+    assert_eq!(expected, deser);
+
+    // Make sure deserializing it also works and we get our starting value back.
+    let roundtrip = serde_json::from_str::<dropbox_sdk::files::Metadata>(&s).unwrap();
+    assert_eq!(roundtrip, value);
+}


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description below.
-->
Four related parts to this change:

First, while structs already omit fields which are null while serializing, but I noticed that the polymorphic struct serializer (used for things like files::Metadata) did not. This changes those to call the logic in their inner structs to do so.

Second, while we skipped nulls, we can also skip non-nullable fields if they are set to the default value for the field.

Third, though the polymorphic struct serializer wrote json with nulls, the deserializer actually couldn't handle them. In practice this won't matter much because the actual Dropbox server backend doesn't do this, but it's still valid json so we should handle it.

Finally, this identified a gap in the automated testing: polymorphic structs did not have tests for their no-optional-fields case. I've implemented `_OnlyRequiredFields` test generation for them similar to those for plain structs. I went back and checked the current master branch, and with these tests, it would have had 32 test failures. This adds 227 new generated tests.

## **Checklist**

**General Contributing**
<!-- Change [ ] to [x] if you have: -->
- [x] I have read the Code of Conduct and signed the [CLA](https://opensource.dropbox.com/cla/).
- [x] I have added an entry to the `RELEASE_NOTES.md` file, or believe it's not necessary for this change.

**Validation**
<!-- Describe which tests cover the changes you've made, and any additional manual validation you
     did to ensure the correctness of this change. Does this change warrant addition of new tests?
     Does this change have performance implications? Etc. -->
Added a couple tests for this, and beefed up the generated tests to cover this in the future.