### PR TITLE
model the 'extends' relationship using From/Into

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -3,6 +3,8 @@ xxxx-yy-zz
 * MSRV raised to 1.63.0
 * Omit fields with null or default value in more places when serializing, and accept nulls when
   deserializing.
+* Types which have an `extends` relationship in the spec now implement `From` to do conversion to
+  or from the other type, as appropriate depending on the kind of types.
 
 # v0.16.0
 2023-08-13

--- a/src/generated/common.rs
+++ b/src/generated/common.rs
@@ -387,6 +387,12 @@ impl ::serde::ser::Serialize for TeamRootInfo {
     }
 }
 
+// struct extends polymorphic struct RootInfo
+impl From<TeamRootInfo> for RootInfo {
+    fn from(subtype: TeamRootInfo) -> Self {
+        RootInfo::Team(subtype)
+    }
+}
 /// Root info when user is not member of a team or the user is a member of a team and the team does
 /// not have a separate root namespace.
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -495,3 +501,9 @@ impl ::serde::ser::Serialize for UserRootInfo {
     }
 }
 
+// struct extends polymorphic struct RootInfo
+impl From<UserRootInfo> for RootInfo {
+    fn from(subtype: UserRootInfo) -> Self {
+        RootInfo::User(subtype)
+    }
+}

--- a/src/generated/dbx_async.rs
+++ b/src/generated/dbx_async.rs
@@ -78,6 +78,14 @@ impl ::serde::ser::Serialize for LaunchEmptyResult {
     }
 }
 
+// union extends LaunchResultBase
+impl From<LaunchResultBase> for LaunchEmptyResult {
+    fn from(parent: LaunchResultBase) -> Self {
+        match parent {
+            LaunchResultBase::AsyncJobId(x) => LaunchEmptyResult::AsyncJobId(x),
+        }
+    }
+}
 /// Result returned by methods that launch an asynchronous job. A method who may either launch an
 /// asynchronous job, or complete the request synchronously, can use this union by extending it, and
 /// adding a 'complete' field with the type of the synchronous response. See
@@ -293,6 +301,14 @@ impl ::serde::ser::Serialize for PollEmptyResult {
     }
 }
 
+// union extends PollResultBase
+impl From<PollResultBase> for PollEmptyResult {
+    fn from(parent: PollResultBase) -> Self {
+        match parent {
+            PollResultBase::InProgress => PollEmptyResult::InProgress,
+        }
+    }
+}
 /// Error returned by methods for polling the status of asynchronous job.
 #[derive(Debug, Clone, PartialEq, Eq)]
 #[non_exhaustive] // variants may be added in the future

--- a/src/generated/file_properties.rs
+++ b/src/generated/file_properties.rs
@@ -563,6 +563,21 @@ impl ::std::fmt::Display for AddPropertiesError {
     }
 }
 
+// union extends InvalidPropertyGroupError
+impl From<InvalidPropertyGroupError> for AddPropertiesError {
+    fn from(parent: InvalidPropertyGroupError) -> Self {
+        match parent {
+            InvalidPropertyGroupError::TemplateNotFound(x) => AddPropertiesError::TemplateNotFound(x),
+            InvalidPropertyGroupError::RestrictedContent => AddPropertiesError::RestrictedContent,
+            InvalidPropertyGroupError::Other => AddPropertiesError::Other,
+            InvalidPropertyGroupError::Path(x) => AddPropertiesError::Path(x),
+            InvalidPropertyGroupError::UnsupportedFolder => AddPropertiesError::UnsupportedFolder,
+            InvalidPropertyGroupError::PropertyFieldTooLarge => AddPropertiesError::PropertyFieldTooLarge,
+            InvalidPropertyGroupError::DoesNotFitTemplate => AddPropertiesError::DoesNotFitTemplate,
+            InvalidPropertyGroupError::DuplicatePropertyGroups => AddPropertiesError::DuplicatePropertyGroups,
+        }
+    }
+}
 #[derive(Debug, Clone, PartialEq, Eq)]
 #[non_exhaustive] // structs may have more fields added in the future.
 pub struct AddTemplateArg {
@@ -681,6 +696,16 @@ impl ::serde::ser::Serialize for AddTemplateArg {
     }
 }
 
+// struct extends PropertyGroupTemplate
+impl From<AddTemplateArg> for PropertyGroupTemplate {
+    fn from(subtype: AddTemplateArg) -> Self {
+        Self {
+            name: subtype.name,
+            description: subtype.description,
+            fields: subtype.fields,
+        }
+    }
+}
 #[derive(Debug, Clone, PartialEq, Eq)]
 #[non_exhaustive] // structs may have more fields added in the future.
 pub struct AddTemplateResult {
@@ -985,6 +1010,16 @@ impl ::serde::ser::Serialize for GetTemplateResult {
     }
 }
 
+// struct extends PropertyGroupTemplate
+impl From<GetTemplateResult> for PropertyGroupTemplate {
+    fn from(subtype: GetTemplateResult) -> Self {
+        Self {
+            name: subtype.name,
+            description: subtype.description,
+            fields: subtype.fields,
+        }
+    }
+}
 #[derive(Debug, Clone, PartialEq, Eq)]
 #[non_exhaustive] // variants may be added in the future
 pub enum InvalidPropertyGroupError {
@@ -1137,6 +1172,18 @@ impl ::std::fmt::Display for InvalidPropertyGroupError {
     }
 }
 
+// union extends PropertiesError
+impl From<PropertiesError> for InvalidPropertyGroupError {
+    fn from(parent: PropertiesError) -> Self {
+        match parent {
+            PropertiesError::TemplateNotFound(x) => InvalidPropertyGroupError::TemplateNotFound(x),
+            PropertiesError::RestrictedContent => InvalidPropertyGroupError::RestrictedContent,
+            PropertiesError::Other => InvalidPropertyGroupError::Other,
+            PropertiesError::Path(x) => InvalidPropertyGroupError::Path(x),
+            PropertiesError::UnsupportedFolder => InvalidPropertyGroupError::UnsupportedFolder,
+        }
+    }
+}
 #[derive(Debug, Clone, PartialEq, Eq)]
 #[non_exhaustive] // structs may have more fields added in the future.
 pub struct ListTemplateResult {
@@ -1601,6 +1648,16 @@ impl ::std::fmt::Display for ModifyTemplateError {
     }
 }
 
+// union extends TemplateError
+impl From<TemplateError> for ModifyTemplateError {
+    fn from(parent: TemplateError) -> Self {
+        match parent {
+            TemplateError::TemplateNotFound(x) => ModifyTemplateError::TemplateNotFound(x),
+            TemplateError::RestrictedContent => ModifyTemplateError::RestrictedContent,
+            TemplateError::Other => ModifyTemplateError::Other,
+        }
+    }
+}
 #[derive(Debug, Clone, PartialEq, Eq)]
 #[non_exhaustive] // structs may have more fields added in the future.
 pub struct OverwritePropertyGroupArg {
@@ -1825,6 +1882,16 @@ impl ::std::fmt::Display for PropertiesError {
     }
 }
 
+// union extends TemplateError
+impl From<TemplateError> for PropertiesError {
+    fn from(parent: TemplateError) -> Self {
+        match parent {
+            TemplateError::TemplateNotFound(x) => PropertiesError::TemplateNotFound(x),
+            TemplateError::RestrictedContent => PropertiesError::RestrictedContent,
+            TemplateError::Other => PropertiesError::Other,
+        }
+    }
+}
 #[derive(Debug, Clone, PartialEq, Eq)]
 #[non_exhaustive] // structs may have more fields added in the future.
 pub struct PropertiesSearchArg {
@@ -3491,6 +3558,18 @@ impl ::std::fmt::Display for RemovePropertiesError {
     }
 }
 
+// union extends PropertiesError
+impl From<PropertiesError> for RemovePropertiesError {
+    fn from(parent: PropertiesError) -> Self {
+        match parent {
+            PropertiesError::TemplateNotFound(x) => RemovePropertiesError::TemplateNotFound(x),
+            PropertiesError::RestrictedContent => RemovePropertiesError::RestrictedContent,
+            PropertiesError::Other => RemovePropertiesError::Other,
+            PropertiesError::Path(x) => RemovePropertiesError::Path(x),
+            PropertiesError::UnsupportedFolder => RemovePropertiesError::UnsupportedFolder,
+        }
+    }
+}
 #[derive(Debug, Clone, PartialEq, Eq)]
 #[non_exhaustive] // structs may have more fields added in the future.
 pub struct RemoveTemplateArg {
@@ -3741,6 +3820,15 @@ impl ::serde::ser::Serialize for TemplateFilter {
     }
 }
 
+// union extends TemplateFilterBase
+impl From<TemplateFilterBase> for TemplateFilter {
+    fn from(parent: TemplateFilterBase) -> Self {
+        match parent {
+            TemplateFilterBase::FilterSome(x) => TemplateFilter::FilterSome(x),
+            TemplateFilterBase::Other => TemplateFilter::Other,
+        }
+    }
+}
 #[derive(Debug, Clone, PartialEq, Eq)]
 #[non_exhaustive] // variants may be added in the future
 pub enum TemplateFilterBase {
@@ -4143,6 +4231,21 @@ impl ::std::fmt::Display for UpdatePropertiesError {
     }
 }
 
+// union extends InvalidPropertyGroupError
+impl From<InvalidPropertyGroupError> for UpdatePropertiesError {
+    fn from(parent: InvalidPropertyGroupError) -> Self {
+        match parent {
+            InvalidPropertyGroupError::TemplateNotFound(x) => UpdatePropertiesError::TemplateNotFound(x),
+            InvalidPropertyGroupError::RestrictedContent => UpdatePropertiesError::RestrictedContent,
+            InvalidPropertyGroupError::Other => UpdatePropertiesError::Other,
+            InvalidPropertyGroupError::Path(x) => UpdatePropertiesError::Path(x),
+            InvalidPropertyGroupError::UnsupportedFolder => UpdatePropertiesError::UnsupportedFolder,
+            InvalidPropertyGroupError::PropertyFieldTooLarge => UpdatePropertiesError::PropertyFieldTooLarge,
+            InvalidPropertyGroupError::DoesNotFitTemplate => UpdatePropertiesError::DoesNotFitTemplate,
+            InvalidPropertyGroupError::DuplicatePropertyGroups => UpdatePropertiesError::DuplicatePropertyGroups,
+        }
+    }
+}
 #[derive(Debug, Clone, PartialEq, Eq)]
 #[non_exhaustive] // structs may have more fields added in the future.
 pub struct UpdateTemplateArg {

--- a/src/generated/file_requests.rs
+++ b/src/generated/file_requests.rs
@@ -208,6 +208,15 @@ impl ::std::fmt::Display for CountFileRequestsError {
     }
 }
 
+// union extends GeneralFileRequestsError
+impl From<GeneralFileRequestsError> for CountFileRequestsError {
+    fn from(parent: GeneralFileRequestsError) -> Self {
+        match parent {
+            GeneralFileRequestsError::DisabledForTeam => CountFileRequestsError::DisabledForTeam,
+            GeneralFileRequestsError::Other => CountFileRequestsError::Other,
+        }
+    }
+}
 /// Result for [`count()`](count).
 #[derive(Debug, Clone, PartialEq, Eq)]
 #[non_exhaustive] // structs may have more fields added in the future.
@@ -628,6 +637,21 @@ impl ::std::fmt::Display for CreateFileRequestError {
     }
 }
 
+// union extends FileRequestError
+impl From<FileRequestError> for CreateFileRequestError {
+    fn from(parent: FileRequestError) -> Self {
+        match parent {
+            FileRequestError::DisabledForTeam => CreateFileRequestError::DisabledForTeam,
+            FileRequestError::Other => CreateFileRequestError::Other,
+            FileRequestError::NotFound => CreateFileRequestError::NotFound,
+            FileRequestError::NotAFolder => CreateFileRequestError::NotAFolder,
+            FileRequestError::AppLacksAccess => CreateFileRequestError::AppLacksAccess,
+            FileRequestError::NoPermission => CreateFileRequestError::NoPermission,
+            FileRequestError::EmailUnverified => CreateFileRequestError::EmailUnverified,
+            FileRequestError::ValidationError => CreateFileRequestError::ValidationError,
+        }
+    }
+}
 /// There was an error deleting all closed file requests.
 #[derive(Debug, Clone, PartialEq, Eq)]
 #[non_exhaustive] // variants may be added in the future
@@ -765,6 +789,21 @@ impl ::std::fmt::Display for DeleteAllClosedFileRequestsError {
     }
 }
 
+// union extends FileRequestError
+impl From<FileRequestError> for DeleteAllClosedFileRequestsError {
+    fn from(parent: FileRequestError) -> Self {
+        match parent {
+            FileRequestError::DisabledForTeam => DeleteAllClosedFileRequestsError::DisabledForTeam,
+            FileRequestError::Other => DeleteAllClosedFileRequestsError::Other,
+            FileRequestError::NotFound => DeleteAllClosedFileRequestsError::NotFound,
+            FileRequestError::NotAFolder => DeleteAllClosedFileRequestsError::NotAFolder,
+            FileRequestError::AppLacksAccess => DeleteAllClosedFileRequestsError::AppLacksAccess,
+            FileRequestError::NoPermission => DeleteAllClosedFileRequestsError::NoPermission,
+            FileRequestError::EmailUnverified => DeleteAllClosedFileRequestsError::EmailUnverified,
+            FileRequestError::ValidationError => DeleteAllClosedFileRequestsError::ValidationError,
+        }
+    }
+}
 /// Result for [`delete_all_closed()`](delete_all_closed).
 #[derive(Debug, Clone, PartialEq, Eq)]
 #[non_exhaustive] // structs may have more fields added in the future.
@@ -1097,6 +1136,21 @@ impl ::std::fmt::Display for DeleteFileRequestError {
     }
 }
 
+// union extends FileRequestError
+impl From<FileRequestError> for DeleteFileRequestError {
+    fn from(parent: FileRequestError) -> Self {
+        match parent {
+            FileRequestError::DisabledForTeam => DeleteFileRequestError::DisabledForTeam,
+            FileRequestError::Other => DeleteFileRequestError::Other,
+            FileRequestError::NotFound => DeleteFileRequestError::NotFound,
+            FileRequestError::NotAFolder => DeleteFileRequestError::NotAFolder,
+            FileRequestError::AppLacksAccess => DeleteFileRequestError::AppLacksAccess,
+            FileRequestError::NoPermission => DeleteFileRequestError::NoPermission,
+            FileRequestError::EmailUnverified => DeleteFileRequestError::EmailUnverified,
+            FileRequestError::ValidationError => DeleteFileRequestError::ValidationError,
+        }
+    }
+}
 /// Result for [`delete()`](delete).
 #[derive(Debug, Clone, PartialEq, Eq)]
 #[non_exhaustive] // structs may have more fields added in the future.
@@ -1666,6 +1720,15 @@ impl ::std::fmt::Display for FileRequestError {
     }
 }
 
+// union extends GeneralFileRequestsError
+impl From<GeneralFileRequestsError> for FileRequestError {
+    fn from(parent: GeneralFileRequestsError) -> Self {
+        match parent {
+            GeneralFileRequestsError::DisabledForTeam => FileRequestError::DisabledForTeam,
+            GeneralFileRequestsError::Other => FileRequestError::Other,
+        }
+    }
+}
 /// There is an error accessing the file requests functionality.
 #[derive(Debug, Clone, PartialEq, Eq)]
 #[non_exhaustive] // variants may be added in the future
@@ -1963,6 +2026,21 @@ impl ::std::fmt::Display for GetFileRequestError {
     }
 }
 
+// union extends FileRequestError
+impl From<FileRequestError> for GetFileRequestError {
+    fn from(parent: FileRequestError) -> Self {
+        match parent {
+            FileRequestError::DisabledForTeam => GetFileRequestError::DisabledForTeam,
+            FileRequestError::Other => GetFileRequestError::Other,
+            FileRequestError::NotFound => GetFileRequestError::NotFound,
+            FileRequestError::NotAFolder => GetFileRequestError::NotAFolder,
+            FileRequestError::AppLacksAccess => GetFileRequestError::AppLacksAccess,
+            FileRequestError::NoPermission => GetFileRequestError::NoPermission,
+            FileRequestError::EmailUnverified => GetFileRequestError::EmailUnverified,
+            FileRequestError::ValidationError => GetFileRequestError::ValidationError,
+        }
+    }
+}
 #[derive(Debug, Clone, PartialEq, Eq)]
 #[non_exhaustive] // variants may be added in the future
 pub enum GracePeriod {
@@ -2313,6 +2391,15 @@ impl ::std::fmt::Display for ListFileRequestsContinueError {
     }
 }
 
