### PR TITLE
rename sync_routes_default feature to sync_routes_in_root and improve docs around that

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -96,7 +96,7 @@ dbx_users = ["dbx_common", "dbx_team_common", "dbx_team_policies", "dbx_users_co
 dbx_users_common = ["dbx_common"]
 
 default_async_client = ["async_routes", "dep:reqwest"]
-default_client = ["sync_routes", "sync_routes_default", "dep:ureq"]
+default_client = ["sync_routes", "sync_routes_in_root", "dep:ureq"]
 
 # Enable unstable ("preview") API routes.
 unstable = []
@@ -109,7 +109,7 @@ async_routes = []
 
 # Re-export the sync routes as `dropbox_sdk::{namsepace}` directly (matches pre-v0.19 structure).
 # If disabled, export the async routes there instead.
-sync_routes_default = ["sync_routes"]
+sync_routes_in_root = ["sync_routes"]
 
 # Include all namespaces by default.
 # Enable sync default client, sync routes, and make the sync routes default, to match pre-v0.19.
@@ -136,7 +136,7 @@ default = [
     "dbx_users_common",
     "default_client",
     "sync_routes",
-    "sync_routes_default",
+    "sync_routes_in_root",
     ]
 
 [package.metadata.docs.rs]

--- a/generator/rust.stoneg.py
+++ b/generator/rust.stoneg.py
@@ -57,15 +57,9 @@ class RustBackend(RustHelperBackend):
             self.emit()
             with self.block('if_feature! { "async_routes",', delim=(None, '}')):
                 self.emit('pub mod async_routes;')
-                with self.block('if_feature! { not "sync_routes_default",', delim=(None, '}')):
-                    self.emit('#[allow(unused_imports)]')
-                    self.emit(f'pub use crate::generated::async_routes::*;')
             self.emit()
             with self.block('if_feature! { "sync_routes",', delim=(None, '}')):
                 self.emit('pub mod sync_routes;')
-                with self.block('if_feature! { "sync_routes_default",', delim=(None, '}')):
-                    self.emit('#[allow(unused_imports)]')
-                    self.emit(f'pub use crate::generated::sync_routes::*;')
             self.emit()
             with self.block('pub(crate) fn eat_json_fields<\'de, V>(map: &mut V)'
                             ' -> Result<(), V::Error>'

--- a/src/generated/mod.rs
+++ b/src/generated/mod.rs
@@ -12,18 +12,10 @@ pub mod types;
 
 if_feature! { "async_routes",
     pub mod async_routes;
-    if_feature! { not "sync_routes_default",
-        #[allow(unused_imports)]
-        pub use crate::generated::async_routes::*;
-    }
 }
 
 if_feature! { "sync_routes",
     pub mod sync_routes;
-    if_feature! { "sync_routes_default",
-        #[allow(unused_imports)]
-        pub use crate::generated::sync_routes::*;
-    }
 }
 
 pub(crate) fn eat_json_fields<'de, V>(map: &mut V) -> Result<(), V::Error> where V: ::serde::de::MapAccess<'de> {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -36,7 +36,7 @@ if_feature! { "default_client",
     pub mod default_client;
 
     // for backwards-compat only; don't match this for async
-    if_feature! { "sync_routes_default",
+    if_feature! { "sync_routes_in_root",
         pub use client_trait::*;
     }
 }
@@ -60,6 +60,14 @@ mod generated;
 
 // You need to run the Stone generator to create this module.
 pub use generated::*;
+
+#[cfg(feature = "async_routes")]
+#[cfg(not(feature = "sync_routes_in_root"))]
+pub use generated::async_routes::*;
+
+#[cfg(feature = "sync_routes")]
+#[cfg(feature = "sync_routes_in_root")]
+pub use generated::sync_routes::*;
 
 mod error;
 pub use error::{BoxedError, Error, NoError};

--- a/src/oauth2.rs
+++ b/src/oauth2.rs
@@ -423,7 +423,7 @@ impl Authorization {
         }
     }
 
-    if_feature! { "sync_routes_default",
+    if_feature! { "sync_routes",
         /// Compatibility shim for working with sync HTTP clients.
         pub fn obtain_access_token(
             &mut self,


### PR DESCRIPTION
In particular, don't show that feature on docs.rs, it clutters it too much.

This doesn't affect what gets reexported where, just how it looks in docs.

## **Checklist**

**General Contributing**
<!-- Change [ ] to [x] if you have: -->
- [x] I have read the Code of Conduct and signed the [CLA](https://opensource.dropbox.com/cla/).
- [x] I have added an entry to the `RELEASE_NOTES.md` file, or believe it's not necessary for this change.

**Validation**
<!-- Describe which tests cover the changes you've made, and any additional manual validation you
     did to ensure the correctness of this change. Does this change warrant addition of new tests?
     Does this change have performance implications? Etc. -->
`cargo +nightly rustdoc --all-features -- --cfg docsrs`