### PR TITLE
remove unmaintained atty crate from dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,12 +12,11 @@ readme = "README.md"
 
 [package.metadata]
 # Keep this at least 1 year old.
-# (or not... 1.75 is required for "-> impl Trait" sadly)
+# 1.75 is required for "-> impl Trait"
 msrv = "1.75.0" # Dec 28, 2023
 
 [dependencies]
 async-lock = "3.3.0"
-atty = "0.2.14"
 base64 = "0.22"
 bytes = "1.6.0"
 log = "0.4"

--- a/src/oauth2.rs
+++ b/src/oauth2.rs
@@ -13,7 +13,7 @@
 //! [OAuth types summary]: https://developers.dropbox.com/oauth-guide#summary
 
 use std::env;
-use std::io::{self, Write};
+use std::io::{self, IsTerminal, Write};
 use std::sync::Arc;
 use async_lock::RwLock;
 use base64::Engine;
@@ -664,7 +664,7 @@ pub fn get_auth_from_env_or_prompt() -> Authorization {
         }
     }
 
-    if !atty::is(atty::Stream::Stdin) {
+    if !io::stdin().is_terminal() {
         panic!("DBX_CLIENT_ID and/or DBX_OAUTH not set, and stdin not a TTY; cannot authorize");
     }
 


### PR DESCRIPTION
There's a replacement in std that requires 1.70 which is old enough for us.

<!--
Thank you for your pull request. Please provide a description below.
-->

## **Checklist**

**General Contributing**
<!-- Change [ ] to [x] if you have: -->
- [x] I have read the Code of Conduct and signed the [CLA](https://opensource.dropbox.com/cla/).
- [x] I have added an entry to the `RELEASE_NOTES.md` file, or believe it's not necessary for this change.

**Validation**
<!-- Describe which tests cover the changes you've made, and any additional manual validation you
     did to ensure the correctness of this change. Does this change warrant addition of new tests?
     Does this change have performance implications? Etc. -->
it builds