+// union extends GeneralFileRequestsError
+impl From<GeneralFileRequestsError> for ListFileRequestsContinueError {
+    fn from(parent: GeneralFileRequestsError) -> Self {
+        match parent {
+            GeneralFileRequestsError::DisabledForTeam => ListFileRequestsContinueError::DisabledForTeam,
+            GeneralFileRequestsError::Other => ListFileRequestsContinueError::Other,
+        }
+    }
+}
 /// There was an error retrieving the file requests.
 #[derive(Debug, Clone, PartialEq, Eq)]
 #[non_exhaustive] // variants may be added in the future
@@ -2381,6 +2468,15 @@ impl ::std::fmt::Display for ListFileRequestsError {
     }
 }
 
+// union extends GeneralFileRequestsError
+impl From<GeneralFileRequestsError> for ListFileRequestsError {
+    fn from(parent: GeneralFileRequestsError) -> Self {
+        match parent {
+            GeneralFileRequestsError::DisabledForTeam => ListFileRequestsError::DisabledForTeam,
+            GeneralFileRequestsError::Other => ListFileRequestsError::Other,
+        }
+    }
+}
 /// Result for [`list()`](list).
 #[derive(Debug, Clone, PartialEq, Eq)]
 #[non_exhaustive] // structs may have more fields added in the future.
@@ -2994,3 +3090,18 @@ impl ::std::fmt::Display for UpdateFileRequestError {
     }
 }
 
+// union extends FileRequestError
+impl From<FileRequestError> for UpdateFileRequestError {
+    fn from(parent: FileRequestError) -> Self {
+        match parent {
+            FileRequestError::DisabledForTeam => UpdateFileRequestError::DisabledForTeam,
+            FileRequestError::Other => UpdateFileRequestError::Other,
+            FileRequestError::NotFound => UpdateFileRequestError::NotFound,
+            FileRequestError::NotAFolder => UpdateFileRequestError::NotAFolder,
+            FileRequestError::AppLacksAccess => UpdateFileRequestError::AppLacksAccess,
+            FileRequestError::NoPermission => UpdateFileRequestError::NoPermission,
+            FileRequestError::EmailUnverified => UpdateFileRequestError::EmailUnverified,
+            FileRequestError::ValidationError => UpdateFileRequestError::ValidationError,
+        }
+    }
+}

--- a/src/generated/files.rs
+++ b/src/generated/files.rs
@@ -1576,6 +1576,15 @@ impl ::std::fmt::Display for AddTagError {
     }
 }
 
+// union extends BaseTagError
+impl From<BaseTagError> for AddTagError {
+    fn from(parent: BaseTagError) -> Self {
+        match parent {
+            BaseTagError::Path(x) => AddTagError::Path(x),
+            BaseTagError::Other => AddTagError::Other,
+        }
+    }
+}
 #[derive(Debug, Clone, PartialEq, Eq)]
 #[non_exhaustive] // structs may have more fields added in the future.
 pub struct AlphaGetMetadataArg {
@@ -1777,6 +1786,18 @@ impl ::serde::ser::Serialize for AlphaGetMetadataArg {
     }
 }
 
+// struct extends GetMetadataArg
+impl From<AlphaGetMetadataArg> for GetMetadataArg {
+    fn from(subtype: AlphaGetMetadataArg) -> Self {
+        Self {
+            path: subtype.path,
+            include_media_info: subtype.include_media_info,
+            include_deleted: subtype.include_deleted,
+            include_has_explicit_shared_members: subtype.include_has_explicit_shared_members,
+            include_property_groups: subtype.include_property_groups,
+        }
+    }
+}
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum AlphaGetMetadataError {
     Path(LookupError),
@@ -1866,6 +1887,14 @@ impl ::std::fmt::Display for AlphaGetMetadataError {
     }
 }
 
+// union extends GetMetadataError
+impl From<GetMetadataError> for AlphaGetMetadataError {
+    fn from(parent: GetMetadataError) -> Self {
+        match parent {
+            GetMetadataError::Path(x) => AlphaGetMetadataError::Path(x),
+        }
+    }
+}
 #[derive(Debug, Clone, PartialEq, Eq)]
 #[non_exhaustive] // variants may be added in the future
 pub enum BaseTagError {
@@ -2772,6 +2801,14 @@ impl ::serde::ser::Serialize for CreateFolderBatchJobStatus {
     }
 }
 
+// union extends crate::dbx_async::PollResultBase
+impl From<crate::dbx_async::PollResultBase> for CreateFolderBatchJobStatus {
+    fn from(parent: crate::dbx_async::PollResultBase) -> Self {
+        match parent {
+            crate::dbx_async::PollResultBase::InProgress => CreateFolderBatchJobStatus::InProgress,
+        }
+    }
+}
 /// Result returned by [`create_folder_batch()`](create_folder_batch) that may either launch an
 /// asynchronous job or complete synchronously.
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -2847,6 +2884,14 @@ impl ::serde::ser::Serialize for CreateFolderBatchLaunch {
     }
 }
 
+// union extends crate::dbx_async::LaunchResultBase
+impl From<crate::dbx_async::LaunchResultBase> for CreateFolderBatchLaunch {
+    fn from(parent: crate::dbx_async::LaunchResultBase) -> Self {
+        match parent {
+            crate::dbx_async::LaunchResultBase::AsyncJobId(x) => CreateFolderBatchLaunch::AsyncJobId(x),
+        }
+    }
+}
 #[derive(Debug, Clone, PartialEq, Eq)]
 #[non_exhaustive] // structs may have more fields added in the future.
 pub struct CreateFolderBatchResult {
@@ -2939,6 +2984,12 @@ impl ::serde::ser::Serialize for CreateFolderBatchResult {
     }
 }
 
+// struct extends FileOpsResult
+impl From<CreateFolderBatchResult> for FileOpsResult {
+    fn from(_: CreateFolderBatchResult) -> Self {
+        Self {}
+    }
+}
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum CreateFolderBatchResultEntry {
     Success(CreateFolderEntryResult),
@@ -3336,6 +3387,12 @@ impl ::serde::ser::Serialize for CreateFolderResult {
     }
 }
 
+// struct extends FileOpsResult
+impl From<CreateFolderResult> for FileOpsResult {
+    fn from(_: CreateFolderResult) -> Self {
+        Self {}
+    }
+}
 #[derive(Debug, Clone, PartialEq, Eq)]
 #[non_exhaustive] // structs may have more fields added in the future.
 pub struct DeleteArg {
@@ -3687,6 +3744,14 @@ impl ::serde::ser::Serialize for DeleteBatchJobStatus {
     }
 }
 
+// union extends crate::dbx_async::PollResultBase
+impl From<crate::dbx_async::PollResultBase> for DeleteBatchJobStatus {
+    fn from(parent: crate::dbx_async::PollResultBase) -> Self {
+        match parent {
+            crate::dbx_async::PollResultBase::InProgress => DeleteBatchJobStatus::InProgress,
+        }
+    }
+}
 /// Result returned by [`delete_batch()`](delete_batch) that may either launch an asynchronous job
 /// or complete synchronously.
 #[derive(Debug, Clone, PartialEq)]
@@ -3762,6 +3827,14 @@ impl ::serde::ser::Serialize for DeleteBatchLaunch {
     }
 }
 
+// union extends crate::dbx_async::LaunchResultBase
+impl From<crate::dbx_async::LaunchResultBase> for DeleteBatchLaunch {
+    fn from(parent: crate::dbx_async::LaunchResultBase) -> Self {
+        match parent {
+            crate::dbx_async::LaunchResultBase::AsyncJobId(x) => DeleteBatchLaunch::AsyncJobId(x),
+        }
+    }
+}
 #[derive(Debug, Clone, PartialEq)]
 #[non_exhaustive] // structs may have more fields added in the future.
 pub struct DeleteBatchResult {
@@ -3854,6 +3927,12 @@ impl ::serde::ser::Serialize for DeleteBatchResult {
     }
 }
 
+// struct extends FileOpsResult
+impl From<DeleteBatchResult> for FileOpsResult {
+    fn from(_: DeleteBatchResult) -> Self {
+        Self {}
+    }
+}
 #[derive(Debug, Clone, PartialEq)]
 #[non_exhaustive] // structs may have more fields added in the future.
 pub struct DeleteBatchResultData {
@@ -4220,6 +4299,12 @@ impl ::serde::ser::Serialize for DeleteResult {
     }
 }
 
+// struct extends FileOpsResult
+impl From<DeleteResult> for FileOpsResult {
+    fn from(_: DeleteResult) -> Self {
+        Self {}
+    }
+}
 /// Indicates that there used to be a file or folder at this path, but it no longer exists.
 #[derive(Debug, Clone, PartialEq, Eq)]
 #[non_exhaustive] // structs may have more fields added in the future.
@@ -4399,6 +4484,12 @@ impl ::serde::ser::Serialize for DeletedMetadata {
     }
 }
 
+// struct extends polymorphic struct Metadata
+impl From<DeletedMetadata> for Metadata {
+    fn from(subtype: DeletedMetadata) -> Self {
+        Metadata::Deleted(subtype)
+    }
+}
 /// Dimensions for a photo or video.
 #[derive(Debug, Clone, PartialEq, Eq)]
 #[non_exhaustive] // structs may have more fields added in the future.
@@ -6451,6 +6542,12 @@ impl ::serde::ser::Serialize for FileMetadata {
     }
 }
 
+// struct extends polymorphic struct Metadata
+impl From<FileMetadata> for Metadata {
+    fn from(subtype: FileMetadata) -> Self {
+        Metadata::File(subtype)
+    }
+}
 #[derive(Debug, Clone, PartialEq, Eq, Default)]
 #[non_exhaustive] // structs may have more fields added in the future.
 pub struct FileOpsResult {
@@ -6620,6 +6717,14 @@ impl ::serde::ser::Serialize for FileSharingInfo {
     }
 }
 
+// struct extends SharingInfo
+impl From<FileSharingInfo> for SharingInfo {
+    fn from(subtype: FileSharingInfo) -> Self {
+        Self {
+            read_only: subtype.read_only,
+        }
+    }
+}
 #[derive(Debug, Clone, PartialEq, Eq)]
 #[non_exhaustive] // variants may be added in the future
 pub enum FileStatus {
@@ -6939,6 +7044,12 @@ impl ::serde::ser::Serialize for FolderMetadata {
     }
 }
 
+// struct extends polymorphic struct Metadata
+impl From<FolderMetadata> for Metadata {
+    fn from(subtype: FolderMetadata) -> Self {
+        Metadata::Folder(subtype)
+    }
+}
 /// Sharing info for a folder which is contained in a shared folder or is a shared folder mount
 /// point.
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -7115,6 +7226,14 @@ impl ::serde::ser::Serialize for FolderSharingInfo {
     }
 }
 
+// struct extends SharingInfo
+impl From<FolderSharingInfo> for SharingInfo {
+    fn from(subtype: FolderSharingInfo) -> Self {
+        Self {
+            read_only: subtype.read_only,
+        }
+    }
+}
 #[derive(Debug, Clone, PartialEq, Eq)]
 #[non_exhaustive] // structs may have more fields added in the future.
 pub struct GetCopyReferenceArg {
@@ -10892,6 +11011,12 @@ impl ::serde::ser::Serialize for LockFileBatchResult {
     }
 }
 
+// struct extends FileOpsResult
+impl From<LockFileBatchResult> for FileOpsResult {
+    fn from(_: LockFileBatchResult) -> Self {
+        Self {}
+    }
+}
 #[derive(Debug, Clone, PartialEq, Eq)]
 #[non_exhaustive] // variants may be added in the future
 pub enum LockFileError {
@@ -11894,6 +12019,15 @@ impl ::serde::ser::Serialize for MoveBatchArg {
     }
 }
 
+// struct extends RelocationBatchArgBase
+impl From<MoveBatchArg> for RelocationBatchArgBase {
+    fn from(subtype: MoveBatchArg) -> Self {
+        Self {
+            entries: subtype.entries,
+            autorename: subtype.autorename,
+        }
+    }
+}
 #[derive(Debug, Clone, PartialEq, Eq)]
 #[non_exhaustive] // variants may be added in the future
 pub enum MoveIntoFamilyError {
@@ -12379,6 +12513,18 @@ impl ::std::fmt::Display for PaperCreateError {
     }
 }
 
+// union extends PaperContentError
+impl From<PaperContentError> for PaperCreateError {
+    fn from(parent: PaperContentError) -> Self {
+        match parent {
+            PaperContentError::InsufficientPermissions => PaperCreateError::InsufficientPermissions,
+            PaperContentError::ContentMalformed => PaperCreateError::ContentMalformed,
+            PaperContentError::DocLengthExceeded => PaperCreateError::DocLengthExceeded,
+            PaperContentError::ImageSizeExceeded => PaperCreateError::ImageSizeExceeded,
+            PaperContentError::Other => PaperCreateError::Other,
+        }
+    }
+}
 #[derive(Debug, Clone, PartialEq, Eq)]
 #[non_exhaustive] // structs may have more fields added in the future.
 pub struct PaperCreateResult {
@@ -12895,6 +13041,18 @@ impl ::std::fmt::Display for PaperUpdateError {
     }
 }
 
+// union extends PaperContentError
+impl From<PaperContentError> for PaperUpdateError {
+    fn from(parent: PaperContentError) -> Self {
+        match parent {
+            PaperContentError::InsufficientPermissions => PaperUpdateError::InsufficientPermissions,
+            PaperContentError::ContentMalformed => PaperUpdateError::ContentMalformed,
+            PaperContentError::DocLengthExceeded => PaperUpdateError::DocLengthExceeded,
+            PaperContentError::ImageSizeExceeded => PaperUpdateError::ImageSizeExceeded,
+            PaperContentError::Other => PaperUpdateError::Other,
+        }
+    }
+}
 #[derive(Debug, Clone, PartialEq, Eq)]
 #[non_exhaustive] // structs may have more fields added in the future.
 pub struct PaperUpdateResult {
@@ -13281,6 +13439,12 @@ impl ::serde::ser::Serialize for PhotoMetadata {
     }
 }
 
+// struct extends polymorphic struct MediaMetadata
+impl From<PhotoMetadata> for MediaMetadata {
+    fn from(subtype: PhotoMetadata) -> Self {
+        MediaMetadata::Photo(subtype)
+    }
+}
 #[derive(Debug, Clone, PartialEq, Eq)]
 #[non_exhaustive] // structs may have more fields added in the future.
 pub struct PreviewArg {
@@ -13766,6 +13930,15 @@ impl ::serde::ser::Serialize for RelocationArg {
     }
 }
 
+// struct extends RelocationPath
+impl From<RelocationArg> for RelocationPath {
+    fn from(subtype: RelocationArg) -> Self {
+        Self {
+            from_path: subtype.from_path,
+            to_path: subtype.to_path,
+        }
+    }
+}
 #[derive(Debug, Clone, PartialEq, Eq)]
 #[non_exhaustive] // structs may have more fields added in the future.
 pub struct RelocationBatchArg {
@@ -13919,6 +14092,15 @@ impl ::serde::ser::Serialize for RelocationBatchArg {
     }
 }
 
+// struct extends RelocationBatchArgBase
+impl From<RelocationBatchArg> for RelocationBatchArgBase {
+    fn from(subtype: RelocationBatchArg) -> Self {
+        Self {
+            entries: subtype.entries,
+            autorename: subtype.autorename,
+        }
+    }
+}
 #[derive(Debug, Clone, PartialEq, Eq)]
 #[non_exhaustive] // structs may have more fields added in the future.
 pub struct RelocationBatchArgBase {
@@ -14296,6 +14478,28 @@ impl ::std::fmt::Display for RelocationBatchError {
     }
 }
 
