### PR TITLE
remove redundant intra-doc link targets from generated doc comments

### DIFF
--- a/generator/rust.stoneg.py
+++ b/generator/rust.stoneg.py
@@ -868,7 +868,7 @@ class RustBackend(RustHelperBackend):
                         field = self.field_name_raw(field)
                         return f'`{field}`'
                     field = self.enum_variant_name_raw(field)
-                    return f'[`{type_name}::{field}`]({type_name}::{field})'
+                    return f'[`{type_name}::{field}`]'
                 else:
                     field = self.field_name_raw(field)
                     # we can't link to the field itself, so just link to the struct
@@ -894,7 +894,7 @@ class RustBackend(RustHelperBackend):
             else:
                 typ = self._all_types[self._current_namespace][val]
                 rust_name = self._rust_type(typ)
-                return f'[`{rust_name}`]({rust_name})'
+                return f'[`{rust_name}`]'
         elif tag == 'link':
             title, url = val.rsplit(' ', 1)
             return f'[{title}]({url})'

--- a/src/generated/async_routes/files.rs
+++ b/src/generated/async_routes/files.rs
@@ -251,9 +251,8 @@ pub fn create_folder_batch_check<'a>(
 
 /// Delete the file or folder at a given path. If the path is a folder, all its contents will be
 /// deleted too. A successful response indicates that the file or folder was deleted. The returned
-/// metadata will be the corresponding [`FileMetadata`](FileMetadata) or
-/// [`FolderMetadata`](FolderMetadata) for the item at time of deletion, and not a
-/// [`DeletedMetadata`](DeletedMetadata) object.
+/// metadata will be the corresponding [`FileMetadata`] or [`FolderMetadata`] for the item at time
+/// of deletion, and not a [`DeletedMetadata`] object.
 pub fn delete_v2<'a>(
     client: &'a impl crate::async_client_trait::UserAuthClient,
     arg: &'a DeleteArg,
@@ -269,9 +268,8 @@ pub fn delete_v2<'a>(
 
 /// Delete the file or folder at a given path. If the path is a folder, all its contents will be
 /// deleted too. A successful response indicates that the file or folder was deleted. The returned
-/// metadata will be the corresponding [`FileMetadata`](FileMetadata) or
-/// [`FolderMetadata`](FolderMetadata) for the item at time of deletion, and not a
-/// [`DeletedMetadata`](DeletedMetadata) object.
+/// metadata will be the corresponding [`FileMetadata`] or [`FolderMetadata`] for the item at time
+/// of deletion, and not a [`DeletedMetadata`] object.
 #[deprecated(note = "replaced by delete_v2")]
 pub fn delete<'a>(
     client: &'a impl crate::async_client_trait::UserAuthClient,
@@ -451,14 +449,13 @@ pub fn get_temporary_link<'a>(
 ///
 /// This endpoint acts as a delayed [`upload()`](crate::files::upload). The returned temporary
 /// upload link may be used to make a POST request with the data to be uploaded. The upload will
-/// then be perfomed with the [`CommitInfo`](CommitInfo) previously provided to
+/// then be perfomed with the [`CommitInfo`] previously provided to
 /// [`get_temporary_upload_link()`](crate::files::get_temporary_upload_link) but evaluated only upon
-/// consumption. Hence, errors stemming from invalid [`CommitInfo`](CommitInfo) with respect to the
-/// state of the user's Dropbox will only be communicated at consumption time. Additionally, these
-/// errors are surfaced as generic HTTP 409 Conflict responses, potentially hiding issue details.
-/// The maximum temporary upload link duration is 4 hours. Upon consumption or expiration, a new
-/// link will have to be generated. Multiple links may exist for a specific upload path at any given
-/// time.
+/// consumption. Hence, errors stemming from invalid [`CommitInfo`] with respect to the state of the
+/// user's Dropbox will only be communicated at consumption time. Additionally, these errors are
+/// surfaced as generic HTTP 409 Conflict responses, potentially hiding issue details. The maximum
+/// temporary upload link duration is 4 hours. Upon consumption or expiration, a new link will have
+/// to be generated. Multiple links may exist for a specific upload path at any given time.
 ///
 /// The POST request on the temporary upload link must have its Content-Type set to
 /// "application/octet-stream".
@@ -579,17 +576,17 @@ pub fn get_thumbnail_batch<'a>(
 /// [`ListFolderResult::cursor`](ListFolderResult) to retrieve more entries. If you're using
 /// [`ListFolderArg::recursive`](ListFolderArg) set to `true` to keep a local cache of the contents
 /// of a Dropbox account, iterate through each entry in order and process them as follows to keep
-/// your local state in sync: For each [`FileMetadata`](FileMetadata), store the new entry at the
-/// given path in your local state. If the required parent folders don't exist yet, create them. If
-/// there's already something else at the given path, replace it and remove all its children. For
-/// each [`FolderMetadata`](FolderMetadata), store the new entry at the given path in your local
-/// state. If the required parent folders don't exist yet, create them. If there's already something
-/// else at the given path, replace it but leave the children as they are. Check the new entry's
+/// your local state in sync: For each [`FileMetadata`], store the new entry at the given path in
+/// your local state. If the required parent folders don't exist yet, create them. If there's
+/// already something else at the given path, replace it and remove all its children. For each
+/// [`FolderMetadata`], store the new entry at the given path in your local state. If the required
+/// parent folders don't exist yet, create them. If there's already something else at the given
+/// path, replace it but leave the children as they are. Check the new entry's
 /// [`FolderSharingInfo::read_only`](FolderSharingInfo) and set all its children's read-only
-/// statuses to match. For each [`DeletedMetadata`](DeletedMetadata), if your local state has
-/// something at the given path, remove it and all its children. If there's nothing at the given
-/// path, ignore this entry. Note: [`auth::RateLimitError`](crate::types::auth::RateLimitError) may
-/// be returned if multiple [`list_folder()`](crate::files::list_folder) or
+/// statuses to match. For each [`DeletedMetadata`], if your local state has something at the given
+/// path, remove it and all its children. If there's nothing at the given path, ignore this entry.
+/// Note: [`auth::RateLimitError`](crate::types::auth::RateLimitError) may be returned if multiple
+/// [`list_folder()`](crate::files::list_folder) or
 /// [`list_folder_continue()`](crate::files::list_folder_continue) calls with same parameters are
 /// made simultaneously by same API app for same user. If your app implements retry logic, please
 /// hold off the retry until the previous request finishes.
@@ -612,17 +609,17 @@ pub fn list_folder<'a>(
 /// [`ListFolderResult::cursor`](ListFolderResult) to retrieve more entries. If you're using
 /// [`ListFolderArg::recursive`](ListFolderArg) set to `true` to keep a local cache of the contents
 /// of a Dropbox account, iterate through each entry in order and process them as follows to keep
-/// your local state in sync: For each [`FileMetadata`](FileMetadata), store the new entry at the
-/// given path in your local state. If the required parent folders don't exist yet, create them. If
-/// there's already something else at the given path, replace it and remove all its children. For
-/// each [`FolderMetadata`](FolderMetadata), store the new entry at the given path in your local
-/// state. If the required parent folders don't exist yet, create them. If there's already something
-/// else at the given path, replace it but leave the children as they are. Check the new entry's
+/// your local state in sync: For each [`FileMetadata`], store the new entry at the given path in
+/// your local state. If the required parent folders don't exist yet, create them. If there's
+/// already something else at the given path, replace it and remove all its children. For each
+/// [`FolderMetadata`], store the new entry at the given path in your local state. If the required
+/// parent folders don't exist yet, create them. If there's already something else at the given
+/// path, replace it but leave the children as they are. Check the new entry's
 /// [`FolderSharingInfo::read_only`](FolderSharingInfo) and set all its children's read-only
-/// statuses to match. For each [`DeletedMetadata`](DeletedMetadata), if your local state has
-/// something at the given path, remove it and all its children. If there's nothing at the given
-/// path, ignore this entry. Note: [`auth::RateLimitError`](crate::types::auth::RateLimitError) may
-/// be returned if multiple [`list_folder()`](crate::files::list_folder) or
+/// statuses to match. For each [`DeletedMetadata`], if your local state has something at the given
+/// path, remove it and all its children. If there's nothing at the given path, ignore this entry.
+/// Note: [`auth::RateLimitError`](crate::types::auth::RateLimitError) may be returned if multiple
+/// [`list_folder()`](crate::files::list_folder) or
 /// [`list_folder_continue()`](crate::files::list_folder_continue) calls with same parameters are
 /// made simultaneously by same API app for same user. If your app implements retry logic, please
 /// hold off the retry until the previous request finishes.
@@ -711,11 +708,10 @@ pub fn list_folder_longpoll<'a>(
 /// Returns revisions for files based on a file path or a file id. The file path or file id is
 /// identified from the latest file entry at the given file path or id. This end point allows your
 /// app to query either by file path or file id by setting the mode parameter appropriately. In the
