### PR TITLE
make Authorization::client_id public

### DIFF
--- a/src/oauth2.rs
+++ b/src/oauth2.rs
@@ -304,7 +304,8 @@ enum AuthorizationState {
 /// Provides for continuing authorization of the app.
 #[derive(Debug, Clone)]
 pub struct Authorization {
-    client_id: String,
+    /// Dropbox app key
+    pub client_id: String,
     state: AuthorizationState,
 }
 


### PR DESCRIPTION
It's useful if you're using oauth2::get_auth_from_env_or_prompt where there isn't otherwise a way to get the client ID the user entered.