+// union extends RelocationError
+impl From<RelocationError> for RelocationBatchError {
+    fn from(parent: RelocationError) -> Self {
+        match parent {
+            RelocationError::FromLookup(x) => RelocationBatchError::FromLookup(x),
+            RelocationError::FromWrite(x) => RelocationBatchError::FromWrite(x),
+            RelocationError::To(x) => RelocationBatchError::To(x),
+            RelocationError::CantCopySharedFolder => RelocationBatchError::CantCopySharedFolder,
+            RelocationError::CantNestSharedFolder => RelocationBatchError::CantNestSharedFolder,
+            RelocationError::CantMoveFolderIntoItself => RelocationBatchError::CantMoveFolderIntoItself,
+            RelocationError::TooManyFiles => RelocationBatchError::TooManyFiles,
+            RelocationError::DuplicatedOrNestedPaths => RelocationBatchError::DuplicatedOrNestedPaths,
+            RelocationError::CantTransferOwnership => RelocationBatchError::CantTransferOwnership,
+            RelocationError::InsufficientQuota => RelocationBatchError::InsufficientQuota,
+            RelocationError::InternalError => RelocationBatchError::InternalError,
+            RelocationError::CantMoveSharedFolder => RelocationBatchError::CantMoveSharedFolder,
+            RelocationError::CantMoveIntoVault(x) => RelocationBatchError::CantMoveIntoVault(x),
+            RelocationError::CantMoveIntoFamily(x) => RelocationBatchError::CantMoveIntoFamily(x),
+            RelocationError::Other => RelocationBatchError::Other,
+        }
+    }
+}
 #[derive(Debug, Clone, PartialEq, Eq)]
 #[non_exhaustive] // variants may be added in the future
 pub enum RelocationBatchErrorEntry {
@@ -14456,6 +14660,14 @@ impl ::serde::ser::Serialize for RelocationBatchJobStatus {
     }
 }
 
+// union extends crate::dbx_async::PollResultBase
+impl From<crate::dbx_async::PollResultBase> for RelocationBatchJobStatus {
+    fn from(parent: crate::dbx_async::PollResultBase) -> Self {
+        match parent {
+            crate::dbx_async::PollResultBase::InProgress => RelocationBatchJobStatus::InProgress,
+        }
+    }
+}
 /// Result returned by [`copy_batch()`](copy_batch) or [`move_batch()`](move_batch) that may either
 /// launch an asynchronous job or complete synchronously.
 #[derive(Debug, Clone, PartialEq)]
@@ -14531,6 +14743,14 @@ impl ::serde::ser::Serialize for RelocationBatchLaunch {
     }
 }
 
+// union extends crate::dbx_async::LaunchResultBase
+impl From<crate::dbx_async::LaunchResultBase> for RelocationBatchLaunch {
+    fn from(parent: crate::dbx_async::LaunchResultBase) -> Self {
+        match parent {
+            crate::dbx_async::LaunchResultBase::AsyncJobId(x) => RelocationBatchLaunch::AsyncJobId(x),
+        }
+    }
+}
 #[derive(Debug, Clone, PartialEq)]
 #[non_exhaustive] // structs may have more fields added in the future.
 pub struct RelocationBatchResult {
@@ -14621,6 +14841,12 @@ impl ::serde::ser::Serialize for RelocationBatchResult {
     }
 }
 
+// struct extends FileOpsResult
+impl From<RelocationBatchResult> for FileOpsResult {
+    fn from(_: RelocationBatchResult) -> Self {
+        Self {}
+    }
+}
 #[derive(Debug, Clone, PartialEq)]
 #[non_exhaustive] // structs may have more fields added in the future.
 pub struct RelocationBatchResultData {
@@ -14852,6 +15078,14 @@ impl ::serde::ser::Serialize for RelocationBatchV2JobStatus {
     }
 }
 
+// union extends crate::dbx_async::PollResultBase
+impl From<crate::dbx_async::PollResultBase> for RelocationBatchV2JobStatus {
+    fn from(parent: crate::dbx_async::PollResultBase) -> Self {
+        match parent {
+            crate::dbx_async::PollResultBase::InProgress => RelocationBatchV2JobStatus::InProgress,
+        }
+    }
+}
 /// Result returned by [`copy_batch_v2()`](copy_batch_v2) or [`move_batch_v2()`](move_batch_v2) that
 /// may either launch an asynchronous job or complete synchronously.
 #[derive(Debug, Clone, PartialEq)]
@@ -14921,6 +15155,14 @@ impl ::serde::ser::Serialize for RelocationBatchV2Launch {
     }
 }
 
+// union extends crate::dbx_async::LaunchResultBase
+impl From<crate::dbx_async::LaunchResultBase> for RelocationBatchV2Launch {
+    fn from(parent: crate::dbx_async::LaunchResultBase) -> Self {
+        match parent {
+            crate::dbx_async::LaunchResultBase::AsyncJobId(x) => RelocationBatchV2Launch::AsyncJobId(x),
+        }
+    }
+}
 #[derive(Debug, Clone, PartialEq)]
 #[non_exhaustive] // structs may have more fields added in the future.
 pub struct RelocationBatchV2Result {
@@ -15013,6 +15255,12 @@ impl ::serde::ser::Serialize for RelocationBatchV2Result {
     }
 }
 
+// struct extends FileOpsResult
+impl From<RelocationBatchV2Result> for FileOpsResult {
+    fn from(_: RelocationBatchV2Result) -> Self {
+        Self {}
+    }
+}
 #[derive(Debug, Clone, PartialEq, Eq)]
 #[non_exhaustive] // variants may be added in the future
 pub enum RelocationError {
@@ -15462,6 +15710,12 @@ impl ::serde::ser::Serialize for RelocationResult {
     }
 }
 
+// struct extends FileOpsResult
+impl From<RelocationResult> for FileOpsResult {
+    fn from(_: RelocationResult) -> Self {
+        Self {}
+    }
+}
 #[derive(Debug, Clone, PartialEq, Eq)]
 #[non_exhaustive] // structs may have more fields added in the future.
 pub struct RemoveTagArg {
@@ -15656,6 +15910,15 @@ impl ::std::fmt::Display for RemoveTagError {
     }
 }
 
+// union extends BaseTagError
+impl From<BaseTagError> for RemoveTagError {
+    fn from(parent: BaseTagError) -> Self {
+        match parent {
+            BaseTagError::Path(x) => RemoveTagError::Path(x),
+            BaseTagError::Other => RemoveTagError::Other,
+        }
+    }
+}
 #[derive(Debug, Clone, PartialEq, Eq)]
 #[non_exhaustive] // structs may have more fields added in the future.
 pub struct RestoreArg {
@@ -16493,6 +16756,14 @@ impl ::serde::ser::Serialize for SaveUrlJobStatus {
     }
 }
 
+// union extends crate::dbx_async::PollResultBase
+impl From<crate::dbx_async::PollResultBase> for SaveUrlJobStatus {
+    fn from(parent: crate::dbx_async::PollResultBase) -> Self {
+        match parent {
+            crate::dbx_async::PollResultBase::InProgress => SaveUrlJobStatus::InProgress,
+        }
+    }
+}
 #[derive(Debug, Clone, PartialEq)]
 pub enum SaveUrlResult {
     /// This response indicates that the processing is asynchronous. The string is an id that can be
@@ -16561,6 +16832,14 @@ impl ::serde::ser::Serialize for SaveUrlResult {
     }
 }
 
+// union extends crate::dbx_async::LaunchResultBase
+impl From<crate::dbx_async::LaunchResultBase> for SaveUrlResult {
+    fn from(parent: crate::dbx_async::LaunchResultBase) -> Self {
+        match parent {
+            crate::dbx_async::LaunchResultBase::AsyncJobId(x) => SaveUrlResult::AsyncJobId(x),
+        }
+    }
+}
 #[derive(Debug, Clone, PartialEq, Eq)]
 #[non_exhaustive] // structs may have more fields added in the future.
 pub struct SearchArg {
@@ -20252,6 +20531,20 @@ impl ::serde::ser::Serialize for UploadArg {
     }
 }
 
+// struct extends CommitInfo
+impl From<UploadArg> for CommitInfo {
+    fn from(subtype: UploadArg) -> Self {
+        Self {
+            path: subtype.path,
+            mode: subtype.mode,
+            autorename: subtype.autorename,
+            client_modified: subtype.client_modified,
+            mute: subtype.mute,
+            property_groups: subtype.property_groups,
+            strict_conflict: subtype.strict_conflict,
+        }
+    }
+}
 #[derive(Debug, Clone, PartialEq, Eq)]
 #[non_exhaustive] // variants may be added in the future
 pub enum UploadError {
@@ -20663,6 +20956,22 @@ impl ::std::fmt::Display for UploadSessionAppendError {
     }
 }
 
+// union extends UploadSessionLookupError
+impl From<UploadSessionLookupError> for UploadSessionAppendError {
+    fn from(parent: UploadSessionLookupError) -> Self {
+        match parent {
+            UploadSessionLookupError::NotFound => UploadSessionAppendError::NotFound,
+            UploadSessionLookupError::IncorrectOffset(x) => UploadSessionAppendError::IncorrectOffset(x),
+            UploadSessionLookupError::Closed => UploadSessionAppendError::Closed,
+            UploadSessionLookupError::NotClosed => UploadSessionAppendError::NotClosed,
+            UploadSessionLookupError::TooLarge => UploadSessionAppendError::TooLarge,
+            UploadSessionLookupError::ConcurrentSessionInvalidOffset => UploadSessionAppendError::ConcurrentSessionInvalidOffset,
+            UploadSessionLookupError::ConcurrentSessionInvalidDataSize => UploadSessionAppendError::ConcurrentSessionInvalidDataSize,
+            UploadSessionLookupError::PayloadTooLarge => UploadSessionAppendError::PayloadTooLarge,
+            UploadSessionLookupError::Other => UploadSessionAppendError::Other,
+        }
+    }
+}
 #[derive(Debug, Clone, PartialEq, Eq)]
 #[non_exhaustive] // structs may have more fields added in the future.
 pub struct UploadSessionCursor {
@@ -21045,6 +21354,14 @@ impl ::serde::ser::Serialize for UploadSessionFinishBatchJobStatus {
     }
 }
 
+// union extends crate::dbx_async::PollResultBase
+impl From<crate::dbx_async::PollResultBase> for UploadSessionFinishBatchJobStatus {
+    fn from(parent: crate::dbx_async::PollResultBase) -> Self {
+        match parent {
+            crate::dbx_async::PollResultBase::InProgress => UploadSessionFinishBatchJobStatus::InProgress,
+        }
+    }
+}
 /// Result returned by [`upload_session_finish_batch()`](upload_session_finish_batch) that may
 /// either launch an asynchronous job or complete synchronously.
 #[derive(Debug, Clone, PartialEq)]
@@ -21120,6 +21437,14 @@ impl ::serde::ser::Serialize for UploadSessionFinishBatchLaunch {
     }
 }
 
+// union extends crate::dbx_async::LaunchResultBase
+impl From<crate::dbx_async::LaunchResultBase> for UploadSessionFinishBatchLaunch {
+    fn from(parent: crate::dbx_async::LaunchResultBase) -> Self {
+        match parent {
+            crate::dbx_async::LaunchResultBase::AsyncJobId(x) => UploadSessionFinishBatchLaunch::AsyncJobId(x),
+        }
+    }
+}
 #[derive(Debug, Clone, PartialEq)]
 #[non_exhaustive] // structs may have more fields added in the future.
 pub struct UploadSessionFinishBatchResult {
@@ -22640,6 +22965,12 @@ impl ::serde::ser::Serialize for VideoMetadata {
     }
 }
 
+// struct extends polymorphic struct MediaMetadata
+impl From<VideoMetadata> for MediaMetadata {
+    fn from(subtype: VideoMetadata) -> Self {
+        MediaMetadata::Video(subtype)
+    }
+}
 #[derive(Debug, Clone, PartialEq, Eq)]
 #[non_exhaustive] // variants may be added in the future
 pub enum WriteConflictError {

--- a/src/generated/paper.rs
+++ b/src/generated/paper.rs
@@ -643,6 +643,14 @@ impl ::serde::ser::Serialize for AddPaperDocUser {
     }
 }
 
+// struct extends RefPaperDoc
+impl From<AddPaperDocUser> for RefPaperDoc {
+    fn from(subtype: AddPaperDocUser) -> Self {
+        Self {
+            doc_id: subtype.doc_id,
+        }
+    }
+}
 /// Per-member result for [`docs_users_add()`](docs_users_add).
 #[derive(Debug, Clone, PartialEq, Eq)]
 #[non_exhaustive] // structs may have more fields added in the future.
@@ -1063,6 +1071,15 @@ impl ::std::fmt::Display for DocLookupError {
     }
 }
 
+// union extends PaperApiBaseError
+impl From<PaperApiBaseError> for DocLookupError {
+    fn from(parent: PaperApiBaseError) -> Self {
+        match parent {
+            PaperApiBaseError::InsufficientPermissions => DocLookupError::InsufficientPermissions,
+            PaperApiBaseError::Other => DocLookupError::Other,
+        }
+    }
+}
 /// The subscription level of a Paper doc.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum DocSubscriptionLevel {
@@ -2494,6 +2511,15 @@ impl ::std::fmt::Display for ListUsersCursorError {
     }
 }
 
+// union extends PaperApiBaseError
+impl From<PaperApiBaseError> for ListUsersCursorError {
+    fn from(parent: PaperApiBaseError) -> Self {
+        match parent {
+            PaperApiBaseError::InsufficientPermissions => ListUsersCursorError::InsufficientPermissions,
+            PaperApiBaseError::Other => ListUsersCursorError::Other,
+        }
+    }
+}
 #[derive(Debug, Clone, PartialEq, Eq)]
 #[non_exhaustive] // structs may have more fields added in the future.
 pub struct ListUsersOnFolderArgs {
@@ -2606,6 +2632,14 @@ impl ::serde::ser::Serialize for ListUsersOnFolderArgs {
     }
 }
 
+// struct extends RefPaperDoc
+impl From<ListUsersOnFolderArgs> for RefPaperDoc {
+    fn from(subtype: ListUsersOnFolderArgs) -> Self {
+        Self {
+            doc_id: subtype.doc_id,
+        }
+    }
+}
 #[derive(Debug, Clone, PartialEq, Eq)]
 #[non_exhaustive] // structs may have more fields added in the future.
 pub struct ListUsersOnFolderContinueArgs {
@@ -2712,6 +2746,14 @@ impl ::serde::ser::Serialize for ListUsersOnFolderContinueArgs {
     }
 }
 
+// struct extends RefPaperDoc
+impl From<ListUsersOnFolderContinueArgs> for RefPaperDoc {
+    fn from(subtype: ListUsersOnFolderContinueArgs) -> Self {
+        Self {
+            doc_id: subtype.doc_id,
+        }
+    }
+}
 #[derive(Debug, Clone, PartialEq, Eq)]
 #[non_exhaustive] // structs may have more fields added in the future.
 pub struct ListUsersOnFolderResponse {
@@ -2984,6 +3026,14 @@ impl ::serde::ser::Serialize for ListUsersOnPaperDocArgs {
     }
 }
 
+// struct extends RefPaperDoc
+impl From<ListUsersOnPaperDocArgs> for RefPaperDoc {
+    fn from(subtype: ListUsersOnPaperDocArgs) -> Self {
+        Self {
+            doc_id: subtype.doc_id,
+        }
+    }
+}
 #[derive(Debug, Clone, PartialEq, Eq)]
 #[non_exhaustive] // structs may have more fields added in the future.
 pub struct ListUsersOnPaperDocContinueArgs {
@@ -3089,6 +3139,14 @@ impl ::serde::ser::Serialize for ListUsersOnPaperDocContinueArgs {
     }
 }
 
+// struct extends RefPaperDoc
+impl From<ListUsersOnPaperDocContinueArgs> for RefPaperDoc {
+    fn from(subtype: ListUsersOnPaperDocContinueArgs) -> Self {
+        Self {
+            doc_id: subtype.doc_id,
+        }
+    }
+}
 #[derive(Debug, Clone, PartialEq, Eq)]
 #[non_exhaustive] // structs may have more fields added in the future.
 pub struct ListUsersOnPaperDocResponse {
@@ -3638,6 +3696,15 @@ impl ::std::fmt::Display for PaperDocCreateError {
     }
 }
 
