### PR TITLE
generated tests: emit assertions for implicit default values

### DIFF
--- a/generator/test.stoneg.py
+++ b/generator/test.stoneg.py
@@ -62,9 +62,6 @@ class TestBackend(RustHelperBackend):
             for variant in typ.all_fields:
                 vals.append(TestUnion(
                     self, typ, self.reference_impls, variant, no_optional_fields=False))
-                if ir.is_struct_type(variant.data_type) and variant.data_type.all_optional_fields:
-                    vals.append(TestUnion(
-                        self, typ, self.reference_impls, variant, no_optional_fields=True))
         else:
             raise RuntimeError(f'ERROR: type {typ} is neither struct nor union')
         return vals

--- a/generator/test.stoneg.py
+++ b/generator/test.stoneg.py
@@ -424,12 +424,8 @@ class TestUnion(TestValue):
             elif codegen.is_nullary_struct(self._variant.data_type):
                 codegen.emit(f'{path}(..) => (), // nullary struct')
             else:
-                if self._no_optional_fields and ir.is_struct_type(self._variant.data_type) \
-                        and not deep_any_required_fields(self._variant.data_type):
-                    codegen.emit(f'{path}(_) => (), // all fields optional')
-                else:
-                    with codegen.block(f'{path}(ref v) =>'):
-                        self._inner_value.emit_assert(codegen, '(*v)')
+                with codegen.block(f'{path}(ref v) =>'):
+                    self._inner_value.emit_assert(codegen, '(*v)')
 
             if self.has_other_variants():
                 codegen.emit('_ => panic!("wrong variant")')
@@ -442,18 +438,6 @@ class TestUnion(TestValue):
         if self._no_optional_fields:
             suf += "_OnlyRequiredFields"
         return suf
-
-
-# Does this struct type have any required fields, and if any of those are structs, do they have
-# any required fields, and so on. Basically, is this type able to be represented by '{}' in json?
-def deep_any_required_fields(typ):
-    for f in typ.all_required_fields:
-        if ir.is_struct_type(f.data_type):
-            if deep_any_required_fields(f.data_type):
-                return True
-        else:
-            return True
-    return False
 
 
 class TestPolymorphicStruct(TestUnion):


### PR DESCRIPTION
When generating the OnlyRequiredFields tests, we need to check that the implicit defaults (the omitted fields in the JSON) were deserialized to the expected value, whether None or an other specified default value.

This means we have to still generate TestField instances for these fields, since that's what's responsible for emitting the assertions.

<!--
Thank you for your pull request. Please provide a description below.
-->

## **Checklist**

**General Contributing**
<!-- Change [ ] to [x] if you have: -->
- [x] I have read the Code of Conduct and signed the [CLA](https://opensource.dropbox.com/cla/).
- [x] I have added an entry to the `RELEASE_NOTES.md` file, or believe it's not necessary for this change.

**Validation**
<!-- Describe which tests cover the changes you've made, and any additional manual validation you
     did to ensure the correctness of this change. Does this change warrant addition of new tests?
     Does this change have performance implications? Etc. -->
This is an improvement to the tests.