-/// [`ListRevisionsMode::Path`](ListRevisionsMode::Path) (default) mode, all revisions at the same
-/// file path as the latest file entry are returned. If revisions with the same file id are desired,
-/// then mode must be set to [`ListRevisionsMode::Id`](ListRevisionsMode::Id). The
-/// [`ListRevisionsMode::Id`](ListRevisionsMode::Id) mode is useful to retrieve revisions for a
-/// given file across moves or renames.
+/// [`ListRevisionsMode::Path`] (default) mode, all revisions at the same file path as the latest
+/// file entry are returned. If revisions with the same file id are desired, then mode must be set
+/// to [`ListRevisionsMode::Id`]. The [`ListRevisionsMode::Id`] mode is useful to retrieve revisions
+/// for a given file across moves or renames.
 pub fn list_revisions<'a>(
     client: &'a impl crate::async_client_trait::UserAuthClient,
     arg: &'a ListRevisionsArg,
@@ -1326,23 +1322,20 @@ pub fn upload_session_finish_batch_check<'a>(
 /// [`UploadSessionStartResult::session_id`](UploadSessionStartResult) with
 /// [`upload_session_append_v2()`](crate::files::upload_session_append_v2) or
 /// [`upload_session_finish()`](crate::files::upload_session_finish) more than 7 days after its
-/// creation will return a
-/// [`UploadSessionLookupError::NotFound`](UploadSessionLookupError::NotFound). Calls to this
-/// endpoint will count as data transport calls for any Dropbox Business teams with a limit on the
-/// number of data transport calls allowed per month. For more information, see the [Data transport
-/// limit page](https://www.dropbox.com/developers/reference/data-transport-limit). By default,
-/// upload sessions require you to send content of the file in sequential order via consecutive
+/// creation will return a [`UploadSessionLookupError::NotFound`]. Calls to this endpoint will count
+/// as data transport calls for any Dropbox Business teams with a limit on the number of data
+/// transport calls allowed per month. For more information, see the [Data transport limit
+/// page](https://www.dropbox.com/developers/reference/data-transport-limit). By default, upload
+/// sessions require you to send content of the file in sequential order via consecutive
 /// [`upload_session_start()`](crate::files::upload_session_start),
 /// [`upload_session_append_v2()`](crate::files::upload_session_append_v2),
 /// [`upload_session_finish()`](crate::files::upload_session_finish) calls. For better performance,
-/// you can instead optionally use a
-/// [`UploadSessionType::Concurrent`](UploadSessionType::Concurrent) upload session. To start a new
-/// concurrent session, set [`UploadSessionStartArg::session_type`](UploadSessionStartArg) to
-/// [`UploadSessionType::Concurrent`](UploadSessionType::Concurrent). After that, you can send file
-/// data in concurrent [`upload_session_append_v2()`](crate::files::upload_session_append_v2)
-/// requests. Finally finish the session with
-/// [`upload_session_finish()`](crate::files::upload_session_finish). There are couple of
-/// constraints with concurrent sessions to make them work. You can not send data with
+/// you can instead optionally use a [`UploadSessionType::Concurrent`] upload session. To start a
+/// new concurrent session, set [`UploadSessionStartArg::session_type`](UploadSessionStartArg) to
+/// [`UploadSessionType::Concurrent`]. After that, you can send file data in concurrent
+/// [`upload_session_append_v2()`](crate::files::upload_session_append_v2) requests. Finally finish
+/// the session with [`upload_session_finish()`](crate::files::upload_session_finish). There are
+/// couple of constraints with concurrent sessions to make them work. You can not send data with
 /// [`upload_session_start()`](crate::files::upload_session_start) or
 /// [`upload_session_finish()`](crate::files::upload_session_finish) call, only with
 /// [`upload_session_append_v2()`](crate::files::upload_session_append_v2) call. Also data uploaded

--- a/src/generated/async_routes/sharing.rs
+++ b/src/generated/async_routes/sharing.rs
@@ -103,8 +103,8 @@ pub fn create_shared_link<'a>(
 }
 
 /// Create a shared link with custom settings. If no settings are given then the default visibility
-/// is [`RequestedVisibility::Public`](RequestedVisibility::Public) (The resolved visibility,
-/// though, may depend on other aspects such as team and shared folder settings).
+/// is [`RequestedVisibility::Public`] (The resolved visibility, though, may depend on other aspects
+/// such as team and shared folder settings).
 pub fn create_shared_link_with_settings<'a>(
     client: &'a impl crate::async_client_trait::UserAuthClient,
     arg: &'a CreateSharedLinkWithSettingsArg,
@@ -206,11 +206,10 @@ pub fn get_shared_link_metadata_app_auth<'a>(
         None)
 }
 
-/// Returns a list of [`LinkMetadata`](LinkMetadata) objects for this user, including collection
-/// links. If no path is given, returns a list of all shared links for the current user, including
-/// collection links, up to a maximum of 1000 links. If a non-empty path is given, returns a list of
-/// all shared links that allow access to the given path.  Collection links are never returned in
-/// this case.
+/// Returns a list of [`LinkMetadata`] objects for this user, including collection links. If no path
+/// is given, returns a list of all shared links for the current user, including collection links,
+/// up to a maximum of 1000 links. If a non-empty path is given, returns a list of all shared links
+/// that allow access to the given path.  Collection links are never returned in this case.
 #[deprecated(note = "replaced by list_shared_links")]
 pub fn get_shared_links<'a>(
     client: &'a impl crate::async_client_trait::UserAuthClient,
@@ -420,8 +419,8 @@ pub fn list_shared_links<'a>(
 /// Modify the shared link's settings. If the requested visibility conflict with the shared links
 /// policy of the team or the shared folder (in case the linked file is part of a shared folder)
 /// then the [`LinkPermissions::resolved_visibility`](LinkPermissions) of the returned
-/// [`SharedLinkMetadata`](SharedLinkMetadata) will reflect the actual visibility of the shared link
-/// and the [`LinkPermissions::requested_visibility`](LinkPermissions) will reflect the requested
+/// [`SharedLinkMetadata`] will reflect the actual visibility of the shared link and the
+/// [`LinkPermissions::requested_visibility`](LinkPermissions) will reflect the requested
 /// visibility.
 pub fn modify_shared_link_settings<'a>(
     client: &'a impl crate::async_client_trait::UserAuthClient,
@@ -546,8 +545,7 @@ pub fn revoke_shared_link<'a>(
 }
 
 /// Change the inheritance policy of an existing Shared Folder. Only permitted for shared folders in
-/// a shared team root. If a [`ShareFolderLaunch::AsyncJobId`](ShareFolderLaunch::AsyncJobId) is
-/// returned, you'll need to call
+/// a shared team root. If a [`ShareFolderLaunch::AsyncJobId`] is returned, you'll need to call
 /// [`check_share_job_status()`](crate::sharing::check_share_job_status) until the action completes
 /// to get the metadata for the folder.
 pub fn set_access_inheritance<'a>(
@@ -565,8 +563,7 @@ pub fn set_access_inheritance<'a>(
 
 /// Share a folder with collaborators. Most sharing will be completed synchronously. Large folders
 /// will be completed asynchronously. To make testing the async case repeatable, set
-/// `ShareFolderArg.force_async`. If a
-/// [`ShareFolderLaunch::AsyncJobId`](ShareFolderLaunch::AsyncJobId) is returned, you'll need to
+/// `ShareFolderArg.force_async`. If a [`ShareFolderLaunch::AsyncJobId`] is returned, you'll need to
 /// call [`check_share_job_status()`](crate::sharing::check_share_job_status) until the action
 /// completes to get the metadata for the folder.
 pub fn share_folder<'a>(
@@ -583,7 +580,7 @@ pub fn share_folder<'a>(
 }
 
 /// Transfer ownership of a shared folder to a member of the shared folder. User must have
-/// [`AccessLevel::Owner`](AccessLevel::Owner) access to the shared folder to perform a transfer.
+/// [`AccessLevel::Owner`] access to the shared folder to perform a transfer.
 pub fn transfer_folder<'a>(
     client: &'a impl crate::async_client_trait::UserAuthClient,
     arg: &'a TransferFolderArg,
@@ -670,8 +667,8 @@ pub fn update_folder_member<'a>(
         None)
 }
 
-/// Update the sharing policies for a shared folder. User must have
-/// [`AccessLevel::Owner`](AccessLevel::Owner) access to the shared folder to update its policies.
+/// Update the sharing policies for a shared folder. User must have [`AccessLevel::Owner`] access to
+/// the shared folder to update its policies.
 pub fn update_folder_policy<'a>(
     client: &'a impl crate::async_client_trait::UserAuthClient,
     arg: &'a UpdateFolderPolicyArg,

--- a/src/generated/async_routes/team.rs
+++ b/src/generated/async_routes/team.rs
@@ -700,8 +700,8 @@ pub fn members_get_available_team_member_roles(
 }
 
 /// Returns information about multiple team members. Permission : Team information This endpoint
-/// will return [`MembersGetInfoItem::IdNotFound`](MembersGetInfoItem::IdNotFound), for IDs (or
-/// emails) that cannot be matched to a valid team member.
+/// will return [`MembersGetInfoItem::IdNotFound`], for IDs (or emails) that cannot be matched to a
+/// valid team member.
 pub fn members_get_info_v2<'a>(
     client: &'a impl crate::async_client_trait::TeamAuthClient,
     arg: &'a MembersGetInfoV2Arg,
@@ -716,8 +716,8 @@ pub fn members_get_info_v2<'a>(
 }
 
 /// Returns information about multiple team members. Permission : Team information This endpoint