+// union extends PaperApiBaseError
+impl From<PaperApiBaseError> for PaperDocCreateError {
+    fn from(parent: PaperApiBaseError) -> Self {
+        match parent {
+            PaperApiBaseError::InsufficientPermissions => PaperDocCreateError::InsufficientPermissions,
+            PaperApiBaseError::Other => PaperDocCreateError::Other,
+        }
+    }
+}
 #[derive(Debug, Clone, PartialEq, Eq)]
 #[non_exhaustive] // structs may have more fields added in the future.
 pub struct PaperDocCreateUpdateResult {
@@ -3858,6 +3925,14 @@ impl ::serde::ser::Serialize for PaperDocExport {
     }
 }
 
+// struct extends RefPaperDoc
+impl From<PaperDocExport> for RefPaperDoc {
+    fn from(subtype: PaperDocExport) -> Self {
+        Self {
+            doc_id: subtype.doc_id,
+        }
+    }
+}
 #[derive(Debug, Clone, PartialEq, Eq)]
 #[non_exhaustive] // structs may have more fields added in the future.
 pub struct PaperDocExportResult {
@@ -4158,6 +4233,14 @@ impl ::serde::ser::Serialize for PaperDocSharingPolicy {
     }
 }
 
+// struct extends RefPaperDoc
+impl From<PaperDocSharingPolicy> for RefPaperDoc {
+    fn from(subtype: PaperDocSharingPolicy) -> Self {
+        Self {
+            doc_id: subtype.doc_id,
+        }
+    }
+}
 #[derive(Debug, Clone, PartialEq, Eq)]
 #[non_exhaustive] // structs may have more fields added in the future.
 pub struct PaperDocUpdateArgs {
@@ -4294,6 +4377,14 @@ impl ::serde::ser::Serialize for PaperDocUpdateArgs {
     }
 }
 
+// struct extends RefPaperDoc
+impl From<PaperDocUpdateArgs> for RefPaperDoc {
+    fn from(subtype: PaperDocUpdateArgs) -> Self {
+        Self {
+            doc_id: subtype.doc_id,
+        }
+    }
+}
 #[derive(Debug, Clone, PartialEq, Eq)]
 #[non_exhaustive] // variants may be added in the future
 pub enum PaperDocUpdateError {
@@ -4441,6 +4532,16 @@ impl ::std::fmt::Display for PaperDocUpdateError {
     }
 }
 
+// union extends DocLookupError
+impl From<DocLookupError> for PaperDocUpdateError {
+    fn from(parent: DocLookupError) -> Self {
+        match parent {
+            DocLookupError::InsufficientPermissions => PaperDocUpdateError::InsufficientPermissions,
+            DocLookupError::Other => PaperDocUpdateError::Other,
+            DocLookupError::DocNotFound => PaperDocUpdateError::DocNotFound,
+        }
+    }
+}
 #[derive(Debug, Clone, PartialEq, Eq)]
 #[non_exhaustive] // variants may be added in the future
 pub enum PaperDocUpdatePolicy {
@@ -4743,6 +4844,15 @@ impl ::std::fmt::Display for PaperFolderCreateError {
     }
 }
 
+// union extends PaperApiBaseError
+impl From<PaperApiBaseError> for PaperFolderCreateError {
+    fn from(parent: PaperApiBaseError) -> Self {
+        match parent {
+            PaperApiBaseError::InsufficientPermissions => PaperFolderCreateError::InsufficientPermissions,
+            PaperApiBaseError::Other => PaperFolderCreateError::Other,
+        }
+    }
+}
 #[derive(Debug, Clone, PartialEq, Eq)]
 #[non_exhaustive] // structs may have more fields added in the future.
 pub struct PaperFolderCreateResult {
@@ -5030,6 +5140,14 @@ impl ::serde::ser::Serialize for RemovePaperDocUser {
     }
 }
 
+// struct extends RefPaperDoc
+impl From<RemovePaperDocUser> for RefPaperDoc {
+    fn from(subtype: RemovePaperDocUser) -> Self {
+        Self {
+            doc_id: subtype.doc_id,
+        }
+    }
+}
 /// Sharing policy of Paper doc.
 #[derive(Debug, Clone, PartialEq, Eq, Default)]
 #[non_exhaustive] // structs may have more fields added in the future.
@@ -5210,6 +5328,16 @@ impl ::serde::ser::Serialize for SharingPublicPolicyType {
     }
 }
 
+// union extends SharingTeamPolicyType
+impl From<SharingTeamPolicyType> for SharingPublicPolicyType {
+    fn from(parent: SharingTeamPolicyType) -> Self {
+        match parent {
+            SharingTeamPolicyType::PeopleWithLinkCanEdit => SharingPublicPolicyType::PeopleWithLinkCanEdit,
+            SharingTeamPolicyType::PeopleWithLinkCanViewAndComment => SharingPublicPolicyType::PeopleWithLinkCanViewAndComment,
+            SharingTeamPolicyType::InviteOnly => SharingPublicPolicyType::InviteOnly,
+        }
+    }
+}
 /// The sharing policy type of the Paper doc.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum SharingTeamPolicyType {

--- a/src/generated/sharing.rs
+++ b/src/generated/sharing.rs
@@ -1996,6 +1996,21 @@ impl ::serde::ser::Serialize for AlphaResolvedVisibility {
     }
 }
 
+// union extends ResolvedVisibility
+impl From<ResolvedVisibility> for AlphaResolvedVisibility {
+    fn from(parent: ResolvedVisibility) -> Self {
+        match parent {
+            ResolvedVisibility::Public => AlphaResolvedVisibility::Public,
+            ResolvedVisibility::TeamOnly => AlphaResolvedVisibility::TeamOnly,
+            ResolvedVisibility::Password => AlphaResolvedVisibility::Password,
+            ResolvedVisibility::TeamAndPassword => AlphaResolvedVisibility::TeamAndPassword,
+            ResolvedVisibility::SharedFolderOnly => AlphaResolvedVisibility::SharedFolderOnly,
+            ResolvedVisibility::NoOne => AlphaResolvedVisibility::NoOne,
+            ResolvedVisibility::OnlyYou => AlphaResolvedVisibility::OnlyYou,
+            ResolvedVisibility::Other => AlphaResolvedVisibility::Other,
+        }
+    }
+}
 /// Information about the content that has a link audience different than that of this folder.
 #[derive(Debug, Clone, PartialEq, Eq)]
 #[non_exhaustive] // structs may have more fields added in the future.
@@ -2443,6 +2458,12 @@ impl ::serde::ser::Serialize for CollectionLinkMetadata {
     }
 }
 
+// struct extends polymorphic struct LinkMetadata
+impl From<CollectionLinkMetadata> for LinkMetadata {
+    fn from(subtype: CollectionLinkMetadata) -> Self {
+        LinkMetadata::Collection(subtype)
+    }
+}
 #[derive(Debug, Clone, PartialEq, Eq)]
 #[non_exhaustive] // structs may have more fields added in the future.
 pub struct CreateSharedLinkArg {
@@ -3106,6 +3127,20 @@ impl ::serde::ser::Serialize for ExpectedSharedContentLinkMetadata {
     }
 }
 
+// struct extends SharedContentLinkMetadataBase
+impl From<ExpectedSharedContentLinkMetadata> for SharedContentLinkMetadataBase {
+    fn from(subtype: ExpectedSharedContentLinkMetadata) -> Self {
+        Self {
+            audience_options: subtype.audience_options,
+            current_audience: subtype.current_audience,
+            link_permissions: subtype.link_permissions,
+            password_protected: subtype.password_protected,
+            access_level: subtype.access_level,
+            audience_restricting_shared_folder: subtype.audience_restricting_shared_folder,
+            expiry: subtype.expiry,
+        }
+    }
+}
 /// Sharing actions that may be taken on files.
 #[derive(Debug, Clone, PartialEq, Eq)]
 #[non_exhaustive] // variants may be added in the future
@@ -3654,6 +3689,12 @@ impl ::serde::ser::Serialize for FileLinkMetadata {
     }
 }
 
+// struct extends polymorphic struct SharedLinkMetadata
+impl From<FileLinkMetadata> for SharedLinkMetadata {
+    fn from(subtype: FileLinkMetadata) -> Self {
+        SharedLinkMetadata::File(subtype)
+    }
+}
 #[derive(Debug, Clone, PartialEq, Eq)]
 #[non_exhaustive] // variants may be added in the future
 pub enum FileMemberActionError {
@@ -4598,6 +4639,12 @@ impl ::serde::ser::Serialize for FolderLinkMetadata {
     }
 }
 
+// struct extends polymorphic struct SharedLinkMetadata
+impl From<FolderLinkMetadata> for SharedLinkMetadata {
+    fn from(subtype: FolderLinkMetadata) -> Self {
+        SharedLinkMetadata::Folder(subtype)
+    }
+}
 /// Whether the user is allowed to take the action on the shared folder.
 #[derive(Debug, Clone, PartialEq, Eq)]
 #[non_exhaustive] // structs may have more fields added in the future.
@@ -5610,6 +5657,17 @@ impl ::std::fmt::Display for GetSharedLinkFileError {
     }
 }
 
+// union extends SharedLinkError
+impl From<SharedLinkError> for GetSharedLinkFileError {
+    fn from(parent: SharedLinkError) -> Self {
+        match parent {
+            SharedLinkError::SharedLinkNotFound => GetSharedLinkFileError::SharedLinkNotFound,
+            SharedLinkError::SharedLinkAccessDenied => GetSharedLinkFileError::SharedLinkAccessDenied,
+            SharedLinkError::UnsupportedLinkType => GetSharedLinkFileError::UnsupportedLinkType,
+            SharedLinkError::Other => GetSharedLinkFileError::Other,
+        }
+    }
+}
 #[derive(Debug, Clone, PartialEq, Eq)]
 #[non_exhaustive] // structs may have more fields added in the future.
 pub struct GetSharedLinkMetadataArg {
@@ -6207,6 +6265,18 @@ impl ::serde::ser::Serialize for GroupInfo {
     }
 }
 
+// struct extends crate::team_common::GroupSummary
+impl From<GroupInfo> for crate::team_common::GroupSummary {
+    fn from(subtype: GroupInfo) -> Self {
+        Self {
+            group_name: subtype.group_name,
+            group_id: subtype.group_id,
+            group_management_type: subtype.group_management_type,
+            group_external_id: subtype.group_external_id,
+            member_count: subtype.member_count,
+        }
+    }
+}
 /// The information about a group member of the shared content.
 #[derive(Debug, Clone, PartialEq, Eq)]
 #[non_exhaustive] // structs may have more fields added in the future.
@@ -6374,6 +6444,17 @@ impl ::serde::ser::Serialize for GroupMembershipInfo {
     }
 }
 
+// struct extends MembershipInfo
+impl From<GroupMembershipInfo> for MembershipInfo {
+    fn from(subtype: GroupMembershipInfo) -> Self {
+        Self {
+            access_type: subtype.access_type,
+            permissions: subtype.permissions,
+            initials: subtype.initials,
+            is_inherited: subtype.is_inherited,
+        }
+    }
+}
 #[derive(Debug, Clone, PartialEq, Eq)]
 #[non_exhaustive] // structs may have more fields added in the future.
 pub struct InsufficientPlan {
@@ -6853,6 +6934,17 @@ impl ::serde::ser::Serialize for InviteeMembershipInfo {
     }
 }
 
+// struct extends MembershipInfo
+impl From<InviteeMembershipInfo> for MembershipInfo {
+    fn from(subtype: InviteeMembershipInfo) -> Self {
+        Self {
+            access_type: subtype.access_type,
+            permissions: subtype.permissions,
+            initials: subtype.initials,
+            is_inherited: subtype.is_inherited,
+        }
+    }
+}
 /// Error occurred while performing an asynchronous job from [`unshare_folder()`](unshare_folder) or
 /// [`remove_folder_member()`](remove_folder_member).
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -7050,6 +7142,14 @@ impl ::serde::ser::Serialize for JobStatus {
     }
 }
 
+// union extends crate::dbx_async::PollResultBase
+impl From<crate::dbx_async::PollResultBase> for JobStatus {
+    fn from(parent: crate::dbx_async::PollResultBase) -> Self {
+        match parent {
+            crate::dbx_async::PollResultBase::InProgress => JobStatus::InProgress,
+        }
+    }
+}
 #[derive(Debug, Clone, PartialEq, Eq)]
 #[non_exhaustive] // variants may be added in the future
 pub enum LinkAccessLevel {
@@ -7426,6 +7526,20 @@ impl ::serde::ser::Serialize for LinkAudienceDisallowedReason {
     }
 }
 
+// union extends VisibilityPolicyDisallowedReason
+impl From<VisibilityPolicyDisallowedReason> for LinkAudienceDisallowedReason {
+    fn from(parent: VisibilityPolicyDisallowedReason) -> Self {
+        match parent {
+            VisibilityPolicyDisallowedReason::DeleteAndRecreate => LinkAudienceDisallowedReason::DeleteAndRecreate,
+            VisibilityPolicyDisallowedReason::RestrictedBySharedFolder => LinkAudienceDisallowedReason::RestrictedBySharedFolder,
+            VisibilityPolicyDisallowedReason::RestrictedByTeam => LinkAudienceDisallowedReason::RestrictedByTeam,
+            VisibilityPolicyDisallowedReason::UserNotOnTeam => LinkAudienceDisallowedReason::UserNotOnTeam,
+            VisibilityPolicyDisallowedReason::UserAccountType => LinkAudienceDisallowedReason::UserAccountType,
+            VisibilityPolicyDisallowedReason::PermissionDenied => LinkAudienceDisallowedReason::PermissionDenied,
+            VisibilityPolicyDisallowedReason::Other => LinkAudienceDisallowedReason::Other,
+        }
+    }
+}
 #[derive(Debug, Clone, PartialEq, Eq)]
 #[non_exhaustive] // structs may have more fields added in the future.
 pub struct LinkAudienceOption {
@@ -9832,6 +9946,15 @@ impl ::serde::ser::Serialize for ListFolderMembersArgs {
     }
 }
 
+// struct extends ListFolderMembersCursorArg
+impl From<ListFolderMembersArgs> for ListFolderMembersCursorArg {
+    fn from(subtype: ListFolderMembersArgs) -> Self {
+        Self {
+            actions: subtype.actions,
+            limit: subtype.limit,
+        }
+    }
+}
 #[derive(Debug, Clone, PartialEq, Eq)]
 #[non_exhaustive] // structs may have more fields added in the future.
 pub struct ListFolderMembersContinueArg {
@@ -11747,6 +11870,17 @@ impl ::std::fmt::Display for ModifySharedLinkSettingsError {
     }
 }
 
+// union extends SharedLinkError
+impl From<SharedLinkError> for ModifySharedLinkSettingsError {
+    fn from(parent: SharedLinkError) -> Self {
+        match parent {
+            SharedLinkError::SharedLinkNotFound => ModifySharedLinkSettingsError::SharedLinkNotFound,
+            SharedLinkError::SharedLinkAccessDenied => ModifySharedLinkSettingsError::SharedLinkAccessDenied,
+            SharedLinkError::UnsupportedLinkType => ModifySharedLinkSettingsError::UnsupportedLinkType,
+            SharedLinkError::Other => ModifySharedLinkSettingsError::Other,
+        }
+    }
+}
 #[derive(Debug, Clone, PartialEq, Eq)]
 #[non_exhaustive] // structs may have more fields added in the future.
 pub struct MountFolderArg {
@@ -12248,6 +12382,12 @@ impl ::serde::ser::Serialize for PathLinkMetadata {
     }
 }
 
+// struct extends polymorphic struct LinkMetadata
+impl From<PathLinkMetadata> for LinkMetadata {
+    fn from(subtype: PathLinkMetadata) -> Self {
+        LinkMetadata::Path(subtype)
+    }
+}
 /// Flag to indicate pending upload default (for linking to not-yet-existing paths).
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum PendingUploadMode {
@@ -13530,6 +13670,14 @@ impl ::serde::ser::Serialize for RemoveMemberJobStatus {
     }
 }
 
+// union extends crate::dbx_async::PollResultBase
+impl From<crate::dbx_async::PollResultBase> for RemoveMemberJobStatus {
+    fn from(parent: crate::dbx_async::PollResultBase) -> Self {
+        match parent {
+            crate::dbx_async::PollResultBase::InProgress => RemoveMemberJobStatus::InProgress,
+        }
+    }
+}
 #[derive(Debug, Clone, PartialEq, Eq)]
 #[non_exhaustive] // variants may be added in the future
 pub enum RequestedLinkAccessLevel {
@@ -13811,6 +13959,16 @@ impl ::serde::ser::Serialize for ResolvedVisibility {
     }
 }
 
