### PR TITLE
make pkcecode string pub to support serialization

### DIFF
--- a/src/oauth2.rs
+++ b/src/oauth2.rs
@@ -94,7 +94,7 @@ impl TokenType {
 /// A proof key for OAuth2 PKCE ("Proof Key for Code Exchange") flow.
 #[derive(Debug, Clone)]
 pub struct PkceCode {
-    code: String,
+    pub code: String,
 }
 
 impl PkceCode {


### PR DESCRIPTION
The purpose of this change is to support the following scenario:
I am writing an app to be as scriptable (non-directly-interactive) as possible. When doing the PKCE auth procedure, it outputs the auth URL and terminates. The user can go to the URL, get the password, and invoke my app again later with this information to finish the procedure.
However, this requires that my app save the PKCE code somewhere between invocations. It's just a string so it's easy to store. The problem is, dropbox-sdk has chosen to wrap it in a single field struct where the code is private, there aren't any setters or getters, and it can't be constructed with a provided value, so I can't get the code out (or back in) by any safe means. Therefore my app currently uses unsafe rust (transmute) to make the code accessible so it can work in this way.
If the field was pub then this scenario would be much more straightforward.

Please let me know if I am off base and should be doing this a different way altogether.

## **Checklist**

**General Contributing**
<!-- Change [ ] to [x] if you have: -->
- [x] I have read the Code of Conduct and signed the [CLA](https://opensource.dropbox.com/cla/).
- [x] I have added an entry to the `RELEASE_NOTES.md` file, or believe it's not necessary for this change.

**Validation**
<!-- Describe which tests cover the changes you've made, and any additional manual validation you
     did to ensure the correctness of this change. Does this change warrant addition of new tests?
     Does this change have performance implications? Etc. -->
This change doesn't add any new functionality