-/// will return [`MembersGetInfoItem::IdNotFound`](MembersGetInfoItem::IdNotFound), for IDs (or
-/// emails) that cannot be matched to a valid team member.
+/// will return [`MembersGetInfoItem::IdNotFound`], for IDs (or emails) that cannot be matched to a
+/// valid team member.
 pub fn members_get_info<'a>(
     client: &'a impl crate::async_client_trait::TeamAuthClient,
     arg: &'a MembersGetInfoArgs,
@@ -842,10 +842,10 @@ pub fn members_recover<'a>(
 /// via [`members_recover()`](crate::team::members_recover) for a 7 day period or until the account
 /// has been permanently deleted or transferred to another account (whichever comes first). Calling
 /// [`members_add()`](crate::team::members_add) while a user is still recoverable on your team will
-/// return with [`MemberAddResult::UserAlreadyOnTeam`](MemberAddResult::UserAlreadyOnTeam). Accounts
-/// can have their files transferred via the admin console for a limited time, based on the version
-/// history length associated with the team (180 days for most teams). This endpoint may initiate an
-/// asynchronous job. To obtain the final result of the job, the client should periodically poll
+/// return with [`MemberAddResult::UserAlreadyOnTeam`]. Accounts can have their files transferred
+/// via the admin console for a limited time, based on the version history length associated with
+/// the team (180 days for most teams). This endpoint may initiate an asynchronous job. To obtain
+/// the final result of the job, the client should periodically poll
 /// [`members_remove_job_status_get()`](crate::team::members_remove_job_status_get).
 pub fn members_remove<'a>(
     client: &'a impl crate::async_client_trait::TeamAuthClient,