+// union extends RequestedVisibility
+impl From<RequestedVisibility> for ResolvedVisibility {
+    fn from(parent: RequestedVisibility) -> Self {
+        match parent {
+            RequestedVisibility::Public => ResolvedVisibility::Public,
+            RequestedVisibility::TeamOnly => ResolvedVisibility::TeamOnly,
+            RequestedVisibility::Password => ResolvedVisibility::Password,
+        }
+    }
+}
 #[derive(Debug, Clone, PartialEq, Eq)]
 #[non_exhaustive] // structs may have more fields added in the future.
 pub struct RevokeSharedLinkArg {
@@ -14001,6 +14159,17 @@ impl ::std::fmt::Display for RevokeSharedLinkError {
     }
 }
 
+// union extends SharedLinkError
+impl From<SharedLinkError> for RevokeSharedLinkError {
+    fn from(parent: SharedLinkError) -> Self {
+        match parent {
+            SharedLinkError::SharedLinkNotFound => RevokeSharedLinkError::SharedLinkNotFound,
+            SharedLinkError::SharedLinkAccessDenied => RevokeSharedLinkError::SharedLinkAccessDenied,
+            SharedLinkError::UnsupportedLinkType => RevokeSharedLinkError::UnsupportedLinkType,
+            SharedLinkError::Other => RevokeSharedLinkError::Other,
+        }
+    }
+}
 #[derive(Debug, Clone, PartialEq, Eq)]
 #[non_exhaustive] // structs may have more fields added in the future.
 pub struct SetAccessInheritanceArg {
@@ -14459,6 +14628,20 @@ impl ::serde::ser::Serialize for ShareFolderArg {
     }
 }
 
+// struct extends ShareFolderArgBase
+impl From<ShareFolderArg> for ShareFolderArgBase {
+    fn from(subtype: ShareFolderArg) -> Self {
+        Self {
+            path: subtype.path,
+            acl_update_policy: subtype.acl_update_policy,
+            force_async: subtype.force_async,
+            member_policy: subtype.member_policy,
+            shared_link_policy: subtype.shared_link_policy,
+            viewer_info_policy: subtype.viewer_info_policy,
+            access_inheritance: subtype.access_inheritance,
+        }
+    }
+}
 #[derive(Debug, Clone, PartialEq, Eq)]
 #[non_exhaustive] // structs may have more fields added in the future.
 pub struct ShareFolderArgBase {
@@ -14797,6 +14980,18 @@ impl ::std::fmt::Display for ShareFolderError {
     }
 }
 
+// union extends ShareFolderErrorBase
+impl From<ShareFolderErrorBase> for ShareFolderError {
+    fn from(parent: ShareFolderErrorBase) -> Self {
+        match parent {
+            ShareFolderErrorBase::EmailUnverified => ShareFolderError::EmailUnverified,
+            ShareFolderErrorBase::BadPath(x) => ShareFolderError::BadPath(x),
+            ShareFolderErrorBase::TeamPolicyDisallowsMemberPolicy => ShareFolderError::TeamPolicyDisallowsMemberPolicy,
+            ShareFolderErrorBase::DisallowedSharedLinkPolicy => ShareFolderError::DisallowedSharedLinkPolicy,
+            ShareFolderErrorBase::Other => ShareFolderError::Other,
+        }
+    }
+}
 #[derive(Debug, Clone, PartialEq, Eq)]
 #[non_exhaustive] // variants may be added in the future
 pub enum ShareFolderErrorBase {
@@ -14968,6 +15163,14 @@ impl ::serde::ser::Serialize for ShareFolderJobStatus {
     }
 }
 
+// union extends crate::dbx_async::PollResultBase
+impl From<crate::dbx_async::PollResultBase> for ShareFolderJobStatus {
+    fn from(parent: crate::dbx_async::PollResultBase) -> Self {
+        match parent {
+            crate::dbx_async::PollResultBase::InProgress => ShareFolderJobStatus::InProgress,
+        }
+    }
+}
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum ShareFolderLaunch {
     /// This response indicates that the processing is asynchronous. The string is an id that can be
@@ -15035,6 +15238,14 @@ impl ::serde::ser::Serialize for ShareFolderLaunch {
     }
 }
 
+// union extends crate::dbx_async::LaunchResultBase
+impl From<crate::dbx_async::LaunchResultBase> for ShareFolderLaunch {
+    fn from(parent: crate::dbx_async::LaunchResultBase) -> Self {
+        match parent {
+            crate::dbx_async::LaunchResultBase::AsyncJobId(x) => ShareFolderLaunch::AsyncJobId(x),
+        }
+    }
+}
 #[derive(Debug, Clone, PartialEq, Eq)]
 #[non_exhaustive] // variants may be added in the future
 pub enum SharePathError {
@@ -15507,6 +15718,20 @@ impl ::serde::ser::Serialize for SharedContentLinkMetadata {
     }
 }
 
+// struct extends SharedContentLinkMetadataBase
+impl From<SharedContentLinkMetadata> for SharedContentLinkMetadataBase {
+    fn from(subtype: SharedContentLinkMetadata) -> Self {
+        Self {
+            audience_options: subtype.audience_options,
+            current_audience: subtype.current_audience,
+            link_permissions: subtype.link_permissions,
+            password_protected: subtype.password_protected,
+            access_level: subtype.access_level,
+            audience_restricting_shared_folder: subtype.audience_restricting_shared_folder,
+            expiry: subtype.expiry,
+        }
+    }
+}
 #[derive(Debug, Clone, PartialEq, Eq)]
 #[non_exhaustive] // structs may have more fields added in the future.
 pub struct SharedContentLinkMetadataBase {
@@ -16930,6 +17155,22 @@ impl ::serde::ser::Serialize for SharedFolderMetadata {
     }
 }
 
+// struct extends SharedFolderMetadataBase
+impl From<SharedFolderMetadata> for SharedFolderMetadataBase {
+    fn from(subtype: SharedFolderMetadata) -> Self {
+        Self {
+            access_type: subtype.access_type,
+            is_inside_team_folder: subtype.is_inside_team_folder,
+            is_team_folder: subtype.is_team_folder,
+            owner_display_names: subtype.owner_display_names,
+            owner_team: subtype.owner_team,
+            parent_shared_folder_id: subtype.parent_shared_folder_id,
+            path_display: subtype.path_display,
+            path_lower: subtype.path_lower,
+            parent_folder_name: subtype.parent_folder_name,
+        }
+    }
+}
 /// Properties of the shared folder.
 #[derive(Debug, Clone, PartialEq, Eq)]
 #[non_exhaustive] // structs may have more fields added in the future.
@@ -19937,6 +20178,18 @@ impl ::serde::ser::Serialize for UserFileMembershipInfo {
     }
 }
 
+// struct extends UserMembershipInfo
+impl From<UserFileMembershipInfo> for UserMembershipInfo {
+    fn from(subtype: UserFileMembershipInfo) -> Self {
+        Self {
+            access_type: subtype.access_type,
+            user: subtype.user,
+            permissions: subtype.permissions,
+            initials: subtype.initials,
+            is_inherited: subtype.is_inherited,
+        }
+    }
+}
 /// Basic information about a user. Use [`users::get_account()`](super::users::get_account) and
 /// [`users::get_account_batch()`](super::users::get_account_batch) to obtain more detailed
 /// information.
@@ -20262,6 +20515,17 @@ impl ::serde::ser::Serialize for UserMembershipInfo {
     }
 }
 
+// struct extends MembershipInfo
+impl From<UserMembershipInfo> for MembershipInfo {
+    fn from(subtype: UserMembershipInfo) -> Self {
+        Self {
+            access_type: subtype.access_type,
+            permissions: subtype.permissions,
+            initials: subtype.initials,
+            is_inherited: subtype.is_inherited,
+        }
+    }
+}
 #[derive(Debug, Clone, PartialEq, Eq)]
 #[non_exhaustive] // variants may be added in the future
 pub enum ViewerInfoPolicy {

--- a/src/generated/team.rs
+++ b/src/generated/team.rs
@@ -1691,6 +1691,18 @@ impl ::serde::ser::Serialize for ActiveWebSession {
     }
 }
 
+// struct extends DeviceSession
+impl From<ActiveWebSession> for DeviceSession {
+    fn from(subtype: ActiveWebSession) -> Self {
+        Self {
+            session_id: subtype.session_id,
+            ip_address: subtype.ip_address,
+            country: subtype.country,
+            created: subtype.created,
+            updated: subtype.updated,
+        }
+    }
+}
 /// Result of trying to add a secondary email to a user. 'success' is the only value indicating that
 /// a secondary email was successfully added to a user. The other values explain the type of error
 /// that occurred, and include the email for which the error occurred.
@@ -3525,6 +3537,18 @@ impl ::serde::ser::Serialize for DesktopClientSession {
     }
 }
 
+// struct extends DeviceSession
+impl From<DesktopClientSession> for DeviceSession {
+    fn from(subtype: DesktopClientSession) -> Self {
+        Self {
+            session_id: subtype.session_id,
+            ip_address: subtype.ip_address,
+            country: subtype.country,
+            created: subtype.created,
+            updated: subtype.updated,
+        }
+    }
+}
 #[derive(Debug, Clone, PartialEq, Eq)]
 #[non_exhaustive] // variants may be added in the future
 pub enum DesktopPlatform {
@@ -5549,6 +5573,14 @@ impl ::serde::ser::Serialize for GetActivityReport {
     }
 }
 
+// struct extends BaseDfbReport
+impl From<GetActivityReport> for BaseDfbReport {
+    fn from(subtype: GetActivityReport) -> Self {
+        Self {
+            start_date: subtype.start_date,
+        }
+    }
+}
 /// Devices Report Result. Contains subsections for different time ranges of activity. Each of the
 /// items in each subsection of the storage report is an array of values, one value per day. If
 /// there is no data for a day, then the value will be None.
@@ -5687,6 +5719,14 @@ impl ::serde::ser::Serialize for GetDevicesReport {
     }
 }
 
+// struct extends BaseDfbReport
+impl From<GetDevicesReport> for BaseDfbReport {
+    fn from(subtype: GetDevicesReport) -> Self {
+        Self {
+            start_date: subtype.start_date,
+        }
+    }
+}
 /// Membership Report Result. Each of the items in the storage report is an array of values, one
 /// value per day. If there is no data for a day, then the value will be None.
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -5852,6 +5892,14 @@ impl ::serde::ser::Serialize for GetMembershipReport {
     }
 }
 
+// struct extends BaseDfbReport
+impl From<GetMembershipReport> for BaseDfbReport {
+    fn from(subtype: GetMembershipReport) -> Self {
+        Self {
+            start_date: subtype.start_date,
+        }
+    }
+}
 /// Storage Report Result. Each of the items in the storage report is an array of values, one value
 /// per day. If there is no data for a day, then the value will be None.
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -6020,6 +6068,14 @@ impl ::serde::ser::Serialize for GetStorageReport {
     }
 }
 
+// struct extends BaseDfbReport
+impl From<GetStorageReport> for BaseDfbReport {
+    fn from(subtype: GetStorageReport) -> Self {
+        Self {
+            start_date: subtype.start_date,
+        }
+    }
+}
 /// Role of a user in group.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum GroupAccessType {
@@ -6423,6 +6479,16 @@ impl ::std::fmt::Display for GroupDeleteError {
     }
 }
 
+// union extends GroupSelectorWithTeamGroupError
+impl From<GroupSelectorWithTeamGroupError> for GroupDeleteError {
+    fn from(parent: GroupSelectorWithTeamGroupError) -> Self {
+        match parent {
+            GroupSelectorWithTeamGroupError::GroupNotFound => GroupDeleteError::GroupNotFound,
+            GroupSelectorWithTeamGroupError::Other => GroupDeleteError::Other,
+            GroupSelectorWithTeamGroupError::SystemManagedGroupDisallowed => GroupDeleteError::SystemManagedGroupDisallowed,
+        }
+    }
+}
 /// Full description of a group.
 #[derive(Debug, Clone, PartialEq, Eq)]
 #[non_exhaustive] // structs may have more fields added in the future.
@@ -6617,6 +6683,18 @@ impl ::serde::ser::Serialize for GroupFullInfo {
     }
 }
 
+// struct extends crate::team_common::GroupSummary
+impl From<GroupFullInfo> for crate::team_common::GroupSummary {
+    fn from(subtype: GroupFullInfo) -> Self {
+        Self {
+            group_name: subtype.group_name,
+            group_id: subtype.group_id,
+            group_management_type: subtype.group_management_type,
+            group_external_id: subtype.group_external_id,
+            member_count: subtype.member_count,
+        }
+    }
+}
 /// Profile of group member, and role in group.
 #[derive(Debug, Clone, PartialEq, Eq)]
 #[non_exhaustive] // structs may have more fields added in the future.
@@ -6918,6 +6996,16 @@ impl ::std::fmt::Display for GroupMemberSelectorError {
     }
 }
 
+// union extends GroupSelectorWithTeamGroupError
+impl From<GroupSelectorWithTeamGroupError> for GroupMemberSelectorError {
+    fn from(parent: GroupSelectorWithTeamGroupError) -> Self {
+        match parent {
+            GroupSelectorWithTeamGroupError::GroupNotFound => GroupMemberSelectorError::GroupNotFound,
+            GroupSelectorWithTeamGroupError::Other => GroupMemberSelectorError::Other,
+            GroupSelectorWithTeamGroupError::SystemManagedGroupDisallowed => GroupMemberSelectorError::SystemManagedGroupDisallowed,
+        }
+    }
+}
 #[derive(Debug, Clone, PartialEq, Eq)]
 #[non_exhaustive] // variants may be added in the future
 pub enum GroupMemberSetAccessTypeError {
@@ -7018,6 +7106,17 @@ impl ::std::fmt::Display for GroupMemberSetAccessTypeError {
     }
 }
 
+// union extends GroupMemberSelectorError
+impl From<GroupMemberSelectorError> for GroupMemberSetAccessTypeError {
+    fn from(parent: GroupMemberSelectorError) -> Self {
+        match parent {
+            GroupMemberSelectorError::GroupNotFound => GroupMemberSetAccessTypeError::GroupNotFound,
+            GroupMemberSelectorError::Other => GroupMemberSetAccessTypeError::Other,
+            GroupMemberSelectorError::SystemManagedGroupDisallowed => GroupMemberSetAccessTypeError::SystemManagedGroupDisallowed,
+            GroupMemberSelectorError::MemberNotInGroup => GroupMemberSetAccessTypeError::MemberNotInGroup,
+        }
+    }
+}
 #[derive(Debug, Clone, PartialEq, Eq)]
 #[non_exhaustive] // structs may have more fields added in the future.
 pub struct GroupMembersAddArg {
@@ -7144,6 +7243,14 @@ impl ::serde::ser::Serialize for GroupMembersAddArg {
     }
 }
 
+// struct extends IncludeMembersArg
+impl From<GroupMembersAddArg> for IncludeMembersArg {
+    fn from(subtype: GroupMembersAddArg) -> Self {
+        Self {
+            return_members: subtype.return_members,
+        }
+    }
+}
 #[derive(Debug, Clone, PartialEq, Eq)]
 #[non_exhaustive] // variants may be added in the future
 pub enum GroupMembersAddError {
@@ -7312,6 +7419,16 @@ impl ::std::fmt::Display for GroupMembersAddError {
     }
 }
 
+// union extends GroupSelectorWithTeamGroupError
+impl From<GroupSelectorWithTeamGroupError> for GroupMembersAddError {
+    fn from(parent: GroupSelectorWithTeamGroupError) -> Self {
+        match parent {
+            GroupSelectorWithTeamGroupError::GroupNotFound => GroupMembersAddError::GroupNotFound,
+            GroupSelectorWithTeamGroupError::Other => GroupMembersAddError::Other,
+            GroupSelectorWithTeamGroupError::SystemManagedGroupDisallowed => GroupMembersAddError::SystemManagedGroupDisallowed,
+        }
+    }
+}
 /// Result returned by [`groups_members_add()`](groups_members_add) and
 /// [`groups_members_remove()`](groups_members_remove).
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -7546,6 +7663,14 @@ impl ::serde::ser::Serialize for GroupMembersRemoveArg {
     }
 }
 
