### PR TITLE
replace deprecated NaiveDateTime::from_timestamp_opt

### DIFF
--- a/examples/large-file-upload.rs
+++ b/examples/large-file-upload.rs
@@ -459,7 +459,7 @@ fn iso8601(t: SystemTime) -> String {
         Err(e) => -(e.duration().as_secs() as i64),
     };
 
-    chrono::NaiveDateTime::from_timestamp_opt(timestamp, 0 /* nsecs */)
+    chrono::DateTime::from_timestamp(timestamp, 0 /* nsecs */)
         .expect("invalid or out-of-range timestamp")
         .format("%Y-%m-%dT%H:%M:%SZ").to_string()
 }


### PR DESCRIPTION
Replace it with `DateTime::from_timestamp`.

<!--
Thank you for your pull request. Please provide a description below.
-->

## **Checklist**

**General Contributing**
<!-- Change [ ] to [x] if you have: -->
- [x] I have read the Code of Conduct and signed the [CLA](https://opensource.dropbox.com/cla/).
- [x] I have added an entry to the `RELEASE_NOTES.md` file, or believe it's not necessary for this change.

**Validation**
<!-- Describe which tests cover the changes you've made, and any additional manual validation you
     did to ensure the correctness of this change. Does this change warrant addition of new tests?
     Does this change have performance implications? Etc. -->
it builds, clippy no longer complains