--- a/src/generated/sync_routes/files.rs
+++ b/src/generated/sync_routes/files.rs
@@ -279,9 +279,8 @@ pub fn create_folder_batch_check(
 
 /// Delete the file or folder at a given path. If the path is a folder, all its contents will be
 /// deleted too. A successful response indicates that the file or folder was deleted. The returned
-/// metadata will be the corresponding [`FileMetadata`](FileMetadata) or
-/// [`FolderMetadata`](FolderMetadata) for the item at time of deletion, and not a
-/// [`DeletedMetadata`](DeletedMetadata) object.
+/// metadata will be the corresponding [`FileMetadata`] or [`FolderMetadata`] for the item at time
+/// of deletion, and not a [`DeletedMetadata`] object.
 pub fn delete_v2(
     client: &impl crate::client_trait::UserAuthClient,
     arg: &DeleteArg,
@@ -299,9 +298,8 @@ pub fn delete_v2(
 
 /// Delete the file or folder at a given path. If the path is a folder, all its contents will be
 /// deleted too. A successful response indicates that the file or folder was deleted. The returned
-/// metadata will be the corresponding [`FileMetadata`](FileMetadata) or
-/// [`FolderMetadata`](FolderMetadata) for the item at time of deletion, and not a
-/// [`DeletedMetadata`](DeletedMetadata) object.
+/// metadata will be the corresponding [`FileMetadata`] or [`FolderMetadata`] for the item at time
+/// of deletion, and not a [`DeletedMetadata`] object.
 #[deprecated(note = "replaced by delete_v2")]
 pub fn delete(
     client: &impl crate::client_trait::UserAuthClient,
@@ -505,14 +503,13 @@ pub fn get_temporary_link(
 ///
 /// This endpoint acts as a delayed [`upload()`](crate::files::upload). The returned temporary
 /// upload link may be used to make a POST request with the data to be uploaded. The upload will
-/// then be perfomed with the [`CommitInfo`](CommitInfo) previously provided to
+/// then be perfomed with the [`CommitInfo`] previously provided to
 /// [`get_temporary_upload_link()`](crate::files::get_temporary_upload_link) but evaluated only upon
-/// consumption. Hence, errors stemming from invalid [`CommitInfo`](CommitInfo) with respect to the
-/// state of the user's Dropbox will only be communicated at consumption time. Additionally, these
-/// errors are surfaced as generic HTTP 409 Conflict responses, potentially hiding issue details.
-/// The maximum temporary upload link duration is 4 hours. Upon consumption or expiration, a new
-/// link will have to be generated. Multiple links may exist for a specific upload path at any given
-/// time.
+/// consumption. Hence, errors stemming from invalid [`CommitInfo`] with respect to the state of the
+/// user's Dropbox will only be communicated at consumption time. Additionally, these errors are
+/// surfaced as generic HTTP 409 Conflict responses, potentially hiding issue details. The maximum
+/// temporary upload link duration is 4 hours. Upon consumption or expiration, a new link will have
+/// to be generated. Multiple links may exist for a specific upload path at any given time.
 ///
 /// The POST request on the temporary upload link must have its Content-Type set to
 /// "application/octet-stream".
@@ -646,17 +643,17 @@ pub fn get_thumbnail_batch(
 /// [`ListFolderResult::cursor`](ListFolderResult) to retrieve more entries. If you're using
 /// [`ListFolderArg::recursive`](ListFolderArg) set to `true` to keep a local cache of the contents
 /// of a Dropbox account, iterate through each entry in order and process them as follows to keep
-/// your local state in sync: For each [`FileMetadata`](FileMetadata), store the new entry at the
-/// given path in your local state. If the required parent folders don't exist yet, create them. If
-/// there's already something else at the given path, replace it and remove all its children. For
-/// each [`FolderMetadata`](FolderMetadata), store the new entry at the given path in your local
-/// state. If the required parent folders don't exist yet, create them. If there's already something
-/// else at the given path, replace it but leave the children as they are. Check the new entry's
+/// your local state in sync: For each [`FileMetadata`], store the new entry at the given path in
+/// your local state. If the required parent folders don't exist yet, create them. If there's
+/// already something else at the given path, replace it and remove all its children. For each
+/// [`FolderMetadata`], store the new entry at the given path in your local state. If the required
+/// parent folders don't exist yet, create them. If there's already something else at the given
+/// path, replace it but leave the children as they are. Check the new entry's
 /// [`FolderSharingInfo::read_only`](FolderSharingInfo) and set all its children's read-only
-/// statuses to match. For each [`DeletedMetadata`](DeletedMetadata), if your local state has
-/// something at the given path, remove it and all its children. If there's nothing at the given
-/// path, ignore this entry. Note: [`auth::RateLimitError`](crate::types::auth::RateLimitError) may
-/// be returned if multiple [`list_folder()`](crate::files::list_folder) or
+/// statuses to match. For each [`DeletedMetadata`], if your local state has something at the given
+/// path, remove it and all its children. If there's nothing at the given path, ignore this entry.
+/// Note: [`auth::RateLimitError`](crate::types::auth::RateLimitError) may be returned if multiple
+/// [`list_folder()`](crate::files::list_folder) or
 /// [`list_folder_continue()`](crate::files::list_folder_continue) calls with same parameters are
 /// made simultaneously by same API app for same user. If your app implements retry logic, please
 /// hold off the retry until the previous request finishes.
@@ -681,17 +678,17 @@ pub fn list_folder(
 /// [`ListFolderResult::cursor`](ListFolderResult) to retrieve more entries. If you're using
 /// [`ListFolderArg::recursive`](ListFolderArg) set to `true` to keep a local cache of the contents
 /// of a Dropbox account, iterate through each entry in order and process them as follows to keep
-/// your local state in sync: For each [`FileMetadata`](FileMetadata), store the new entry at the
-/// given path in your local state. If the required parent folders don't exist yet, create them. If
-/// there's already something else at the given path, replace it and remove all its children. For
-/// each [`FolderMetadata`](FolderMetadata), store the new entry at the given path in your local
-/// state. If the required parent folders don't exist yet, create them. If there's already something
-/// else at the given path, replace it but leave the children as they are. Check the new entry's
+/// your local state in sync: For each [`FileMetadata`], store the new entry at the given path in
+/// your local state. If the required parent folders don't exist yet, create them. If there's
+/// already something else at the given path, replace it and remove all its children. For each
+/// [`FolderMetadata`], store the new entry at the given path in your local state. If the required
+/// parent folders don't exist yet, create them. If there's already something else at the given
+/// path, replace it but leave the children as they are. Check the new entry's
 /// [`FolderSharingInfo::read_only`](FolderSharingInfo) and set all its children's read-only
-/// statuses to match. For each [`DeletedMetadata`](DeletedMetadata), if your local state has
-/// something at the given path, remove it and all its children. If there's nothing at the given
-/// path, ignore this entry. Note: [`auth::RateLimitError`](crate::types::auth::RateLimitError) may
-/// be returned if multiple [`list_folder()`](crate::files::list_folder) or
+/// statuses to match. For each [`DeletedMetadata`], if your local state has something at the given
+/// path, remove it and all its children. If there's nothing at the given path, ignore this entry.
+/// Note: [`auth::RateLimitError`](crate::types::auth::RateLimitError) may be returned if multiple
+/// [`list_folder()`](crate::files::list_folder) or
 /// [`list_folder_continue()`](crate::files::list_folder_continue) calls with same parameters are
 /// made simultaneously by same API app for same user. If your app implements retry logic, please
 /// hold off the retry until the previous request finishes.
@@ -790,11 +787,10 @@ pub fn list_folder_longpoll(
 /// Returns revisions for files based on a file path or a file id. The file path or file id is
 /// identified from the latest file entry at the given file path or id. This end point allows your
 /// app to query either by file path or file id by setting the mode parameter appropriately. In the
-/// [`ListRevisionsMode::Path`](ListRevisionsMode::Path) (default) mode, all revisions at the same
-/// file path as the latest file entry are returned. If revisions with the same file id are desired,
-/// then mode must be set to [`ListRevisionsMode::Id`](ListRevisionsMode::Id). The
-/// [`ListRevisionsMode::Id`](ListRevisionsMode::Id) mode is useful to retrieve revisions for a
-/// given file across moves or renames.
+/// [`ListRevisionsMode::Path`] (default) mode, all revisions at the same file path as the latest
+/// file entry are returned. If revisions with the same file id are desired, then mode must be set
+/// to [`ListRevisionsMode::Id`]. The [`ListRevisionsMode::Id`] mode is useful to retrieve revisions
+/// for a given file across moves or renames.
 pub fn list_revisions(
     client: &impl crate::client_trait::UserAuthClient,
     arg: &ListRevisionsArg,
@@ -1473,23 +1469,20 @@ pub fn upload_session_finish_batch_check(
 /// [`UploadSessionStartResult::session_id`](UploadSessionStartResult) with
 /// [`upload_session_append_v2()`](crate::files::upload_session_append_v2) or
 /// [`upload_session_finish()`](crate::files::upload_session_finish) more than 7 days after its
-/// creation will return a
-/// [`UploadSessionLookupError::NotFound`](UploadSessionLookupError::NotFound). Calls to this
-/// endpoint will count as data transport calls for any Dropbox Business teams with a limit on the
-/// number of data transport calls allowed per month. For more information, see the [Data transport
-/// limit page](https://www.dropbox.com/developers/reference/data-transport-limit). By default,
-/// upload sessions require you to send content of the file in sequential order via consecutive
+/// creation will return a [`UploadSessionLookupError::NotFound`]. Calls to this endpoint will count
+/// as data transport calls for any Dropbox Business teams with a limit on the number of data
+/// transport calls allowed per month. For more information, see the [Data transport limit
+/// page](https://www.dropbox.com/developers/reference/data-transport-limit). By default, upload
+/// sessions require you to send content of the file in sequential order via consecutive
 /// [`upload_session_start()`](crate::files::upload_session_start),
 /// [`upload_session_append_v2()`](crate::files::upload_session_append_v2),
 /// [`upload_session_finish()`](crate::files::upload_session_finish) calls. For better performance,
-/// you can instead optionally use a
-/// [`UploadSessionType::Concurrent`](UploadSessionType::Concurrent) upload session. To start a new
-/// concurrent session, set [`UploadSessionStartArg::session_type`](UploadSessionStartArg) to
-/// [`UploadSessionType::Concurrent`](UploadSessionType::Concurrent). After that, you can send file
-/// data in concurrent [`upload_session_append_v2()`](crate::files::upload_session_append_v2)
-/// requests. Finally finish the session with
-/// [`upload_session_finish()`](crate::files::upload_session_finish). There are couple of
-/// constraints with concurrent sessions to make them work. You can not send data with
+/// you can instead optionally use a [`UploadSessionType::Concurrent`] upload session. To start a
+/// new concurrent session, set [`UploadSessionStartArg::session_type`](UploadSessionStartArg) to
+/// [`UploadSessionType::Concurrent`]. After that, you can send file data in concurrent
+/// [`upload_session_append_v2()`](crate::files::upload_session_append_v2) requests. Finally finish
+/// the session with [`upload_session_finish()`](crate::files::upload_session_finish). There are
+/// couple of constraints with concurrent sessions to make them work. You can not send data with
 /// [`upload_session_start()`](crate::files::upload_session_start) or
 /// [`upload_session_finish()`](crate::files::upload_session_finish) call, only with
 /// [`upload_session_append_v2()`](crate::files::upload_session_append_v2) call. Also data uploaded

--- a/src/generated/sync_routes/sharing.rs
+++ b/src/generated/sync_routes/sharing.rs
@@ -115,8 +115,8 @@ pub fn create_shared_link(
 }
 
 /// Create a shared link with custom settings. If no settings are given then the default visibility
-/// is [`RequestedVisibility::Public`](RequestedVisibility::Public) (The resolved visibility,
-/// though, may depend on other aspects such as team and shared folder settings).
+/// is [`RequestedVisibility::Public`] (The resolved visibility, though, may depend on other aspects
+/// such as team and shared folder settings).
 pub fn create_shared_link_with_settings(
     client: &impl crate::client_trait::UserAuthClient,
     arg: &CreateSharedLinkWithSettingsArg,
@@ -233,11 +233,10 @@ pub fn get_shared_link_metadata_app_auth(
     )
 }
 
-/// Returns a list of [`LinkMetadata`](LinkMetadata) objects for this user, including collection
-/// links. If no path is given, returns a list of all shared links for the current user, including
-/// collection links, up to a maximum of 1000 links. If a non-empty path is given, returns a list of
-/// all shared links that allow access to the given path.  Collection links are never returned in
-/// this case.
+/// Returns a list of [`LinkMetadata`] objects for this user, including collection links. If no path
+/// is given, returns a list of all shared links for the current user, including collection links,
+/// up to a maximum of 1000 links. If a non-empty path is given, returns a list of all shared links
+/// that allow access to the given path.  Collection links are never returned in this case.
 #[deprecated(note = "replaced by list_shared_links")]
 pub fn get_shared_links(
     client: &impl crate::client_trait::UserAuthClient,
@@ -473,8 +472,8 @@ pub fn list_shared_links(
 /// Modify the shared link's settings. If the requested visibility conflict with the shared links
 /// policy of the team or the shared folder (in case the linked file is part of a shared folder)
 /// then the [`LinkPermissions::resolved_visibility`](LinkPermissions) of the returned
-/// [`SharedLinkMetadata`](SharedLinkMetadata) will reflect the actual visibility of the shared link
-/// and the [`LinkPermissions::requested_visibility`](LinkPermissions) will reflect the requested
+/// [`SharedLinkMetadata`] will reflect the actual visibility of the shared link and the
+/// [`LinkPermissions::requested_visibility`](LinkPermissions) will reflect the requested
 /// visibility.
 pub fn modify_shared_link_settings(
     client: &impl crate::client_trait::UserAuthClient,
@@ -615,8 +614,7 @@ pub fn revoke_shared_link(
 }
 
 /// Change the inheritance policy of an existing Shared Folder. Only permitted for shared folders in
-/// a shared team root. If a [`ShareFolderLaunch::AsyncJobId`](ShareFolderLaunch::AsyncJobId) is
-/// returned, you'll need to call
+/// a shared team root. If a [`ShareFolderLaunch::AsyncJobId`] is returned, you'll need to call
 /// [`check_share_job_status()`](crate::sharing::check_share_job_status) until the action completes
 /// to get the metadata for the folder.
 pub fn set_access_inheritance(
@@ -636,8 +634,7 @@ pub fn set_access_inheritance(
 
 /// Share a folder with collaborators. Most sharing will be completed synchronously. Large folders
 /// will be completed asynchronously. To make testing the async case repeatable, set
-/// `ShareFolderArg.force_async`. If a
-/// [`ShareFolderLaunch::AsyncJobId`](ShareFolderLaunch::AsyncJobId) is returned, you'll need to
+/// `ShareFolderArg.force_async`. If a [`ShareFolderLaunch::AsyncJobId`] is returned, you'll need to
 /// call [`check_share_job_status()`](crate::sharing::check_share_job_status) until the action
 /// completes to get the metadata for the folder.
 pub fn share_folder(
@@ -656,7 +653,7 @@ pub fn share_folder(
 }
 
 /// Transfer ownership of a shared folder to a member of the shared folder. User must have
-/// [`AccessLevel::Owner`](AccessLevel::Owner) access to the shared folder to perform a transfer.
+/// [`AccessLevel::Owner`] access to the shared folder to perform a transfer.
 pub fn transfer_folder(
     client: &impl crate::client_trait::UserAuthClient,
     arg: &TransferFolderArg,
@@ -755,8 +752,8 @@ pub fn update_folder_member(
     )
 }
 
-/// Update the sharing policies for a shared folder. User must have
-/// [`AccessLevel::Owner`](AccessLevel::Owner) access to the shared folder to update its policies.
+/// Update the sharing policies for a shared folder. User must have [`AccessLevel::Owner`] access to
+/// the shared folder to update its policies.
 pub fn update_folder_policy(
     client: &impl crate::client_trait::UserAuthClient,
     arg: &UpdateFolderPolicyArg,

--- a/src/generated/sync_routes/team.rs
+++ b/src/generated/sync_routes/team.rs
@@ -790,8 +790,8 @@ pub fn members_get_available_team_member_roles(
 }
 
 /// Returns information about multiple team members. Permission : Team information This endpoint
-/// will return [`MembersGetInfoItem::IdNotFound`](MembersGetInfoItem::IdNotFound), for IDs (or
-/// emails) that cannot be matched to a valid team member.
+/// will return [`MembersGetInfoItem::IdNotFound`], for IDs (or emails) that cannot be matched to a
+/// valid team member.
 pub fn members_get_info_v2(
     client: &impl crate::client_trait::TeamAuthClient,
     arg: &MembersGetInfoV2Arg,
@@ -808,8 +808,8 @@ pub fn members_get_info_v2(
 }
 
 /// Returns information about multiple team members. Permission : Team information This endpoint
-/// will return [`MembersGetInfoItem::IdNotFound`](MembersGetInfoItem::IdNotFound), for IDs (or
-/// emails) that cannot be matched to a valid team member.
+/// will return [`MembersGetInfoItem::IdNotFound`], for IDs (or emails) that cannot be matched to a
+/// valid team member.
 pub fn members_get_info(
     client: &impl crate::client_trait::TeamAuthClient,
     arg: &MembersGetInfoArgs,
@@ -950,10 +950,10 @@ pub fn members_recover(
 /// via [`members_recover()`](crate::team::members_recover) for a 7 day period or until the account
 /// has been permanently deleted or transferred to another account (whichever comes first). Calling
 /// [`members_add()`](crate::team::members_add) while a user is still recoverable on your team will
-/// return with [`MemberAddResult::UserAlreadyOnTeam`](MemberAddResult::UserAlreadyOnTeam). Accounts
-/// can have their files transferred via the admin console for a limited time, based on the version
-/// history length associated with the team (180 days for most teams). This endpoint may initiate an
-/// asynchronous job. To obtain the final result of the job, the client should periodically poll
+/// return with [`MemberAddResult::UserAlreadyOnTeam`]. Accounts can have their files transferred
+/// via the admin console for a limited time, based on the version history length associated with
+/// the team (180 days for most teams). This endpoint may initiate an asynchronous job. To obtain
+/// the final result of the job, the client should periodically poll
 /// [`members_remove_job_status_get()`](crate::team::members_remove_job_status_get).
 pub fn members_remove(
     client: &impl crate::client_trait::TeamAuthClient,

--- a/src/generated/types/common.rs
+++ b/src/generated/types/common.rs
@@ -27,12 +27,10 @@ pub enum PathRoot {
     /// belongs to a team.
     Home,
     /// Paths are relative to the authenticating user's root namespace (This results in
-    /// [`PathRootError::InvalidRoot`](PathRootError::InvalidRoot) if the user's root namespace has
-    /// changed.).
+    /// [`PathRootError::InvalidRoot`] if the user's root namespace has changed.).
     Root(NamespaceId),
-    /// Paths are relative to given namespace id (This results in
-    /// [`PathRootError::NoPermission`](PathRootError::NoPermission) if you don't have access to
-    /// this namespace.).
+    /// Paths are relative to given namespace id (This results in [`PathRootError::NoPermission`] if
+    /// you don't have access to this namespace.).
     NamespaceId(NamespaceId),
     /// Catch-all used for unrecognized values returned from the server. Encountering this value
     /// typically indicates that this SDK version is out of date.

--- a/src/generated/types/dbx_async.rs
+++ b/src/generated/types/dbx_async.rs
@@ -89,8 +89,8 @@ impl From<LaunchResultBase> for LaunchEmptyResult {
 }
 /// Result returned by methods that launch an asynchronous job. A method who may either launch an
 /// asynchronous job, or complete the request synchronously, can use this union by extending it, and
-/// adding a 'complete' field with the type of the synchronous response. See
-/// [`LaunchEmptyResult`](LaunchEmptyResult) for an example.
+/// adding a 'complete' field with the type of the synchronous response. See [`LaunchEmptyResult`]
+/// for an example.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum LaunchResultBase {
     /// This response indicates that the processing is asynchronous. The string is an id that can be
@@ -392,7 +392,7 @@ impl ::std::fmt::Display for PollError {
 
 /// Result returned by methods that poll for the status of an asynchronous job. Unions that extend
 /// this union should add a 'complete' field with a type of the information returned upon job
-/// completion. See [`PollEmptyResult`](PollEmptyResult) for an example.
+/// completion. See [`PollEmptyResult`] for an example.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum PollResultBase {
     /// The asynchronous job is still in progress.

--- a/src/generated/types/file_properties.rs
+++ b/src/generated/types/file_properties.rs
@@ -12,17 +12,16 @@
 //!
 //! These endpoints enable you to tag arbitrary key/value data to Dropbox files.
 //!
-//! The most basic unit in this namespace is the [`PropertyField`](PropertyField). These fields
-//! encapsulate the actual key/value data.
+//! The most basic unit in this namespace is the [`PropertyField`]. These fields encapsulate the
+//! actual key/value data.
 //!
-//! Fields are added to a Dropbox file using a [`PropertyGroup`](PropertyGroup). Property groups
-//! contain a reference to a Dropbox file and a [`PropertyGroupTemplate`](PropertyGroupTemplate).
-//! Property groups are uniquely identified by the combination of their associated Dropbox file and
-//! template.
+//! Fields are added to a Dropbox file using a [`PropertyGroup`]. Property groups contain a
+//! reference to a Dropbox file and a [`PropertyGroupTemplate`]. Property groups are uniquely
+//! identified by the combination of their associated Dropbox file and template.
 //!
-//! The [`PropertyGroupTemplate`](PropertyGroupTemplate) is a way of restricting the possible key
-//! names and value types of the data within a property group. The possible key names and value
-//! types are explicitly enumerated using [`PropertyFieldTemplate`](PropertyFieldTemplate) objects.
+//! The [`PropertyGroupTemplate`] is a way of restricting the possible key names and value types of
+//! the data within a property group. The possible key names and value types are explicitly
+//! enumerated using [`PropertyFieldTemplate`] objects.
 //!
 //! You can think of a property group template as a class definition for a particular key/value
 //! metadata object, and the property groups themselves as the instantiations of these objects.
@@ -2425,7 +2424,7 @@ impl ::serde::ser::Serialize for PropertiesSearchResult {
 }
 
 /// Raw key/value data to be associated with a Dropbox file. Property fields are added to Dropbox
-/// files as a [`PropertyGroup`](PropertyGroup).
+/// files as a [`PropertyGroup`].
 #[derive(Debug, Clone, PartialEq, Eq)]
 #[non_exhaustive] // structs may have more fields added in the future.
 pub struct PropertyField {
@@ -2532,7 +2531,7 @@ impl ::serde::ser::Serialize for PropertyField {
 }
 
 /// Defines how a single property field may be structured. Used exclusively by
-/// [`PropertyGroupTemplate`](PropertyGroupTemplate).
+/// [`PropertyGroupTemplate`].
 #[derive(Debug, Clone, PartialEq, Eq)]
 #[non_exhaustive] // structs may have more fields added in the future.
 pub struct PropertyFieldTemplate {
@@ -2651,10 +2650,9 @@ impl ::serde::ser::Serialize for PropertyFieldTemplate {
     }
 }
 
-/// A subset of the property fields described by the corresponding
-/// [`PropertyGroupTemplate`](PropertyGroupTemplate). Properties are always added to a Dropbox file
-/// as a [`PropertyGroup`](PropertyGroup). The possible key names and value types in this group are
-/// defined by the corresponding [`PropertyGroupTemplate`](PropertyGroupTemplate).
+/// A subset of the property fields described by the corresponding [`PropertyGroupTemplate`].
+/// Properties are always added to a Dropbox file as a [`PropertyGroup`]. The possible key names and
+/// value types in this group are defined by the corresponding [`PropertyGroupTemplate`].
 #[derive(Debug, Clone, PartialEq, Eq)]
 #[non_exhaustive] // structs may have more fields added in the future.
 pub struct PropertyGroup {

--- a/src/generated/types/files.rs
+++ b/src/generated/types/files.rs
@@ -238,8 +238,8 @@ pub struct AlphaGetMetadataArg {
     pub path: ReadPath,
     /// If true, [`FileMetadata::media_info`](FileMetadata) is set for photo and video.
     pub include_media_info: bool,
-    /// If true, [`DeletedMetadata`](DeletedMetadata) will be returned for deleted file or folder,
-    /// otherwise [`LookupError::NotFound`](LookupError::NotFound) will be returned.
+    /// If true, [`DeletedMetadata`] will be returned for deleted file or folder, otherwise
+    /// [`LookupError::NotFound`] will be returned.
     pub include_deleted: bool,
     /// If true, the results will include a flag for each file indicating whether or not  that file
     /// has any explicit members.
@@ -641,11 +641,10 @@ pub struct CommitInfo {
     pub mute: bool,
     /// List of custom properties to add to file.
     pub property_groups: Option<Vec<crate::types::file_properties::PropertyGroup>>,
-    /// Be more strict about how each [`WriteMode`](WriteMode) detects conflict. For example, always
-    /// return a conflict error when `mode` = [`WriteMode::Update`](WriteMode::Update) and the given
-    /// "rev" doesn't match the existing file's "rev", even if the existing file has been deleted.
-    /// This also forces a conflict even when the target path refers to a file with identical
-    /// contents.
+    /// Be more strict about how each [`WriteMode`] detects conflict. For example, always return a
+    /// conflict error when `mode` = [`WriteMode::Update`] and the given "rev" doesn't match the
+    /// existing file's "rev", even if the existing file has been deleted. This also forces a
+    /// conflict even when the target path refers to a file with identical contents.
     pub strict_conflict: bool,
 }
 
@@ -2244,9 +2243,8 @@ impl ::serde::ser::Serialize for DeleteBatchArg {
 #[derive(Debug, Clone, PartialEq, Eq)]
 #[non_exhaustive] // variants may be added in the future
 pub enum DeleteBatchError {
-    /// Use [`DeleteError::TooManyWriteOperations`](DeleteError::TooManyWriteOperations).
-    /// [`delete_batch()`](crate::files::delete_batch) now provides smaller granularity about which
-    /// entry has failed because of this.
+    /// Use [`DeleteError::TooManyWriteOperations`]. [`delete_batch()`](crate::files::delete_batch)
+    /// now provides smaller granularity about which entry has failed because of this.
     TooManyWriteOperations,
     /// Catch-all used for unrecognized values returned from the server. Encountering this value
     /// typically indicates that this SDK version is out of date.
@@ -6200,8 +6198,8 @@ pub struct GetMetadataArg {
     pub path: ReadPath,
     /// If true, [`FileMetadata::media_info`](FileMetadata) is set for photo and video.
     pub include_media_info: bool,
-    /// If true, [`DeletedMetadata`](DeletedMetadata) will be returned for deleted file or folder,
-    /// otherwise [`LookupError::NotFound`](LookupError::NotFound) will be returned.
+    /// If true, [`DeletedMetadata`] will be returned for deleted file or folder, otherwise
+    /// [`LookupError::NotFound`] will be returned.
     pub include_deleted: bool,
     /// If true, the results will include a flag for each file indicating whether or not  that file
     /// has any explicit members.
@@ -10556,7 +10554,7 @@ impl ::serde::ser::Serialize for MinimalFileLinkMetadata {
 #[derive(Debug, Clone, PartialEq, Eq)]
 #[non_exhaustive] // structs may have more fields added in the future.
 pub struct MoveBatchArg {
-    /// List of entries to be moved or copied. Each entry is [`RelocationPath`](RelocationPath).
+    /// List of entries to be moved or copied. Each entry is [`RelocationPath`].
     pub entries: Vec<RelocationPath>,
     /// If there's a conflict with any file, have the Dropbox server try to autorename that file to
     /// avoid the conflict.
@@ -12609,7 +12607,7 @@ impl From<RelocationArg> for RelocationPath {
 #[derive(Debug, Clone, PartialEq, Eq)]
 #[non_exhaustive] // structs may have more fields added in the future.
 pub struct RelocationBatchArg {
-    /// List of entries to be moved or copied. Each entry is [`RelocationPath`](RelocationPath).
+    /// List of entries to be moved or copied. Each entry is [`RelocationPath`].
     pub entries: Vec<RelocationPath>,
     /// If there's a conflict with any file, have the Dropbox server try to autorename that file to
     /// avoid the conflict.
@@ -12771,7 +12769,7 @@ impl From<RelocationBatchArg> for RelocationBatchArgBase {
 #[derive(Debug, Clone, PartialEq, Eq)]
 #[non_exhaustive] // structs may have more fields added in the future.
 pub struct RelocationBatchArgBase {
-    /// List of entries to be moved or copied. Each entry is [`RelocationPath`](RelocationPath).
+    /// List of entries to be moved or copied. Each entry is [`RelocationPath`].
     pub entries: Vec<RelocationPath>,
     /// If there's a conflict with any file, have the Dropbox server try to autorename that file to
     /// avoid the conflict.
@@ -18976,11 +18974,10 @@ pub struct UploadArg {
     pub mute: bool,
     /// List of custom properties to add to file.
     pub property_groups: Option<Vec<crate::types::file_properties::PropertyGroup>>,
-    /// Be more strict about how each [`WriteMode`](WriteMode) detects conflict. For example, always
-    /// return a conflict error when `mode` = [`WriteMode::Update`](WriteMode::Update) and the given
-    /// "rev" doesn't match the existing file's "rev", even if the existing file has been deleted.
-    /// This also forces a conflict even when the target path refers to a file with identical
-    /// contents.
+    /// Be more strict about how each [`WriteMode`] detects conflict. For example, always return a
+    /// conflict error when `mode` = [`WriteMode::Update`] and the given "rev" doesn't match the
+    /// existing file's "rev", even if the existing file has been deleted. This also forces a
+    /// conflict even when the target path refers to a file with identical contents.
     pub strict_conflict: bool,
     /// A hash of the file content uploaded in this call. If provided and the uploaded content does
     /// not match this hash, an error will be returned. For more information see our [Content
@@ -20724,7 +20721,7 @@ pub struct UploadSessionStartArg {
     /// current session.
     pub close: bool,
     /// Type of upload session you want to start. If not specified, default is
-    /// [`UploadSessionType::Sequential`](UploadSessionType::Sequential).
+    /// [`UploadSessionType::Sequential`].
     pub session_type: Option<UploadSessionType>,
     /// A hash of the file content uploaded in this call. If provided and the uploaded content does
     /// not match this hash, an error will be returned. For more information see our [Content
@@ -20846,7 +20843,7 @@ pub struct UploadSessionStartBatchArg {
     /// The number of upload sessions to start.
     pub num_sessions: u64,
     /// Type of upload session you want to start. If not specified, default is
-    /// [`UploadSessionType::Sequential`](UploadSessionType::Sequential).
+    /// [`UploadSessionType::Sequential`].
     pub session_type: Option<UploadSessionType>,
 }
 
@@ -21920,12 +21917,12 @@ pub enum WriteMode {
     /// [`Add`](WriteMode::Add).
     Overwrite,
     /// Overwrite if the given "rev" matches the existing file's "rev". The supplied value should be
-    /// the latest known "rev" of the file, for example, from [`FileMetadata`](FileMetadata), from
-    /// when the file was last downloaded by the app. This will cause the file on the Dropbox
-    /// servers to be overwritten if the given "rev" matches the existing file's current "rev" on
-    /// the Dropbox servers. The autorename strategy is to append the string "conflicted copy" to
-    /// the file name. For example, "document.txt" might become "document (conflicted copy).txt" or
-    /// "document (Panda's conflicted copy).txt".
+    /// the latest known "rev" of the file, for example, from [`FileMetadata`], from when the file
+    /// was last downloaded by the app. This will cause the file on the Dropbox servers to be
+    /// overwritten if the given "rev" matches the existing file's current "rev" on the Dropbox
+    /// servers. The autorename strategy is to append the string "conflicted copy" to the file name.
+    /// For example, "document.txt" might become "document (conflicted copy).txt" or "document
+    /// (Panda's conflicted copy).txt".
     Update(Rev),
 }
 

--- a/src/generated/types/paper.rs
+++ b/src/generated/types/paper.rs
@@ -3578,8 +3578,7 @@ pub struct PaperDocExportResult {
     pub title: String,
     /// The Paper doc revision. Simply an ever increasing number.
     pub revision: i64,
-    /// MIME type of the export. This corresponds to [`ExportFormat`](ExportFormat) specified in the
-    /// request.
+    /// MIME type of the export. This corresponds to [`ExportFormat`] specified in the request.
     pub mime_type: String,
 }
 

--- a/src/generated/types/sharing.rs
+++ b/src/generated/types/sharing.rs
@@ -961,8 +961,8 @@ impl ::std::fmt::Display for AddFolderMemberError {
 pub struct AddMember {
     /// The member to add to the shared folder.
     pub member: MemberSelector,
-    /// The access level to grant `member` to the shared folder.
-    /// [`AccessLevel::Owner`](AccessLevel::Owner) is disallowed.
+    /// The access level to grant `member` to the shared folder.  [`AccessLevel::Owner`] is
+    /// disallowed.
     pub access_level: AccessLevel,
 }
 
@@ -1807,9 +1807,8 @@ pub struct CreateSharedLinkArg {
     pub path: String,
     pub short_url: bool,
     /// If it's okay to share a path that does not yet exist, set this to either
-    /// [`PendingUploadMode::File`](PendingUploadMode::File) or
-    /// [`PendingUploadMode::Folder`](PendingUploadMode::Folder) to indicate whether to assume it's
-    /// a file or folder.
+    /// [`PendingUploadMode::File`] or [`PendingUploadMode::Folder`] to indicate whether to assume
+    /// it's a file or folder.
     pub pending_upload: Option<PendingUploadMode>,
 }
 
@@ -7079,8 +7078,8 @@ impl ::serde::ser::Serialize for LinkExpiry {
     }
 }
 
-/// Metadata for a shared link. This can be either a [`PathLinkMetadata`](PathLinkMetadata) or
-/// [`CollectionLinkMetadata`](CollectionLinkMetadata).
+/// Metadata for a shared link. This can be either a [`PathLinkMetadata`] or
+/// [`CollectionLinkMetadata`].
 #[derive(Debug, Clone, PartialEq, Eq)]
 #[non_exhaustive] // variants may be added in the future
 pub enum LinkMetadata {
@@ -13112,8 +13111,8 @@ impl ::serde::ser::Serialize for RequestedLinkAccessLevel {
 
 /// The access permission that can be requested by the caller for the shared link. Note that the
 /// final resolved visibility of the shared link takes into account other aspects, such as team and
-/// shared folder settings. Check the [`ResolvedVisibility`](ResolvedVisibility) for more info on
-/// the possible resolved visibility values of shared links.
+/// shared folder settings. Check the [`ResolvedVisibility`] for more info on the possible resolved
+/// visibility values of shared links.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum RequestedVisibility {
     /// Anyone who has received the link can access it. No login required.
@@ -13184,8 +13183,8 @@ impl ::serde::ser::Serialize for RequestedVisibility {
 }
 
 /// The actual access permissions values of shared links after taking into account user preferences
-/// and the team and shared folder settings. Check the [`RequestedVisibility`](RequestedVisibility)
-/// for more info on the possible visibility values that can be set by the shared link's owner.
+/// and the team and shared folder settings. Check the [`RequestedVisibility`] for more info on the
+/// possible visibility values that can be set by the shared link's owner.
 #[derive(Debug, Clone, PartialEq, Eq)]
 #[non_exhaustive] // variants may be added in the future
 pub enum ResolvedVisibility {
@@ -13731,8 +13730,7 @@ pub struct ShareFolderArg {
     /// Who can be a member of this shared folder. Only applicable if the current user is on a team.
     pub member_policy: Option<MemberPolicy>,
     /// The policy to apply to shared links created for content inside this shared folder.  The
-    /// current user must be on a team to set this policy to
-    /// [`SharedLinkPolicy::Members`](SharedLinkPolicy::Members).
+    /// current user must be on a team to set this policy to [`SharedLinkPolicy::Members`].
     pub shared_link_policy: Option<SharedLinkPolicy>,
     /// Who can enable/disable viewer info for this shared folder.
     pub viewer_info_policy: Option<ViewerInfoPolicy>,
@@ -14001,8 +13999,7 @@ pub struct ShareFolderArgBase {
     /// Who can be a member of this shared folder. Only applicable if the current user is on a team.
     pub member_policy: Option<MemberPolicy>,
     /// The policy to apply to shared links created for content inside this shared folder.  The
-    /// current user must be on a team to set this policy to
-    /// [`SharedLinkPolicy::Members`](SharedLinkPolicy::Members).
+    /// current user must be on a team to set this policy to [`SharedLinkPolicy::Members`].
     pub shared_link_policy: Option<SharedLinkPolicy>,
     /// Who can enable/disable viewer info for this shared folder.
     pub viewer_info_policy: Option<ViewerInfoPolicy>,
@@ -17361,14 +17358,13 @@ impl ::serde::ser::Serialize for SharedLinkSettings {
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum SharedLinkSettingsError {
-    /// The given settings are invalid (for example, all attributes of the
-    /// [`SharedLinkSettings`](SharedLinkSettings) are empty, the requested visibility is
-    /// [`RequestedVisibility::Password`](RequestedVisibility::Password) but the
+    /// The given settings are invalid (for example, all attributes of the [`SharedLinkSettings`]
+    /// are empty, the requested visibility is [`RequestedVisibility::Password`] but the
     /// [`SharedLinkSettings::link_password`](SharedLinkSettings) is missing,
     /// [`SharedLinkSettings::expires`](SharedLinkSettings) is set to the past, etc.).
     InvalidSettings,
     /// User is not allowed to modify the settings of this link. Note that basic users can only set
-    /// [`RequestedVisibility::Public`](RequestedVisibility::Public) as the
+    /// [`RequestedVisibility::Public`] as the
     /// [`SharedLinkSettings::requested_visibility`](SharedLinkSettings) and cannot set
     /// [`SharedLinkSettings::expires`](SharedLinkSettings).
     NotAuthorized,
@@ -18722,10 +18718,10 @@ impl ::serde::ser::Serialize for UpdateFileMemberArgs {
 pub struct UpdateFolderMemberArg {
     /// The ID for the shared folder.
     pub shared_folder_id: crate::types::common::SharedFolderId,
-    /// The member of the shared folder to update.  Only the
-    /// [`MemberSelector::DropboxId`](MemberSelector::DropboxId) may be set at this time.
+    /// The member of the shared folder to update.  Only the [`MemberSelector::DropboxId`] may be
+    /// set at this time.
     pub member: MemberSelector,
-    /// The new access level for `member`. [`AccessLevel::Owner`](AccessLevel::Owner) is disallowed.
+    /// The new access level for `member`. [`AccessLevel::Owner`] is disallowed.
     pub access_level: AccessLevel,
 }
 
@@ -18993,8 +18989,7 @@ pub struct UpdateFolderPolicyArg {
     /// Who can enable/disable viewer info for this shared folder.
     pub viewer_info_policy: Option<ViewerInfoPolicy>,
     /// The policy to apply to shared links created for content inside this shared folder. The
-    /// current user must be on a team to set this policy to
-    /// [`SharedLinkPolicy::Members`](SharedLinkPolicy::Members).
+    /// current user must be on a team to set this policy to [`SharedLinkPolicy::Members`].
     pub shared_link_policy: Option<SharedLinkPolicy>,
     /// Settings on the link for this folder.
     pub link_settings: Option<LinkSettings>,

--- a/src/generated/types/team.rs
+++ b/src/generated/types/team.rs
@@ -3485,8 +3485,8 @@ impl ::serde::ser::Serialize for Feature {
     }
 }
 
-/// The values correspond to entries in [`Feature`](Feature). You may get different value according
-/// to your Dropbox Business plan.
+/// The values correspond to entries in [`Feature`]. You may get different value according to your
+/// Dropbox Business plan.
 #[derive(Debug, Clone, PartialEq, Eq)]
 #[non_exhaustive] // variants may be added in the future
 pub enum FeatureValue {
@@ -3599,8 +3599,8 @@ impl ::serde::ser::Serialize for FeatureValue {
 #[derive(Debug, Clone, PartialEq, Eq)]
 #[non_exhaustive] // structs may have more fields added in the future.
 pub struct FeaturesGetValuesBatchArg {
-    /// A list of features in [`Feature`](Feature). If the list is empty, this route will return
-    /// [`FeaturesGetValuesBatchError`](FeaturesGetValuesBatchError).
+    /// A list of features in [`Feature`]. If the list is empty, this route will return
+    /// [`FeaturesGetValuesBatchError`].
     pub features: Vec<Feature>,
 }
 
@@ -3691,8 +3691,8 @@ impl ::serde::ser::Serialize for FeaturesGetValuesBatchArg {
 #[derive(Debug, Clone, PartialEq, Eq)]
 #[non_exhaustive] // variants may be added in the future
 pub enum FeaturesGetValuesBatchError {
-    /// At least one [`Feature`](Feature) must be included in the
-    /// [`FeaturesGetValuesBatchArg`](FeaturesGetValuesBatchArg).features list.
+    /// At least one [`Feature`] must be included in the [`FeaturesGetValuesBatchArg`].features
+    /// list.
     EmptyFeaturesList,
     /// Catch-all used for unrecognized values returned from the server. Encountering this value
     /// typically indicates that this SDK version is out of date.
@@ -5474,8 +5474,8 @@ impl ::serde::ser::Serialize for GroupMemberSelector {
     }
 }
 
-/// Error that can be raised when [`GroupMemberSelector`](GroupMemberSelector) is used, and the user
-/// is required to be a member of the specified group.
+/// Error that can be raised when [`GroupMemberSelector`] is used, and the user is required to be a
+/// member of the specified group.
 #[derive(Debug, Clone, PartialEq, Eq)]
 #[non_exhaustive] // variants may be added in the future
 pub enum GroupMemberSelectorError {
@@ -5839,8 +5839,7 @@ pub enum GroupMembersAddError {
     MembersNotInTeam(Vec<String>),
     /// These users were not found in Dropbox.
     UsersNotFound(Vec<String>),
-    /// A suspended user cannot be added to a group as
-    /// [`GroupAccessType::Owner`](GroupAccessType::Owner).
+    /// A suspended user cannot be added to a group as [`GroupAccessType::Owner`].
     UserMustBeActiveToBeOwner,
     /// A company-managed group cannot be managed by a user.
     UserCannotBeManagerOfCompanyManagedGroup(Vec<String>),
@@ -6497,8 +6496,8 @@ impl ::serde::ser::Serialize for GroupMembersSelector {
     }
 }
 
-/// Error that can be raised when [`GroupMembersSelector`](GroupMembersSelector) is used, and the
-/// users are required to be members of the specified group.
+/// Error that can be raised when [`GroupMembersSelector`] is used, and the users are required to be
+/// members of the specified group.
 #[derive(Debug, Clone, PartialEq, Eq)]
 #[non_exhaustive] // variants may be added in the future
 pub enum GroupMembersSelectorError {
@@ -6820,7 +6819,7 @@ impl ::serde::ser::Serialize for GroupSelector {
     }
 }
 
-/// Error that can be raised when [`GroupSelector`](GroupSelector) is used.
+/// Error that can be raised when [`GroupSelector`] is used.
 #[derive(Debug, Clone, PartialEq, Eq)]
 #[non_exhaustive] // variants may be added in the future
 pub enum GroupSelectorError {
@@ -6888,8 +6887,8 @@ impl ::std::fmt::Display for GroupSelectorError {
     }
 }
 
-/// Error that can be raised when [`GroupSelector`](GroupSelector) is used and team groups are
-/// disallowed from being used.
+/// Error that can be raised when [`GroupSelector`] is used and team groups are disallowed from
+/// being used.
 #[derive(Debug, Clone, PartialEq, Eq)]
 #[non_exhaustive] // variants may be added in the future
 pub enum GroupSelectorWithTeamGroupError {
@@ -8354,7 +8353,7 @@ impl ::serde::ser::Serialize for GroupsSelector {
     }
 }
 
-/// The value for [`Feature::HasTeamFileEvents`](Feature::HasTeamFileEvents).
+/// The value for [`Feature::HasTeamFileEvents`].
 #[derive(Debug, Clone, PartialEq, Eq)]
 #[non_exhaustive] // variants may be added in the future
 pub enum HasTeamFileEventsValue {
@@ -8417,7 +8416,7 @@ impl ::serde::ser::Serialize for HasTeamFileEventsValue {
     }
 }
 
-/// The value for [`Feature::HasTeamSelectiveSync`](Feature::HasTeamSelectiveSync).
+/// The value for [`Feature::HasTeamSelectiveSync`].
 #[derive(Debug, Clone, PartialEq, Eq)]
 #[non_exhaustive] // variants may be added in the future
 pub enum HasTeamSelectiveSyncValue {
@@ -8480,7 +8479,7 @@ impl ::serde::ser::Serialize for HasTeamSelectiveSyncValue {
     }
 }
 
-/// The value for [`Feature::HasTeamSharedDropbox`](Feature::HasTeamSharedDropbox).
+/// The value for [`Feature::HasTeamSharedDropbox`].
 #[derive(Debug, Clone, PartialEq, Eq)]
 #[non_exhaustive] // variants may be added in the future
 pub enum HasTeamSharedDropboxValue {
@@ -14799,12 +14798,12 @@ pub struct MemberProfile {
     /// Secondary emails of a user.
     pub secondary_emails: Option<Vec<crate::types::secondary_emails::SecondaryEmail>>,
     /// The date and time the user was invited to the team (contains value only when the member's
-    /// status matches [`TeamMemberStatus::Invited`](TeamMemberStatus::Invited)).
+    /// status matches [`TeamMemberStatus::Invited`]).
     pub invited_on: Option<crate::types::common::DropboxTimestamp>,
     /// The date and time the user joined as a member of a specific team.
     pub joined_on: Option<crate::types::common::DropboxTimestamp>,
     /// The date and time the user was suspended from the team (contains value only when the
-    /// member's status matches [`TeamMemberStatus::Suspended`](TeamMemberStatus::Suspended)).
+    /// member's status matches [`TeamMemberStatus::Suspended`]).
     pub suspended_on: Option<crate::types::common::DropboxTimestamp>,
     /// Persistent ID that a team can attach to the user. The persistent ID is unique ID to be used
     /// for SAML authentication.
@@ -15411,8 +15410,8 @@ pub enum MembersAddJobStatus {
     /// The asynchronous job is still in progress.
     InProgress,
     /// The asynchronous job has finished. For each member that was specified in the parameter
-    /// [`MembersAddArg`](MembersAddArg) that was provided to
-    /// [`members_add()`](crate::team::members_add), a corresponding item is returned in this list.
+    /// [`MembersAddArg`] that was provided to [`members_add()`](crate::team::members_add), a
+    /// corresponding item is returned in this list.
     Complete(Vec<MemberAddResult>),
     /// The asynchronous job returned an error. The string contains an error message.
     Failed(String),
@@ -15505,9 +15504,8 @@ pub enum MembersAddJobStatusV2Result {
     /// The asynchronous job is still in progress.
     InProgress,
     /// The asynchronous job has finished. For each member that was specified in the parameter
-    /// [`MembersAddArg`](MembersAddArg) that was provided to
-    /// [`members_add_v2()`](crate::team::members_add_v2), a corresponding item is returned in this
-    /// list.
+    /// [`MembersAddArg`] that was provided to [`members_add_v2()`](crate::team::members_add_v2), a
+    /// corresponding item is returned in this list.
     Complete(Vec<MemberAddV2Result>),
     /// The asynchronous job returned an error. The string contains an error message.
     Failed(String),
@@ -27376,12 +27374,12 @@ pub struct TeamMemberProfile {
     /// Secondary emails of a user.
     pub secondary_emails: Option<Vec<crate::types::secondary_emails::SecondaryEmail>>,
     /// The date and time the user was invited to the team (contains value only when the member's
-    /// status matches [`TeamMemberStatus::Invited`](TeamMemberStatus::Invited)).
+    /// status matches [`TeamMemberStatus::Invited`]).
     pub invited_on: Option<crate::types::common::DropboxTimestamp>,
     /// The date and time the user joined as a member of a specific team.
     pub joined_on: Option<crate::types::common::DropboxTimestamp>,
     /// The date and time the user was suspended from the team (contains value only when the
-    /// member's status matches [`TeamMemberStatus::Suspended`](TeamMemberStatus::Suspended)).
+    /// member's status matches [`TeamMemberStatus::Suspended`]).
     pub suspended_on: Option<crate::types::common::DropboxTimestamp>,
     /// Persistent ID that a team can attach to the user. The persistent ID is unique ID to be used
     /// for SAML authentication.
@@ -28717,7 +28715,7 @@ impl ::serde::ser::Serialize for TokenGetAuthenticatedAdminResult {
     }
 }
 
-/// The value for [`Feature::UploadApiRateLimit`](Feature::UploadApiRateLimit).
+/// The value for [`Feature::UploadApiRateLimit`].
 #[derive(Debug, Clone, PartialEq, Eq)]
 #[non_exhaustive] // variants may be added in the future
 pub enum UploadApiRateLimitValue {
@@ -29767,8 +29765,7 @@ impl ::serde::ser::Serialize for UserSelectorArg {
     }
 }
 
-/// Error that can be returned whenever a struct derived from [`UserSelectorArg`](UserSelectorArg)
-/// is used.
+/// Error that can be returned whenever a struct derived from [`UserSelectorArg`] is used.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum UserSelectorError {
     /// No matching user found. The provided team_member_id, email, or external_id does not exist on

--- a/src/generated/types/users.rs
+++ b/src/generated/types/users.rs
@@ -404,7 +404,7 @@ impl From<BasicAccount> for Account {
         }
     }
 }
-/// The value for [`UserFeature::FileLocking`](UserFeature::FileLocking).
+/// The value for [`UserFeature::FileLocking`].
 #[derive(Debug, Clone, PartialEq, Eq)]
 #[non_exhaustive] // variants may be added in the future
 pub enum FileLockingValue {
@@ -1494,7 +1494,7 @@ impl ::serde::ser::Serialize for Name {
     }
 }
 
-/// The value for [`UserFeature::PaperAsFiles`](UserFeature::PaperAsFiles).
+/// The value for [`UserFeature::PaperAsFiles`].
 #[derive(Debug, Clone, PartialEq, Eq)]
 #[non_exhaustive] // variants may be added in the future
 pub enum PaperAsFilesValue {
@@ -2054,7 +2054,7 @@ impl ::serde::ser::Serialize for UserFeature {
     }
 }
 
-/// Values that correspond to entries in [`UserFeature`](UserFeature).
+/// Values that correspond to entries in [`UserFeature`].
 #[derive(Debug, Clone, PartialEq, Eq)]
 #[non_exhaustive] // variants may be added in the future
 pub enum UserFeatureValue {
@@ -2135,8 +2135,8 @@ impl ::serde::ser::Serialize for UserFeatureValue {
 #[derive(Debug, Clone, PartialEq, Eq)]
 #[non_exhaustive] // structs may have more fields added in the future.
 pub struct UserFeaturesGetValuesBatchArg {
-    /// A list of features in [`UserFeature`](UserFeature). If the list is empty, this route will
-    /// return [`UserFeaturesGetValuesBatchError`](UserFeaturesGetValuesBatchError).
+    /// A list of features in [`UserFeature`]. If the list is empty, this route will return
+    /// [`UserFeaturesGetValuesBatchError`].
     pub features: Vec<UserFeature>,
 }
 
@@ -2227,8 +2227,8 @@ impl ::serde::ser::Serialize for UserFeaturesGetValuesBatchArg {
 #[derive(Debug, Clone, PartialEq, Eq)]
 #[non_exhaustive] // variants may be added in the future
 pub enum UserFeaturesGetValuesBatchError {
-    /// At least one [`UserFeature`](UserFeature) must be included in the
-    /// [`UserFeaturesGetValuesBatchArg`](UserFeaturesGetValuesBatchArg).features list.
+    /// At least one [`UserFeature`] must be included in the
+    /// [`UserFeaturesGetValuesBatchArg`].features list.
     EmptyFeaturesList,
     /// Catch-all used for unrecognized values returned from the server. Encountering this value
     /// typically indicates that this SDK version is out of date.


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description below.
-->

This uses the shorthand for links to things already in scope. It shortens the generated code a bit and makes it easier to read.

## **Checklist**

**General Contributing**
<!-- Change [ ] to [x] if you have: -->
- [x] I have read the Code of Conduct and signed the [CLA](https://opensource.dropbox.com/cla/).
- [x] I have added an entry to the `RELEASE_NOTES.md` file, or believe it's not necessary for this change.

**Validation**
<!-- Describe which tests cover the changes you've made, and any additional manual validation you
     did to ensure the correctness of this change. Does this change warrant addition of new tests?
     Does this change have performance implications? Etc. -->
CI