+// struct extends IncludeMembersArg
+impl From<GroupMembersRemoveArg> for IncludeMembersArg {
+    fn from(subtype: GroupMembersRemoveArg) -> Self {
+        Self {
+            return_members: subtype.return_members,
+        }
+    }
+}
 #[derive(Debug, Clone, PartialEq, Eq)]
 #[non_exhaustive] // variants may be added in the future
 pub enum GroupMembersRemoveError {
@@ -7683,6 +7808,17 @@ impl ::std::fmt::Display for GroupMembersRemoveError {
     }
 }
 
+// union extends GroupMembersSelectorError
+impl From<GroupMembersSelectorError> for GroupMembersRemoveError {
+    fn from(parent: GroupMembersSelectorError) -> Self {
+        match parent {
+            GroupMembersSelectorError::GroupNotFound => GroupMembersRemoveError::GroupNotFound,
+            GroupMembersSelectorError::Other => GroupMembersRemoveError::Other,
+            GroupMembersSelectorError::SystemManagedGroupDisallowed => GroupMembersRemoveError::SystemManagedGroupDisallowed,
+            GroupMembersSelectorError::MemberNotInGroup => GroupMembersRemoveError::MemberNotInGroup,
+        }
+    }
+}
 /// Argument for selecting a group and a list of users.
 #[derive(Debug, Clone, PartialEq, Eq)]
 #[non_exhaustive] // structs may have more fields added in the future.
@@ -7879,6 +8015,16 @@ impl ::std::fmt::Display for GroupMembersSelectorError {
     }
 }
 
+// union extends GroupSelectorWithTeamGroupError
+impl From<GroupSelectorWithTeamGroupError> for GroupMembersSelectorError {
+    fn from(parent: GroupSelectorWithTeamGroupError) -> Self {
+        match parent {
+            GroupSelectorWithTeamGroupError::GroupNotFound => GroupMembersSelectorError::GroupNotFound,
+            GroupSelectorWithTeamGroupError::Other => GroupMembersSelectorError::Other,
+            GroupSelectorWithTeamGroupError::SystemManagedGroupDisallowed => GroupMembersSelectorError::SystemManagedGroupDisallowed,
+        }
+    }
+}
 #[derive(Debug, Clone, PartialEq, Eq)]
 #[non_exhaustive] // structs may have more fields added in the future.
 pub struct GroupMembersSetAccessTypeArg {
@@ -8018,6 +8164,15 @@ impl ::serde::ser::Serialize for GroupMembersSetAccessTypeArg {
     }
 }
 
+// struct extends GroupMemberSelector
+impl From<GroupMembersSetAccessTypeArg> for GroupMemberSelector {
+    fn from(subtype: GroupMembersSetAccessTypeArg) -> Self {
+        Self {
+            group: subtype.group,
+            user: subtype.user,
+        }
+    }
+}
 /// Argument for selecting a single group, either by group_id or by external group ID.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum GroupSelector {
@@ -8240,6 +8395,15 @@ impl ::std::fmt::Display for GroupSelectorWithTeamGroupError {
     }
 }
 
+// union extends GroupSelectorError
+impl From<GroupSelectorError> for GroupSelectorWithTeamGroupError {
+    fn from(parent: GroupSelectorError) -> Self {
+        match parent {
+            GroupSelectorError::GroupNotFound => GroupSelectorWithTeamGroupError::GroupNotFound,
+            GroupSelectorError::Other => GroupSelectorWithTeamGroupError::Other,
+        }
+    }
+}
 #[derive(Debug, Clone, PartialEq, Eq)]
 #[non_exhaustive] // structs may have more fields added in the future.
 pub struct GroupUpdateArgs {
@@ -8420,6 +8584,14 @@ impl ::serde::ser::Serialize for GroupUpdateArgs {
     }
 }
 
+// struct extends IncludeMembersArg
+impl From<GroupUpdateArgs> for IncludeMembersArg {
+    fn from(subtype: GroupUpdateArgs) -> Self {
+        Self {
+            return_members: subtype.return_members,
+        }
+    }
+}
 #[derive(Debug, Clone, PartialEq, Eq)]
 #[non_exhaustive] // variants may be added in the future
 pub enum GroupUpdateError {
@@ -8531,6 +8703,16 @@ impl ::std::fmt::Display for GroupUpdateError {
     }
 }
 
+// union extends GroupSelectorWithTeamGroupError
+impl From<GroupSelectorWithTeamGroupError> for GroupUpdateError {
+    fn from(parent: GroupSelectorWithTeamGroupError) -> Self {
+        match parent {
+            GroupSelectorWithTeamGroupError::GroupNotFound => GroupUpdateError::GroupNotFound,
+            GroupSelectorWithTeamGroupError::Other => GroupUpdateError::Other,
+            GroupSelectorWithTeamGroupError::SystemManagedGroupDisallowed => GroupUpdateError::SystemManagedGroupDisallowed,
+        }
+    }
+}
 #[derive(Debug, Clone, PartialEq, Eq)]
 #[non_exhaustive] // variants may be added in the future
 pub enum GroupsGetInfoError {
@@ -9513,6 +9695,16 @@ impl ::std::fmt::Display for GroupsPollError {
     }
 }
 
+// union extends crate::dbx_async::PollError
+impl From<crate::dbx_async::PollError> for GroupsPollError {
+    fn from(parent: crate::dbx_async::PollError) -> Self {
+        match parent {
+            crate::dbx_async::PollError::InvalidAsyncJobId => GroupsPollError::InvalidAsyncJobId,
+            crate::dbx_async::PollError::InternalError => GroupsPollError::InternalError,
+            crate::dbx_async::PollError::Other => GroupsPollError::Other,
+        }
+    }
+}
 /// Argument for selecting a list of groups, either by group_ids, or external group IDs.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum GroupsSelector {
@@ -10659,6 +10851,16 @@ impl ::std::fmt::Display for LegalHoldsGetPolicyError {
     }
 }
 
+// union extends LegalHoldsError
+impl From<LegalHoldsError> for LegalHoldsGetPolicyError {
+    fn from(parent: LegalHoldsError) -> Self {
+        match parent {
+            LegalHoldsError::UnknownLegalHoldError => LegalHoldsGetPolicyError::UnknownLegalHoldError,
+            LegalHoldsError::InsufficientPermissions => LegalHoldsGetPolicyError::InsufficientPermissions,
+            LegalHoldsError::Other => LegalHoldsGetPolicyError::Other,
+        }
+    }
+}
 #[derive(Debug, Clone, PartialEq, Eq)]
 #[non_exhaustive] // structs may have more fields added in the future.
 pub struct LegalHoldsListHeldRevisionResult {
@@ -11190,6 +11392,16 @@ impl ::std::fmt::Display for LegalHoldsListHeldRevisionsError {
     }
 }
 
+// union extends LegalHoldsError
+impl From<LegalHoldsError> for LegalHoldsListHeldRevisionsError {
+    fn from(parent: LegalHoldsError) -> Self {
+        match parent {
+            LegalHoldsError::UnknownLegalHoldError => LegalHoldsListHeldRevisionsError::UnknownLegalHoldError,
+            LegalHoldsError::InsufficientPermissions => LegalHoldsListHeldRevisionsError::InsufficientPermissions,
+            LegalHoldsError::Other => LegalHoldsListHeldRevisionsError::Other,
+        }
+    }
+}
 #[derive(Debug, Clone, PartialEq, Eq, Default)]
 #[non_exhaustive] // structs may have more fields added in the future.
 pub struct LegalHoldsListPoliciesArg {
@@ -11360,6 +11572,16 @@ impl ::std::fmt::Display for LegalHoldsListPoliciesError {
     }
 }
 
+// union extends LegalHoldsError
+impl From<LegalHoldsError> for LegalHoldsListPoliciesError {
+    fn from(parent: LegalHoldsError) -> Self {
+        match parent {
+            LegalHoldsError::UnknownLegalHoldError => LegalHoldsListPoliciesError::UnknownLegalHoldError,
+            LegalHoldsError::InsufficientPermissions => LegalHoldsListPoliciesError::InsufficientPermissions,
+            LegalHoldsError::Other => LegalHoldsListPoliciesError::Other,
+        }
+    }
+}
 #[derive(Debug, Clone, PartialEq, Eq)]
 #[non_exhaustive] // structs may have more fields added in the future.
 pub struct LegalHoldsListPoliciesResult {
@@ -11780,6 +12002,16 @@ impl ::std::fmt::Display for LegalHoldsPolicyCreateError {
     }
 }
 
+// union extends LegalHoldsError
+impl From<LegalHoldsError> for LegalHoldsPolicyCreateError {
+    fn from(parent: LegalHoldsError) -> Self {
+        match parent {
+            LegalHoldsError::UnknownLegalHoldError => LegalHoldsPolicyCreateError::UnknownLegalHoldError,
+            LegalHoldsError::InsufficientPermissions => LegalHoldsPolicyCreateError::InsufficientPermissions,
+            LegalHoldsError::Other => LegalHoldsPolicyCreateError::Other,
+        }
+    }
+}
 #[derive(Debug, Clone, PartialEq, Eq)]
 #[non_exhaustive] // structs may have more fields added in the future.
 pub struct LegalHoldsPolicyReleaseArg {
@@ -11982,6 +12214,16 @@ impl ::std::fmt::Display for LegalHoldsPolicyReleaseError {
     }
 }
 
+// union extends LegalHoldsError
+impl From<LegalHoldsError> for LegalHoldsPolicyReleaseError {
+    fn from(parent: LegalHoldsError) -> Self {
+        match parent {
+            LegalHoldsError::UnknownLegalHoldError => LegalHoldsPolicyReleaseError::UnknownLegalHoldError,
+            LegalHoldsError::InsufficientPermissions => LegalHoldsPolicyReleaseError::InsufficientPermissions,
+            LegalHoldsError::Other => LegalHoldsPolicyReleaseError::Other,
+        }
+    }
+}
 #[derive(Debug, Clone, PartialEq, Eq)]
 #[non_exhaustive] // structs may have more fields added in the future.
 pub struct LegalHoldsPolicyUpdateArg {
@@ -12299,6 +12541,16 @@ impl ::std::fmt::Display for LegalHoldsPolicyUpdateError {
     }
 }
 
+// union extends LegalHoldsError
+impl From<LegalHoldsError> for LegalHoldsPolicyUpdateError {
+    fn from(parent: LegalHoldsError) -> Self {
+        match parent {
+            LegalHoldsError::UnknownLegalHoldError => LegalHoldsPolicyUpdateError::UnknownLegalHoldError,
+            LegalHoldsError::InsufficientPermissions => LegalHoldsPolicyUpdateError::InsufficientPermissions,
+            LegalHoldsError::Other => LegalHoldsPolicyUpdateError::Other,
+        }
+    }
+}
 #[derive(Debug, Clone, PartialEq, Eq)]
 #[non_exhaustive] // structs may have more fields added in the future.
 pub struct ListMemberAppsArg {
@@ -14479,6 +14731,20 @@ impl ::serde::ser::Serialize for MemberAddArg {
     }
 }
 
+// struct extends MemberAddArgBase
+impl From<MemberAddArg> for MemberAddArgBase {
+    fn from(subtype: MemberAddArg) -> Self {
+        Self {
+            member_email: subtype.member_email,
+            member_given_name: subtype.member_given_name,
+            member_surname: subtype.member_surname,
+            member_external_id: subtype.member_external_id,
+            member_persistent_id: subtype.member_persistent_id,
+            send_welcome_email: subtype.send_welcome_email,
+            is_directory_restricted: subtype.is_directory_restricted,
+        }
+    }
+}
 #[derive(Debug, Clone, PartialEq, Eq)]
 #[non_exhaustive] // structs may have more fields added in the future.
 pub struct MemberAddArgBase {
@@ -14920,6 +15186,23 @@ impl ::serde::ser::Serialize for MemberAddResult {
     }
 }
 
+// union extends MemberAddResultBase
+impl From<MemberAddResultBase> for MemberAddResult {
+    fn from(parent: MemberAddResultBase) -> Self {
+        match parent {
+            MemberAddResultBase::TeamLicenseLimit(x) => MemberAddResult::TeamLicenseLimit(x),
+            MemberAddResultBase::FreeTeamMemberLimitReached(x) => MemberAddResult::FreeTeamMemberLimitReached(x),
+            MemberAddResultBase::UserAlreadyOnTeam(x) => MemberAddResult::UserAlreadyOnTeam(x),
+            MemberAddResultBase::UserOnAnotherTeam(x) => MemberAddResult::UserOnAnotherTeam(x),
+            MemberAddResultBase::UserAlreadyPaired(x) => MemberAddResult::UserAlreadyPaired(x),
+            MemberAddResultBase::UserMigrationFailed(x) => MemberAddResult::UserMigrationFailed(x),
+            MemberAddResultBase::DuplicateExternalMemberId(x) => MemberAddResult::DuplicateExternalMemberId(x),
+            MemberAddResultBase::DuplicateMemberPersistentId(x) => MemberAddResult::DuplicateMemberPersistentId(x),
+            MemberAddResultBase::PersistentIdDisabled(x) => MemberAddResult::PersistentIdDisabled(x),
+            MemberAddResultBase::UserCreationFailed(x) => MemberAddResult::UserCreationFailed(x),
+        }
+    }
+}
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum MemberAddResultBase {
     /// Team is already full. The organization has no available licenses.
@@ -15366,6 +15649,20 @@ impl ::serde::ser::Serialize for MemberAddV2Arg {
     }
 }
 
+// struct extends MemberAddArgBase
+impl From<MemberAddV2Arg> for MemberAddArgBase {
+    fn from(subtype: MemberAddV2Arg) -> Self {
+        Self {
+            member_email: subtype.member_email,
+            member_given_name: subtype.member_given_name,
+            member_surname: subtype.member_surname,
+            member_external_id: subtype.member_external_id,
+            member_persistent_id: subtype.member_persistent_id,
+            send_welcome_email: subtype.send_welcome_email,
+            is_directory_restricted: subtype.is_directory_restricted,
+        }
+    }
+}
 /// Describes the result of attempting to add a single user to the team. 'success' is the only value
 /// indicating that a user was indeed added to the team - the other values explain the type of
 /// failure that occurred, and include the email of the user for which the operation has failed.
@@ -15600,6 +15897,23 @@ impl ::serde::ser::Serialize for MemberAddV2Result {
     }
 }
 
+// union extends MemberAddResultBase
+impl From<MemberAddResultBase> for MemberAddV2Result {
+    fn from(parent: MemberAddResultBase) -> Self {
+        match parent {
+            MemberAddResultBase::TeamLicenseLimit(x) => MemberAddV2Result::TeamLicenseLimit(x),
+            MemberAddResultBase::FreeTeamMemberLimitReached(x) => MemberAddV2Result::FreeTeamMemberLimitReached(x),
+            MemberAddResultBase::UserAlreadyOnTeam(x) => MemberAddV2Result::UserAlreadyOnTeam(x),
+            MemberAddResultBase::UserOnAnotherTeam(x) => MemberAddV2Result::UserOnAnotherTeam(x),
+            MemberAddResultBase::UserAlreadyPaired(x) => MemberAddV2Result::UserAlreadyPaired(x),
+            MemberAddResultBase::UserMigrationFailed(x) => MemberAddV2Result::UserMigrationFailed(x),
+            MemberAddResultBase::DuplicateExternalMemberId(x) => MemberAddV2Result::DuplicateExternalMemberId(x),
+            MemberAddResultBase::DuplicateMemberPersistentId(x) => MemberAddV2Result::DuplicateMemberPersistentId(x),
+            MemberAddResultBase::PersistentIdDisabled(x) => MemberAddV2Result::PersistentIdDisabled(x),
+            MemberAddResultBase::UserCreationFailed(x) => MemberAddV2Result::UserCreationFailed(x),
+        }
+    }
+}
 /// Information on devices of a team's member.
 #[derive(Debug, Clone, PartialEq, Eq)]
 #[non_exhaustive] // structs may have more fields added in the future.
@@ -16281,6 +16595,14 @@ impl ::std::fmt::Display for MemberSelectorError {
     }
 }
 
+// union extends UserSelectorError
+impl From<UserSelectorError> for MemberSelectorError {
+    fn from(parent: UserSelectorError) -> Self {
+        match parent {
+            UserSelectorError::UserNotFound => MemberSelectorError::UserNotFound,
+        }
+    }
+}
 #[derive(Debug, Clone, PartialEq, Eq)]
 #[non_exhaustive] // structs may have more fields added in the future.
 pub struct MembersAddArg {
@@ -16392,6 +16714,14 @@ impl ::serde::ser::Serialize for MembersAddArg {
     }
 }
 
+// struct extends MembersAddArgBase
+impl From<MembersAddArg> for MembersAddArgBase {
+    fn from(subtype: MembersAddArg) -> Self {
+        Self {
+            force_async: subtype.force_async,
+        }
+    }
+}
 #[derive(Debug, Clone, PartialEq, Eq, Default)]
 #[non_exhaustive] // structs may have more fields added in the future.
 pub struct MembersAddArgBase {
@@ -16558,6 +16888,14 @@ impl ::serde::ser::Serialize for MembersAddJobStatus {
     }
 }
 
+// union extends crate::dbx_async::PollResultBase
+impl From<crate::dbx_async::PollResultBase> for MembersAddJobStatus {
+    fn from(parent: crate::dbx_async::PollResultBase) -> Self {
+        match parent {
+            crate::dbx_async::PollResultBase::InProgress => MembersAddJobStatus::InProgress,
+        }
+    }
+}
 #[derive(Debug, Clone, PartialEq, Eq)]
 #[non_exhaustive] // variants may be added in the future
 pub enum MembersAddJobStatusV2Result {
@@ -16649,6 +16987,14 @@ impl ::serde::ser::Serialize for MembersAddJobStatusV2Result {
     }
 }
 
+// union extends crate::dbx_async::PollResultBase
+impl From<crate::dbx_async::PollResultBase> for MembersAddJobStatusV2Result {
+    fn from(parent: crate::dbx_async::PollResultBase) -> Self {
+        match parent {
+            crate::dbx_async::PollResultBase::InProgress => MembersAddJobStatusV2Result::InProgress,
+        }
+    }
+}
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum MembersAddLaunch {
     /// This response indicates that the processing is asynchronous. The string is an id that can be
@@ -16722,6 +17068,14 @@ impl ::serde::ser::Serialize for MembersAddLaunch {
     }
 }
 
+// union extends crate::dbx_async::LaunchResultBase
+impl From<crate::dbx_async::LaunchResultBase> for MembersAddLaunch {
+    fn from(parent: crate::dbx_async::LaunchResultBase) -> Self {
+        match parent {
+            crate::dbx_async::LaunchResultBase::AsyncJobId(x) => MembersAddLaunch::AsyncJobId(x),
+        }
+    }
+}
 #[derive(Debug, Clone, PartialEq, Eq)]
 #[non_exhaustive] // variants may be added in the future
 pub enum MembersAddLaunchV2Result {
@@ -16801,6 +17155,14 @@ impl ::serde::ser::Serialize for MembersAddLaunchV2Result {
     }
 }
 
+// union extends crate::dbx_async::LaunchResultBase
+impl From<crate::dbx_async::LaunchResultBase> for MembersAddLaunchV2Result {
+    fn from(parent: crate::dbx_async::LaunchResultBase) -> Self {
+        match parent {
+            crate::dbx_async::LaunchResultBase::AsyncJobId(x) => MembersAddLaunchV2Result::AsyncJobId(x),
+        }
+    }
+}
 #[derive(Debug, Clone, PartialEq, Eq)]
 #[non_exhaustive] // structs may have more fields added in the future.
 pub struct MembersAddV2Arg {
@@ -16912,6 +17274,14 @@ impl ::serde::ser::Serialize for MembersAddV2Arg {
     }
 }
 
+// struct extends MembersAddArgBase
+impl From<MembersAddV2Arg> for MembersAddArgBase {
+    fn from(subtype: MembersAddV2Arg) -> Self {
+        Self {
+            force_async: subtype.force_async,
+        }
+    }
+}
 #[derive(Debug, Clone, PartialEq, Eq)]
 #[non_exhaustive] // structs may have more fields added in the future.
 pub struct MembersDataTransferArg {
@@ -17033,6 +17403,14 @@ impl ::serde::ser::Serialize for MembersDataTransferArg {
     }
 }
 
+// struct extends MembersDeactivateBaseArg
+impl From<MembersDataTransferArg> for MembersDeactivateBaseArg {
+    fn from(subtype: MembersDataTransferArg) -> Self {
+        Self {
+            user: subtype.user,
+        }
+    }
+}
 #[derive(Debug, Clone, PartialEq, Eq)]
 #[non_exhaustive] // structs may have more fields added in the future.
 pub struct MembersDeactivateArg {
@@ -17144,6 +17522,14 @@ impl ::serde::ser::Serialize for MembersDeactivateArg {
     }
 }
 
+// struct extends MembersDeactivateBaseArg
+impl From<MembersDeactivateArg> for MembersDeactivateBaseArg {
+    fn from(subtype: MembersDeactivateArg) -> Self {
+        Self {
+            user: subtype.user,
+        }
+    }
+}
 /// Exactly one of team_member_id, email, or external_id must be provided to identify the user
 /// account.
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -17316,6 +17702,14 @@ impl ::std::fmt::Display for MembersDeactivateError {
     }
 }
 
+// union extends UserSelectorError
+impl From<UserSelectorError> for MembersDeactivateError {
+    fn from(parent: UserSelectorError) -> Self {
+        match parent {
+            UserSelectorError::UserNotFound => MembersDeactivateError::UserNotFound,
+        }
+    }
+}
 #[derive(Debug, Clone, PartialEq, Eq)]
 #[non_exhaustive] // structs may have more fields added in the future.
 pub struct MembersDeleteProfilePhotoArg {
@@ -17497,6 +17891,15 @@ impl ::std::fmt::Display for MembersDeleteProfilePhotoError {
     }
 }
 
+// union extends MemberSelectorError
+impl From<MemberSelectorError> for MembersDeleteProfilePhotoError {
+    fn from(parent: MemberSelectorError) -> Self {
+        match parent {
+            MemberSelectorError::UserNotFound => MembersDeleteProfilePhotoError::UserNotFound,
+            MemberSelectorError::UserNotInTeam => MembersDeleteProfilePhotoError::UserNotInTeam,
+        }
+    }
+}
 /// Available TeamMemberRole for the connected team. To be used with
 /// [`members_set_admin_permissions_v2()`](members_set_admin_permissions_v2).
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -17805,6 +18208,14 @@ impl ::serde::ser::Serialize for MembersGetInfoItem {
     }
 }
 
+// union extends MembersGetInfoItemBase
+impl From<MembersGetInfoItemBase> for MembersGetInfoItem {
+    fn from(parent: MembersGetInfoItemBase) -> Self {
+        match parent {
+            MembersGetInfoItemBase::IdNotFound(x) => MembersGetInfoItem::IdNotFound(x),
+        }
+    }
+}
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum MembersGetInfoItemBase {
     /// An ID that was provided as a parameter to [`members_get_info()`](members_get_info) or
@@ -17942,6 +18353,14 @@ impl ::serde::ser::Serialize for MembersGetInfoItemV2 {
     }
 }
 
+// union extends MembersGetInfoItemBase
+impl From<MembersGetInfoItemBase> for MembersGetInfoItemV2 {
+    fn from(parent: MembersGetInfoItemBase) -> Self {
+        match parent {
+            MembersGetInfoItemBase::IdNotFound(x) => MembersGetInfoItemV2::IdNotFound(x),
+        }
+    }
+}
 #[derive(Debug, Clone, PartialEq, Eq)]
 #[non_exhaustive] // structs may have more fields added in the future.
 pub struct MembersGetInfoV2Arg {
@@ -18982,6 +19401,14 @@ impl ::std::fmt::Display for MembersRecoverError {
     }
 }
 
+// union extends UserSelectorError
+impl From<UserSelectorError> for MembersRecoverError {
+    fn from(parent: UserSelectorError) -> Self {
+        match parent {
+            UserSelectorError::UserNotFound => MembersRecoverError::UserNotFound,
+        }
+    }
+}
 #[derive(Debug, Clone, PartialEq, Eq)]
 #[non_exhaustive] // structs may have more fields added in the future.
 pub struct MembersRemoveArg {
@@ -19180,6 +19607,15 @@ impl ::serde::ser::Serialize for MembersRemoveArg {
     }
 }
 
+// struct extends MembersDeactivateArg
+impl From<MembersRemoveArg> for MembersDeactivateArg {
+    fn from(subtype: MembersRemoveArg) -> Self {
+        Self {
+            user: subtype.user,
+            wipe_data: subtype.wipe_data,
+        }
+    }
+}
 #[derive(Debug, Clone, PartialEq, Eq)]
 #[non_exhaustive] // variants may be added in the future
 pub enum MembersRemoveError {
@@ -19482,6 +19918,25 @@ impl ::std::fmt::Display for MembersRemoveError {
     }
 }
 
+// union extends MembersTransferFilesError
+impl From<MembersTransferFilesError> for MembersRemoveError {
+    fn from(parent: MembersTransferFilesError) -> Self {
+        match parent {
+            MembersTransferFilesError::UserNotFound => MembersRemoveError::UserNotFound,
+            MembersTransferFilesError::UserNotInTeam => MembersRemoveError::UserNotInTeam,
+            MembersTransferFilesError::Other => MembersRemoveError::Other,
+            MembersTransferFilesError::RemovedAndTransferDestShouldDiffer => MembersRemoveError::RemovedAndTransferDestShouldDiffer,
+            MembersTransferFilesError::RemovedAndTransferAdminShouldDiffer => MembersRemoveError::RemovedAndTransferAdminShouldDiffer,
+            MembersTransferFilesError::TransferDestUserNotFound => MembersRemoveError::TransferDestUserNotFound,
+            MembersTransferFilesError::TransferDestUserNotInTeam => MembersRemoveError::TransferDestUserNotInTeam,
+            MembersTransferFilesError::TransferAdminUserNotInTeam => MembersRemoveError::TransferAdminUserNotInTeam,
+            MembersTransferFilesError::TransferAdminUserNotFound => MembersRemoveError::TransferAdminUserNotFound,
+            MembersTransferFilesError::UnspecifiedTransferAdminId => MembersRemoveError::UnspecifiedTransferAdminId,
+            MembersTransferFilesError::TransferAdminIsNotAdmin => MembersRemoveError::TransferAdminIsNotAdmin,
+            MembersTransferFilesError::RecipientNotVerified => MembersRemoveError::RecipientNotVerified,
+        }
+    }
+}
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 #[non_exhaustive] // variants may be added in the future
@@ -19562,6 +20017,15 @@ impl ::std::fmt::Display for MembersSendWelcomeError {
     }
 }
 
+// union extends MemberSelectorError
+impl From<MemberSelectorError> for MembersSendWelcomeError {
+    fn from(parent: MemberSelectorError) -> Self {
+        match parent {
+            MemberSelectorError::UserNotFound => MembersSendWelcomeError::UserNotFound,
+            MemberSelectorError::UserNotInTeam => MembersSendWelcomeError::UserNotInTeam,
+        }
+    }
+}
 /// Exactly one of team_member_id, email, or external_id must be provided to identify the user
 /// account.
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -19788,6 +20252,14 @@ impl ::std::fmt::Display for MembersSetPermissions2Error {
     }
 }
 
+// union extends UserSelectorError
+impl From<UserSelectorError> for MembersSetPermissions2Error {
+    fn from(parent: UserSelectorError) -> Self {
+        match parent {
+            UserSelectorError::UserNotFound => MembersSetPermissions2Error::UserNotFound,
+        }
+    }
+}
 #[derive(Debug, Clone, PartialEq, Eq)]
 #[non_exhaustive] // structs may have more fields added in the future.
 pub struct MembersSetPermissions2Result {
@@ -20117,6 +20589,14 @@ impl ::std::fmt::Display for MembersSetPermissionsError {
     }
 }
 
+// union extends UserSelectorError
+impl From<UserSelectorError> for MembersSetPermissionsError {
+    fn from(parent: UserSelectorError) -> Self {
+        match parent {
+            UserSelectorError::UserNotFound => MembersSetPermissionsError::UserNotFound,
+        }
+    }
+}
 #[derive(Debug, Clone, PartialEq, Eq)]
 #[non_exhaustive] // structs may have more fields added in the future.
 pub struct MembersSetPermissionsResult {
@@ -20615,6 +21095,15 @@ impl ::std::fmt::Display for MembersSetProfileError {
     }
 }
 
+// union extends MemberSelectorError
+impl From<MemberSelectorError> for MembersSetProfileError {
+    fn from(parent: MemberSelectorError) -> Self {
+        match parent {
+            MemberSelectorError::UserNotFound => MembersSetProfileError::UserNotFound,
+            MemberSelectorError::UserNotInTeam => MembersSetProfileError::UserNotInTeam,
+        }
+    }
+}
 #[derive(Debug, Clone, PartialEq, Eq)]
 #[non_exhaustive] // structs may have more fields added in the future.
 pub struct MembersSetProfilePhotoArg {
@@ -20832,6 +21321,15 @@ impl ::std::fmt::Display for MembersSetProfilePhotoError {
     }
 }
 
+// union extends MemberSelectorError
+impl From<MemberSelectorError> for MembersSetProfilePhotoError {
+    fn from(parent: MemberSelectorError) -> Self {
+        match parent {
+            MemberSelectorError::UserNotFound => MembersSetProfilePhotoError::UserNotFound,
+            MemberSelectorError::UserNotInTeam => MembersSetProfilePhotoError::UserNotInTeam,
+        }
+    }
+}
 #[derive(Debug, Clone, PartialEq, Eq)]
 #[non_exhaustive] // variants may be added in the future
 pub enum MembersSuspendError {
@@ -20944,6 +21442,16 @@ impl ::std::fmt::Display for MembersSuspendError {
     }
 }
 
+// union extends MembersDeactivateError
+impl From<MembersDeactivateError> for MembersSuspendError {
+    fn from(parent: MembersDeactivateError) -> Self {
+        match parent {
+            MembersDeactivateError::UserNotFound => MembersSuspendError::UserNotFound,
+            MembersDeactivateError::UserNotInTeam => MembersSuspendError::UserNotInTeam,
+            MembersDeactivateError::Other => MembersSuspendError::Other,
+        }
+    }
+}
 #[derive(Debug, Clone, PartialEq, Eq)]
 #[non_exhaustive] // variants may be added in the future
 pub enum MembersTransferFilesError {
@@ -21122,6 +21630,16 @@ impl ::std::fmt::Display for MembersTransferFilesError {
     }
 }
 
+// union extends MembersDeactivateError
+impl From<MembersDeactivateError> for MembersTransferFilesError {
+    fn from(parent: MembersDeactivateError) -> Self {
+        match parent {
+            MembersDeactivateError::UserNotFound => MembersTransferFilesError::UserNotFound,
+            MembersDeactivateError::UserNotInTeam => MembersTransferFilesError::UserNotInTeam,
+            MembersDeactivateError::Other => MembersTransferFilesError::Other,
+        }
+    }
+}
 #[derive(Debug, Clone, PartialEq, Eq)]
 #[non_exhaustive] // variants may be added in the future
 pub enum MembersTransferFormerMembersFilesError {
@@ -21344,6 +21862,25 @@ impl ::std::fmt::Display for MembersTransferFormerMembersFilesError {
     }
 }
 
+// union extends MembersTransferFilesError
+impl From<MembersTransferFilesError> for MembersTransferFormerMembersFilesError {
+    fn from(parent: MembersTransferFilesError) -> Self {
+        match parent {
+            MembersTransferFilesError::UserNotFound => MembersTransferFormerMembersFilesError::UserNotFound,
+            MembersTransferFilesError::UserNotInTeam => MembersTransferFormerMembersFilesError::UserNotInTeam,
+            MembersTransferFilesError::Other => MembersTransferFormerMembersFilesError::Other,
+            MembersTransferFilesError::RemovedAndTransferDestShouldDiffer => MembersTransferFormerMembersFilesError::RemovedAndTransferDestShouldDiffer,
+            MembersTransferFilesError::RemovedAndTransferAdminShouldDiffer => MembersTransferFormerMembersFilesError::RemovedAndTransferAdminShouldDiffer,
+            MembersTransferFilesError::TransferDestUserNotFound => MembersTransferFormerMembersFilesError::TransferDestUserNotFound,
+            MembersTransferFilesError::TransferDestUserNotInTeam => MembersTransferFormerMembersFilesError::TransferDestUserNotInTeam,
+            MembersTransferFilesError::TransferAdminUserNotInTeam => MembersTransferFormerMembersFilesError::TransferAdminUserNotInTeam,
+            MembersTransferFilesError::TransferAdminUserNotFound => MembersTransferFormerMembersFilesError::TransferAdminUserNotFound,
+            MembersTransferFilesError::UnspecifiedTransferAdminId => MembersTransferFormerMembersFilesError::UnspecifiedTransferAdminId,
+            MembersTransferFilesError::TransferAdminIsNotAdmin => MembersTransferFormerMembersFilesError::TransferAdminIsNotAdmin,
+            MembersTransferFilesError::RecipientNotVerified => MembersTransferFormerMembersFilesError::RecipientNotVerified,
+        }
+    }
+}
 /// Exactly one of team_member_id, email, or external_id must be provided to identify the user
 /// account.
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -21538,6 +22075,16 @@ impl ::std::fmt::Display for MembersUnsuspendError {
     }
 }
 
+// union extends MembersDeactivateError
+impl From<MembersDeactivateError> for MembersUnsuspendError {
+    fn from(parent: MembersDeactivateError) -> Self {
+        match parent {
+            MembersDeactivateError::UserNotFound => MembersUnsuspendError::UserNotFound,
+            MembersDeactivateError::UserNotInTeam => MembersUnsuspendError::UserNotInTeam,
+            MembersDeactivateError::Other => MembersUnsuspendError::Other,
+        }
+    }
+}
 #[derive(Debug, Clone, PartialEq, Eq)]
 #[non_exhaustive] // variants may be added in the future
 pub enum MobileClientPlatform {
@@ -21895,6 +22442,18 @@ impl ::serde::ser::Serialize for MobileClientSession {
     }
 }
 
+// struct extends DeviceSession
+impl From<MobileClientSession> for DeviceSession {
+    fn from(subtype: MobileClientSession) -> Self {
+        Self {
+            session_id: subtype.session_id,
+            ip_address: subtype.ip_address,
+            country: subtype.country,
+            created: subtype.created,
+            updated: subtype.updated,
+        }
+    }
+}
 /// Properties of a namespace.
 #[derive(Debug, Clone, PartialEq, Eq)]
 #[non_exhaustive] // structs may have more fields added in the future.
@@ -22713,6 +23272,15 @@ impl ::serde::ser::Serialize for RevokeDesktopClientArg {
     }
 }
 
+// struct extends DeviceSessionArg
+impl From<RevokeDesktopClientArg> for DeviceSessionArg {
+    fn from(subtype: RevokeDesktopClientArg) -> Self {
+        Self {
+            session_id: subtype.session_id,
+            team_member_id: subtype.team_member_id,
+        }
+    }
+}
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum RevokeDeviceSessionArg {
     /// End an active session.
@@ -23935,6 +24503,15 @@ impl ::std::fmt::Display for SetCustomQuotaError {
     }
 }
 
+// union extends CustomQuotaError
+impl From<CustomQuotaError> for SetCustomQuotaError {
+    fn from(parent: CustomQuotaError) -> Self {
+        match parent {
+            CustomQuotaError::TooManyUsers => SetCustomQuotaError::TooManyUsers,
+            CustomQuotaError::Other => SetCustomQuotaError::Other,
+        }
+    }
+}
 /// Structure representing Approve List entries. Domain and emails are supported. At least one entry
 /// of any supported type is required.
 #[derive(Debug, Clone, PartialEq, Eq, Default)]
@@ -25237,6 +25814,17 @@ impl ::std::fmt::Display for TeamFolderActivateError {
     }
 }
 
+// union extends BaseTeamFolderError
+impl From<BaseTeamFolderError> for TeamFolderActivateError {
+    fn from(parent: BaseTeamFolderError) -> Self {
+        match parent {
+            BaseTeamFolderError::AccessError(x) => TeamFolderActivateError::AccessError(x),
+            BaseTeamFolderError::StatusError(x) => TeamFolderActivateError::StatusError(x),
+            BaseTeamFolderError::TeamSharedDropboxError(x) => TeamFolderActivateError::TeamSharedDropboxError(x),
+            BaseTeamFolderError::Other => TeamFolderActivateError::Other,
+        }
+    }
+}
 #[derive(Debug, Clone, PartialEq, Eq)]
 #[non_exhaustive] // structs may have more fields added in the future.
 pub struct TeamFolderArchiveArg {
@@ -25348,6 +25936,14 @@ impl ::serde::ser::Serialize for TeamFolderArchiveArg {
     }
 }
 
+// struct extends TeamFolderIdArg
+impl From<TeamFolderArchiveArg> for TeamFolderIdArg {
+    fn from(subtype: TeamFolderArchiveArg) -> Self {
+        Self {
+            team_folder_id: subtype.team_folder_id,
+        }
+    }
+}
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 #[non_exhaustive] // variants may be added in the future
@@ -25464,6 +26060,17 @@ impl ::std::fmt::Display for TeamFolderArchiveError {
     }
 }
 
+// union extends BaseTeamFolderError
+impl From<BaseTeamFolderError> for TeamFolderArchiveError {
+    fn from(parent: BaseTeamFolderError) -> Self {
+        match parent {
+            BaseTeamFolderError::AccessError(x) => TeamFolderArchiveError::AccessError(x),
+            BaseTeamFolderError::StatusError(x) => TeamFolderArchiveError::StatusError(x),
+            BaseTeamFolderError::TeamSharedDropboxError(x) => TeamFolderArchiveError::TeamSharedDropboxError(x),
+            BaseTeamFolderError::Other => TeamFolderArchiveError::Other,
+        }
+    }
+}
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum TeamFolderArchiveJobStatus {
     /// The asynchronous job is still in progress.
@@ -25542,6 +26149,14 @@ impl ::serde::ser::Serialize for TeamFolderArchiveJobStatus {
     }
 }
 
+// union extends crate::dbx_async::PollResultBase
+impl From<crate::dbx_async::PollResultBase> for TeamFolderArchiveJobStatus {
+    fn from(parent: crate::dbx_async::PollResultBase) -> Self {
+        match parent {
+            crate::dbx_async::PollResultBase::InProgress => TeamFolderArchiveJobStatus::InProgress,
+        }
+    }
+}
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum TeamFolderArchiveLaunch {
     /// This response indicates that the processing is asynchronous. The string is an id that can be
@@ -25609,6 +26224,14 @@ impl ::serde::ser::Serialize for TeamFolderArchiveLaunch {
     }
 }
 
+// union extends crate::dbx_async::LaunchResultBase
+impl From<crate::dbx_async::LaunchResultBase> for TeamFolderArchiveLaunch {
+    fn from(parent: crate::dbx_async::LaunchResultBase) -> Self {
+        match parent {
+            crate::dbx_async::LaunchResultBase::AsyncJobId(x) => TeamFolderArchiveLaunch::AsyncJobId(x),
+        }
+    }
+}
 #[derive(Debug, Clone, PartialEq, Eq)]
 #[non_exhaustive] // structs may have more fields added in the future.
 pub struct TeamFolderCreateArg {
@@ -26920,6 +27543,17 @@ impl ::std::fmt::Display for TeamFolderPermanentlyDeleteError {
     }
 }
 
+// union extends BaseTeamFolderError
+impl From<BaseTeamFolderError> for TeamFolderPermanentlyDeleteError {
+    fn from(parent: BaseTeamFolderError) -> Self {
+        match parent {
+            BaseTeamFolderError::AccessError(x) => TeamFolderPermanentlyDeleteError::AccessError(x),
+            BaseTeamFolderError::StatusError(x) => TeamFolderPermanentlyDeleteError::StatusError(x),
+            BaseTeamFolderError::TeamSharedDropboxError(x) => TeamFolderPermanentlyDeleteError::TeamSharedDropboxError(x),
+            BaseTeamFolderError::Other => TeamFolderPermanentlyDeleteError::Other,
+        }
+    }
+}
 #[derive(Debug, Clone, PartialEq, Eq)]
 #[non_exhaustive] // structs may have more fields added in the future.
 pub struct TeamFolderRenameArg {
@@ -27024,6 +27658,14 @@ impl ::serde::ser::Serialize for TeamFolderRenameArg {
     }
 }
 
+// struct extends TeamFolderIdArg
+impl From<TeamFolderRenameArg> for TeamFolderIdArg {
+    fn from(subtype: TeamFolderRenameArg) -> Self {
+        Self {
+            team_folder_id: subtype.team_folder_id,
+        }
+    }
+}
 #[derive(Debug, Clone, PartialEq, Eq)]
 #[non_exhaustive] // variants may be added in the future
 pub enum TeamFolderRenameError {
@@ -27172,6 +27814,17 @@ impl ::std::fmt::Display for TeamFolderRenameError {
     }
 }
 
+// union extends BaseTeamFolderError
+impl From<BaseTeamFolderError> for TeamFolderRenameError {
+    fn from(parent: BaseTeamFolderError) -> Self {
+        match parent {
+            BaseTeamFolderError::AccessError(x) => TeamFolderRenameError::AccessError(x),
+            BaseTeamFolderError::StatusError(x) => TeamFolderRenameError::StatusError(x),
+            BaseTeamFolderError::TeamSharedDropboxError(x) => TeamFolderRenameError::TeamSharedDropboxError(x),
+            BaseTeamFolderError::Other => TeamFolderRenameError::Other,
+        }
+    }
+}
 #[derive(Debug, Clone, PartialEq, Eq)]
 #[non_exhaustive] // variants may be added in the future
 pub enum TeamFolderStatus {
@@ -27449,6 +28102,14 @@ impl ::serde::ser::Serialize for TeamFolderUpdateSyncSettingsArg {
     }
 }
 
+// struct extends TeamFolderIdArg
+impl From<TeamFolderUpdateSyncSettingsArg> for TeamFolderIdArg {
+    fn from(subtype: TeamFolderUpdateSyncSettingsArg) -> Self {
+        Self {
+            team_folder_id: subtype.team_folder_id,
+        }
+    }
+}
 #[derive(Debug, Clone, PartialEq, Eq)]
 #[non_exhaustive] // variants may be added in the future
 pub enum TeamFolderUpdateSyncSettingsError {
@@ -27583,6 +28244,17 @@ impl ::std::fmt::Display for TeamFolderUpdateSyncSettingsError {
     }
 }
 
+// union extends BaseTeamFolderError
+impl From<BaseTeamFolderError> for TeamFolderUpdateSyncSettingsError {
+    fn from(parent: BaseTeamFolderError) -> Self {
+        match parent {
+            BaseTeamFolderError::AccessError(x) => TeamFolderUpdateSyncSettingsError::AccessError(x),
+            BaseTeamFolderError::StatusError(x) => TeamFolderUpdateSyncSettingsError::StatusError(x),
+            BaseTeamFolderError::TeamSharedDropboxError(x) => TeamFolderUpdateSyncSettingsError::TeamSharedDropboxError(x),
+            BaseTeamFolderError::Other => TeamFolderUpdateSyncSettingsError::Other,
+        }
+    }
+}
 #[derive(Debug, Clone, PartialEq, Eq)]
 #[non_exhaustive] // structs may have more fields added in the future.
 pub struct TeamGetInfoResult {
@@ -28441,6 +29113,28 @@ impl ::serde::ser::Serialize for TeamMemberProfile {
     }
 }
 
+// struct extends MemberProfile
+impl From<TeamMemberProfile> for MemberProfile {
+    fn from(subtype: TeamMemberProfile) -> Self {
+        Self {
+            team_member_id: subtype.team_member_id,
+            email: subtype.email,
+            email_verified: subtype.email_verified,
+            status: subtype.status,
+            name: subtype.name,
+            membership_type: subtype.membership_type,
+            external_id: subtype.external_id,
+            account_id: subtype.account_id,
+            secondary_emails: subtype.secondary_emails,
+            invited_on: subtype.invited_on,
+            joined_on: subtype.joined_on,
+            suspended_on: subtype.suspended_on,
+            persistent_id: subtype.persistent_id,
+            is_directory_restricted: subtype.is_directory_restricted,
+            profile_photo_url: subtype.profile_photo_url,
+        }
+    }
+}
 /// A role which can be attached to a team member. This replaces AdminTier; each AdminTier
 /// corresponds to a new TeamMemberRole with a matching name.
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -28962,6 +29656,15 @@ impl ::std::fmt::Display for TeamNamespacesListContinueError {
     }
 }
 
+// union extends TeamNamespacesListError
+impl From<TeamNamespacesListError> for TeamNamespacesListContinueError {
+    fn from(parent: TeamNamespacesListError) -> Self {
+        match parent {
+            TeamNamespacesListError::InvalidArg => TeamNamespacesListContinueError::InvalidArg,
+            TeamNamespacesListError::Other => TeamNamespacesListContinueError::Other,
+        }
+    }
+}
 #[derive(Debug, Clone, PartialEq, Eq)]
 #[non_exhaustive] // variants may be added in the future
 pub enum TeamNamespacesListError {

--- a/src/generated/users.rs
+++ b/src/generated/users.rs
@@ -458,6 +458,19 @@ impl ::serde::ser::Serialize for BasicAccount {
     }
 }
 
+// struct extends Account
+impl From<BasicAccount> for Account {
+    fn from(subtype: BasicAccount) -> Self {
+        Self {
+            account_id: subtype.account_id,
+            name: subtype.name,
+            email: subtype.email,
+            email_verified: subtype.email_verified,
+            disabled: subtype.disabled,
+            profile_photo_url: subtype.profile_photo_url,
+        }
+    }
+}
 /// The value for [`UserFeature::FileLocking`](UserFeature::FileLocking).
 #[derive(Debug, Clone, PartialEq, Eq)]
 #[non_exhaustive] // variants may be added in the future
@@ -827,6 +840,19 @@ impl ::serde::ser::Serialize for FullAccount {
     }
 }
 
+// struct extends Account
+impl From<FullAccount> for Account {
+    fn from(subtype: FullAccount) -> Self {
+        Self {
+            account_id: subtype.account_id,
+            name: subtype.name,
+            email: subtype.email,
+            email_verified: subtype.email_verified,
+            disabled: subtype.disabled,
+            profile_photo_url: subtype.profile_photo_url,
+        }
+    }
+}
 /// Detailed information about a team.
 #[derive(Debug, Clone, PartialEq, Eq)]
 #[non_exhaustive] // structs may have more fields added in the future.
@@ -963,6 +989,15 @@ impl ::serde::ser::Serialize for FullTeam {
     }
 }
 
+// struct extends Team
+impl From<FullTeam> for Team {
+    fn from(subtype: FullTeam) -> Self {
+        Self {
+            id: subtype.id,
+            name: subtype.name,
+        }
+    }
+}
 #[derive(Debug, Clone, PartialEq, Eq)]
 #[non_exhaustive] // structs may have more fields added in the future.
 pub struct GetAccountArg {


### PR DESCRIPTION
Fixes #128.

For structs, `extends` means the subtype adds additional fields, so we can implement `From` to upcast from the subtype to the supertype.

For unions, `extends` means the subtype adds additional variants, so we can implement `From` to downcast from the supertype to the subtype.

For polymorphic structs, `extends` is for the inner data type of variants, so we can implement `From` on the subtype to return the correct variant of the parent type.

This solves some common problems, such as `files::UploadArg` which extends `files::CommitInfo`: they have nearly the same fields and are used together usually, so being able to convert from one to the other is useful.

<!--
Thank you for your pull request. Please provide a description below.
-->

## **Checklist**

**General Contributing**
<!-- Change [ ] to [x] if you have: -->
- [x] I have read the Code of Conduct and signed the [CLA](https://opensource.dropbox.com/cla/).
- [x] I have added an entry to the `RELEASE_NOTES.md` file, or believe it's not necessary for this change.

**Validation**
<!-- Describe which tests cover the changes you've made, and any additional manual validation you
     did to ensure the correctness of this change. Does this change warrant addition of new tests?
     Does this change have performance implications? Etc. -->
No tests for this specifically. Just having it compile is good enough for this IMO.