### PR TITLE
rustfmt everything except generated code

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,0 +1,3 @@
+# .git-blame-ignore-revs
+# rustfmt everything except generated code
+3e04628e0c4bfc64247fd68e2924792c7632e783

--- a/.github/workflows/cargo-test.yml
+++ b/.github/workflows/cargo-test.yml
@@ -12,6 +12,23 @@ jobs:
         with:
           submodules: true
 
+      - name: Install nightly toolchain
+        run: |
+          rustup install nightly --profile minimal
+          rustup component add clippy --toolchain nightly
+          rustup component add rustfmt --toolchain nightly
+
+      - name: Run rustfmt
+        # Delete the generated code so it doesn't get formatted.
+        # We'll be re-running the generator later, so this is okay.
+        run: |
+          rm -rf src/generated
+          echo "// empty module for rustfmt" > src/generated.rs
+          echo "// empty module for rustfmt" > tests/generated.rs
+          rustup run nightly cargo fmt --check
+          rm src/generated.rs
+          rm tests/generated.rs
+
       - name: Set up Python
         uses: actions/setup-python@v5.3.0
         with:
@@ -33,11 +50,6 @@ jobs:
 
       - name: Run cargo test
         run: rustup run 1.75.0 cargo test --all-features
-
-      - name: Install nightly toolchain
-        run: |
-          rustup install nightly --profile minimal
-          rustup component add clippy --toolchain nightly
 
       - name: Run clippy
         run: rustup run nightly cargo clippy --all-targets --all-features -- --deny warnings

--- a/examples/demo-async.rs
+++ b/examples/demo-async.rs
@@ -3,9 +3,9 @@
 //! This example illustrates a few basic Dropbox API operations: getting an OAuth2 token, listing
 //! the contents of a folder recursively, and fetching a file given its path.
 
-use tokio_util::compat::FuturesAsyncReadCompatExt;
-use dropbox_sdk::default_async_client::{NoauthDefaultClient, UserAuthDefaultClient};
 use dropbox_sdk::async_routes::files;
+use dropbox_sdk::default_async_client::{NoauthDefaultClient, UserAuthDefaultClient};
+use tokio_util::compat::FuturesAsyncReadCompatExt;
 
 enum Operation {
     Usage,
@@ -68,7 +68,9 @@ async fn main() {
 
     let mut auth = dropbox_sdk::oauth2::get_auth_from_env_or_prompt();
     if auth.save().is_none() {
-        auth.obtain_access_token_async(NoauthDefaultClient::default()).await.unwrap();
+        auth.obtain_access_token_async(NoauthDefaultClient::default())
+            .await
+            .unwrap();
         eprintln!("Next time set these environment variables to reuse this authorization:");
         eprintln!("  DBX_CLIENT_ID={}", auth.client_id());
         eprintln!("  DBX_OAUTH={}", auth.save().unwrap());
@@ -84,10 +86,11 @@ async fn main() {
             match files::download(&client, &files::DownloadArg::new(path), None, None).await {
                 Ok(result) => {
                     match tokio::io::copy(
-                        &mut result.body.expect("there must be a response body")
-                            .compat(),
+                        &mut result.body.expect("there must be a response body").compat(),
                         &mut tokio::io::stdout(),
-                    ).await {
+                    )
+                    .await
+                    {
                         Ok(n) => {
                             eprintln!("Downloaded {n} bytes");
                         }
@@ -112,7 +115,9 @@ async fn main() {
             let mut result = match files::list_folder(
                 &client,
                 &files::ListFolderArg::new(path).with_recursive(true),
-            ).await {
+            )
+            .await
+            {
                 Ok(result) => result,
                 Err(e) => {
                     eprintln!("Error from files/list_folder: {e}");
@@ -145,7 +150,9 @@ async fn main() {
                 result = match files::list_folder_continue(
                     &client,
                     &files::ListFolderContinueArg::new(result.cursor),
-                ).await {
+                )
+                .await
+                {
                     Ok(result) => {
                         num_pages += 1;
                         num_entries += result.entries.len();

--- a/examples/demo.rs
+++ b/examples/demo.rs
@@ -68,7 +68,8 @@ fn main() {
 
     let mut auth = dropbox_sdk::oauth2::get_auth_from_env_or_prompt();
     if auth.save().is_none() {
-        auth.obtain_access_token(NoauthDefaultClient::default()).unwrap();
+        auth.obtain_access_token(NoauthDefaultClient::default())
+            .unwrap();
         eprintln!("Next time set these environment variables to reuse this authorization:");
         eprintln!("  DBX_CLIENT_ID={}", auth.client_id());
         eprintln!("  DBX_OAUTH={}", auth.save().unwrap());

--- a/src/client_trait.rs
+++ b/src/client_trait.rs
@@ -2,10 +2,10 @@
 
 //! Everything needed to implement your HTTP client.
 
-use std::io::Read;
-use std::sync::Arc;
 pub use crate::client_trait_common::{HttpRequest, TeamSelect};
 use crate::Error;
+use std::io::Read;
+use std::sync::Arc;
 
 /// The base HTTP synchronous client trait.
 pub trait HttpClient: Sync {
@@ -13,11 +13,7 @@ pub trait HttpClient: Sync {
     type Request: HttpRequest + Send;
 
     /// Make a HTTP request.
-    fn execute(
-        &self,
-        request: Self::Request,
-        body: &[u8],
-    ) -> Result<HttpRequestResultRaw, Error>;
+    fn execute(&self, request: Self::Request, body: &[u8]) -> Result<HttpRequestResultRaw, Error>;
 
     /// Create a new request instance for the given URL. It should be a POST request.
     fn new_request(&self, url: &str) -> Self::Request;
@@ -92,4 +88,3 @@ pub struct HttpRequestResult<T> {
     /// [`Style::Download`](crate::client_trait_common::Style::Download) endpoints.
     pub body: Option<Box<dyn Read>>,
 }
-

--- a/src/error.rs
+++ b/src/error.rs
@@ -29,8 +29,10 @@ pub enum Error<E = NoError> {
     Authentication(#[source] types::auth::AuthError),
 
     /// Your request was rejected due to rate-limiting. You can retry it later.
-    #[error("Dropbox API declined the request due to rate-limiting ({reason}), \
-        retry after {retry_after_seconds}s")]
+    #[error(
+        "Dropbox API declined the request due to rate-limiting ({reason}), \
+        retry after {retry_after_seconds}s"
+    )]
     RateLimited {
         /// The server-given reason for the rate-limiting.
         reason: types::auth::RateLimitReason,
@@ -103,10 +105,18 @@ impl<E: std::error::Error + Send + Sync + 'static> Error<E> {
             Error::UnexpectedResponse(e) => Error::UnexpectedResponse(e),
             Error::BadRequest(e) => Error::BadRequest(e),
             Error::Authentication(e) => Error::Authentication(e),
-            Error::RateLimited { reason, retry_after_seconds } => Error::RateLimited { reason, retry_after_seconds },
+            Error::RateLimited {
+                reason,
+                retry_after_seconds,
+            } => Error::RateLimited {
+                reason,
+                retry_after_seconds,
+            },
             Error::AccessDenied(e) => Error::AccessDenied(e),
             Error::ServerError(e) => Error::ServerError(e),
-            Error::UnexpectedHttpError { code, response } => Error::UnexpectedHttpError { code, response },
+            Error::UnexpectedHttpError { code, response } => {
+                Error::UnexpectedHttpError { code, response }
+            }
         }
     }
 }
@@ -125,14 +135,21 @@ impl Error<NoError> {
             Error::UnexpectedResponse(e) => Error::UnexpectedResponse(e),
             Error::BadRequest(e) => Error::BadRequest(e),
             Error::Authentication(e) => Error::Authentication(e),
-            Error::RateLimited { reason, retry_after_seconds } => Error::RateLimited { reason, retry_after_seconds },
+            Error::RateLimited {
+                reason,
+                retry_after_seconds,
+            } => Error::RateLimited {
+                reason,
+                retry_after_seconds,
+            },
             Error::AccessDenied(e) => Error::AccessDenied(e),
             Error::ServerError(e) => Error::ServerError(e),
-            Error::UnexpectedHttpError { code, response } => Error::UnexpectedHttpError { code, response },
+            Error::UnexpectedHttpError { code, response } => {
+                Error::UnexpectedHttpError { code, response }
+            }
         }
     }
 }
-
 
 /// A special error type for a method that doesn't have any defined error return. You can't
 /// actually encounter a value of this type in real life; it's here to satisfy type requirements.
@@ -174,11 +191,10 @@ impl std::fmt::Display for NoError {
 // This is the reason we can't just use the otherwise-identical `void` crate's Void type: we need
 // to implement this trait.
 impl<'de> serde::de::Deserialize<'de> for NoError {
-    fn deserialize<D: serde::de::Deserializer<'de>>(_: D)
-        -> Result<Self, D::Error>
-    {
+    fn deserialize<D: serde::de::Deserializer<'de>>(_: D) -> Result<Self, D::Error> {
         Err(serde::de::Error::custom(
-            "method has no defined error type, but an error was returned"))
+            "method has no defined error type, but an error was returned",
+        ))
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,16 +1,14 @@
 // Copyright (c) 2019-2025 Dropbox, Inc.
 
-#![deny(
-    missing_docs,
-    rust_2018_idioms,
-)]
-
+#![deny(missing_docs, rust_2018_idioms)]
 // Enable a nightly feature for docs.rs which enables decorating feature-gated items.
 // To enable this manually, run e.g. `cargo rustdoc --all-features -- --cfg docsrs`.
 #![cfg_attr(docsrs, feature(doc_cfg))]
-
 #![cfg_attr(docsrs, doc = include_str!("../README.md"))]
-#![cfg_attr(not(docsrs), doc = "Dropbox SDK for Rust. See README.md for more details.")]
+#![cfg_attr(
+    not(docsrs),
+    doc = "Dropbox SDK for Rust. See README.md for more details."
+)]
 
 /// Feature-gate something and also decorate it with the feature name on docs.rs.
 macro_rules! if_feature {
@@ -30,7 +28,8 @@ macro_rules! if_feature {
     };
 }
 
-#[macro_use] extern crate log;
+#[macro_use]
+extern crate log;
 
 if_feature! { "default_client",
     pub mod default_client;

--- a/tests/async_client_test.rs
+++ b/tests/async_client_test.rs
@@ -1,8 +1,8 @@
 use bytes::Bytes;
-use futures::io::Cursor;
-use dropbox_sdk::async_routes::check;
 use dropbox_sdk::async_client_trait::*;
+use dropbox_sdk::async_routes::check;
 use dropbox_sdk::Error;
+use futures::io::Cursor;
 
 struct TestAsyncClient;
 struct TestRequest {
@@ -12,7 +12,11 @@ struct TestRequest {
 impl HttpClient for TestAsyncClient {
     type Request = TestRequest;
 
-    async fn execute(&self, request: Self::Request, body: Bytes) -> Result<HttpRequestResultRaw, Error> {
+    async fn execute(
+        &self,
+        request: Self::Request,
+        body: Bytes,
+    ) -> Result<HttpRequestResultRaw, Error> {
         match request.url.as_str() {
             "https://api.dropboxapi.com/2/check/user" => {
                 let arg = serde_json::from_slice::<check::EchoArg>(&body)?;
@@ -24,15 +28,22 @@ impl HttpClient for TestAsyncClient {
                     status: 200,
                     result_header: None,
                     content_length: None,
-                    body: Box::new(Cursor::new(format!(r#"{{"result":"{}"}}"#, arg.query).into_bytes())),
+                    body: Box::new(Cursor::new(
+                        format!(r#"{{"result":"{}"}}"#, arg.query).into_bytes(),
+                    )),
                 })
             }
-            _ => Err(Error::HttpClient(Box::new(std::io::Error::other(format!("unhandled URL {}", request.url))))),
+            _ => Err(Error::HttpClient(Box::new(std::io::Error::other(format!(
+                "unhandled URL {}",
+                request.url
+            ))))),
         }
     }
 
     fn new_request(&self, url: &str) -> Self::Request {
-        TestRequest{ url: url.to_owned() }
+        TestRequest {
+            url: url.to_owned(),
+        }
     }
 }
 
@@ -48,7 +59,9 @@ impl HttpRequest for TestRequest {
 async fn test_sync_client() {
     let client = TestAsyncClient;
     let req = check::EchoArg::default().with_query("foobar".to_owned());
-    let resp = check::user(&client, &req).await.expect("request must not fail");
+    let resp = check::user(&client, &req)
+        .await
+        .expect("request must not fail");
     if resp.result != req.query {
         panic!("response mismatch");
     }

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -1,6 +1,6 @@
-use dropbox_sdk::Error::Api;
-use dropbox_sdk::files;
 use dropbox_sdk::client_trait::UserAuthClient;
+use dropbox_sdk::files;
+use dropbox_sdk::Error::Api;
 use std::sync::Arc;
 use std::thread;
 use std::time::Duration;
@@ -14,34 +14,37 @@ pub fn create_files(
 ) -> (impl Fn(u32) -> String, impl Fn(u32) -> Vec<u8>) {
     let threadpool = ThreadPool::new(20);
 
-    let file_bytes = move |i| format!("This is file {}.\n", i)
-        .into_bytes()
-        .into_iter()
-        .cycle()
-        .take(size)
-        .collect::<Vec<u8>>();
-    let file_path = move |i| format!("{}/file{}.txt", path, i);
+    let file_bytes = move |i| {
+        format!("This is file {i}.\n")
+            .into_bytes()
+            .into_iter()
+            .cycle()
+            .take(size)
+            .collect::<Vec<u8>>()
+    };
+    let file_path = move |i| format!("{path}/file{i}.txt");
 
-    println!("Creating {} files in {}", num_files, path);
-    for i in 0 .. num_files {
+    println!("Creating {num_files} files in {path}");
+    for i in 0..num_files {
         let c = client.clone();
         threadpool.execute(move || {
             let path = file_path(i);
-            let arg = files::UploadArg::new(path.clone())
-                .with_mode(files::WriteMode::Overwrite);
+            let arg = files::UploadArg::new(path.clone()).with_mode(files::WriteMode::Overwrite);
             loop {
-                println!("{}: writing", path);
+                println!("{path}: writing");
                 match files::upload(c.as_ref(), &arg, &file_bytes(i)) {
                     Ok(_) => (),
-                    Err(dropbox_sdk::Error::RateLimited { retry_after_seconds, .. }) => {
-                        println!("{}: rate limited; sleeping {} seconds",
-                            path, retry_after_seconds);
+                    Err(dropbox_sdk::Error::RateLimited {
+                        retry_after_seconds,
+                        ..
+                    }) => {
+                        println!("{path}: rate limited; sleeping {retry_after_seconds} seconds");
                         thread::sleep(Duration::from_secs(retry_after_seconds as u64));
                         continue;
                     }
-                    Err(e) => panic!("{}: upload failed: {:?}", path, e),
+                    Err(e) => panic!("{path}: upload failed: {e:?}"),
                 }
-                println!("{}: done", path);
+                println!("{path}: done");
                 break;
             }
         });
@@ -52,17 +55,18 @@ pub fn create_files(
 }
 
 pub fn create_clean_folder(client: &impl UserAuthClient, path: &str) {
-    println!("Deleting any existing {} folder", path);
+    println!("Deleting any existing {path} folder");
     match files::delete_v2(client, &files::DeleteArg::new(path.to_owned())) {
         Ok(_) | Err(Api(files::DeleteError::PathLookup(files::LookupError::NotFound))) => (),
-        Err(e) => panic!("unexpected result when deleting {}: {:?}", path, e),
+        Err(e) => panic!("unexpected result when deleting {path}: {e:?}"),
     }
 
-    println!("Creating folder {}", path);
+    println!("Creating folder {path}");
     match files::create_folder_v2(
-        client, &files::CreateFolderArg::new(path.to_owned()).with_autorename(false))
-    {
+        client,
+        &files::CreateFolderArg::new(path.to_owned()).with_autorename(false),
+    ) {
         Ok(_) => (),
-        Err(e) => panic!("unexpected result when creating {}: {:?}", path, e),
+        Err(e) => panic!("unexpected result when creating {path}: {e:?}"),
     }
 }

--- a/tests/json.rs
+++ b/tests/json.rs
@@ -1,16 +1,15 @@
 #[test]
 fn test_null_fields_elided() {
     // Struct fields with optional or default values don't need to be serialized.
-    let value = dropbox_sdk::files::Metadata::File(
-        dropbox_sdk::files::FileMetadata::new(
-            "name".to_owned(),
-            "id".to_owned(),
-            "client_modified".to_owned(),
-            "server_modified".to_owned(),
-            "rev".to_owned(),
-            1337)
+    let value = dropbox_sdk::files::Metadata::File(dropbox_sdk::files::FileMetadata::new(
+        "name".to_owned(),
+        "id".to_owned(),
+        "client_modified".to_owned(),
+        "server_modified".to_owned(),
+        "rev".to_owned(),
+        1337,
         // Many other optional fields not populated.
-    );
+    ));
 
     // Serialized value should only contain these fields, and should not have the optional fields
     // included, like `"media_info": null`.

--- a/tests/list_folder_recursive.rs
+++ b/tests/list_folder_recursive.rs
@@ -1,5 +1,5 @@
-use dropbox_sdk::files;
 use dropbox_sdk::default_client::UserAuthDefaultClient;
+use dropbox_sdk::files;
 use std::collections::HashSet;
 use std::sync::Arc;
 
@@ -23,7 +23,7 @@ fn list_folder_recursive() {
     let (files_b, _) = common::create_files(client.clone(), FOLDER_INNER, NUM_FILES, FILE_SIZE);
 
     let mut files = HashSet::new();
-    for i in 0 .. NUM_FILES {
+    for i in 0..NUM_FILES {
         files.insert(files_a(i));
         files.insert(files_b(i));
     }
@@ -35,7 +35,11 @@ fn list_folder_recursive() {
             match metadata {
                 files::Metadata::File(files::FileMetadata { path_lower, .. }) => {
                     let path_lower = path_lower.expect("missing path_lower in response");
-                    assert!(files.remove(&path_lower), "got unexpected path {}", path_lower);
+                    assert!(
+                        files.remove(&path_lower),
+                        "got unexpected path {}",
+                        path_lower
+                    );
                 }
                 files::Metadata::Folder(files::FolderMetadata { path_lower, .. }) => {
                     let path_lower = path_lower.expect("missing path_lower in response");
@@ -51,9 +55,14 @@ fn list_folder_recursive() {
         client.as_ref(),
         &files::ListFolderArg::new(FOLDER.to_owned())
             .with_recursive(true)
-            .with_limit(10))
-    {
-        Ok(files::ListFolderResult { entries, cursor, has_more, .. }) => {
+            .with_limit(10),
+    ) {
+        Ok(files::ListFolderResult {
+            entries,
+            cursor,
+            has_more,
+            ..
+        }) => {
             println!("{} entries", entries.len());
             process_entries(entries);
             assert!(has_more, "expected has_more from list_folder");
@@ -65,9 +74,15 @@ fn list_folder_recursive() {
     while has_more {
         println!("list_folder_continue");
         let next = match files::list_folder_continue(
-            client.as_ref(), &files::ListFolderContinueArg::new(cursor.clone()))
-        {
-            Ok(files::ListFolderResult { entries, cursor, has_more, .. }) => {
+            client.as_ref(),
+            &files::ListFolderContinueArg::new(cursor.clone()),
+        ) {
+            Ok(files::ListFolderResult {
+                entries,
+                cursor,
+                has_more,
+                ..
+            }) => {
                 println!("{} entries", entries.len());
                 process_entries(entries);
                 (cursor, has_more)

--- a/tests/noop_client.rs
+++ b/tests/noop_client.rs
@@ -1,5 +1,5 @@
-use std::fmt::{Debug, Display, Formatter};
 use dropbox_sdk::client_trait::*;
+use std::fmt::{Debug, Display, Formatter};
 
 macro_rules! noop_client {
     ($name:ident) => {
@@ -16,7 +16,9 @@ macro_rules! noop_client {
                     _request: Self::Request,
                     _body: &[u8],
                 ) -> Result<HttpRequestResultRaw, dropbox_sdk::Error> {
-                    Err(dropbox_sdk::Error::HttpClient(Box::new(super::ErrMsg("noop client called".to_owned()))))
+                    Err(dropbox_sdk::Error::HttpClient(Box::new(super::ErrMsg(
+                        "noop client called".to_owned(),
+                    ))))
                 }
 
                 fn new_request(&self, _url: &str) -> Self::Request {
@@ -24,7 +26,7 @@ macro_rules! noop_client {
                 }
             }
         }
-    }
+    };
 }
 
 noop_client!(app);
@@ -54,4 +56,4 @@ impl Display for ErrMsg {
     }
 }
 
-impl std::error::Error for ErrMsg{}
+impl std::error::Error for ErrMsg {}

--- a/tests/path_root.rs
+++ b/tests/path_root.rs
@@ -11,17 +11,23 @@ fn invalid_path_root() {
     match files::list_folder(&client, &ListFolderArg::new("/".to_owned())) {
         // If the oauth token is for an app which only has access to its app folder, then the path
         // root cannot be specified.
-        Err(dropbox_sdk::Error::BadRequest(msg)) if msg.contains("Path root is not supported for sandbox app") => (),
+        Err(dropbox_sdk::Error::BadRequest(msg))
+            if msg.contains("Path root is not supported for sandbox app") => {}
 
         // If the oauth token is for a "whole dropbox" app, then we should get this error, which
         // inside will have a "no_permission" error.
         // If the error is due to a change in the user's home nsid, then we get an "invalid_root"
         // error which includes the new nsid, but that's not what we expect here, where we're just
         // giving a bogus nsid.
-        Err(dropbox_sdk::Error::UnexpectedHttpError { code: 422, response, .. }) => {
+        Err(dropbox_sdk::Error::UnexpectedHttpError {
+            code: 422,
+            response,
+            ..
+        }) => {
             let error = serde_json::from_str::<serde_json::Value>(&response)
                 .unwrap_or_else(|e| panic!("invalid json {:?}: {}", response, e));
-            let tag = error.as_object()
+            let tag = error
+                .as_object()
                 .and_then(|map| map.get("error"))
                 .and_then(|v| v.as_object())
                 .and_then(|map| map.get(".tag"))

--- a/tests/sync_client_test.rs
+++ b/tests/sync_client_test.rs
@@ -1,7 +1,7 @@
-use std::io::Cursor;
-use dropbox_sdk::sync_routes::check;
 use dropbox_sdk::client_trait::*;
+use dropbox_sdk::sync_routes::check;
 use dropbox_sdk::Error;
+use std::io::Cursor;
 
 struct TestSyncClient;
 struct TestRequest {
@@ -22,12 +22,17 @@ impl HttpClient for TestSyncClient {
                     body: Box::new(Cursor::new(format!(r#"{{"result":"{}"}}"#, arg.query))),
                 })
             }
-            _ => Err(Error::HttpClient(Box::new(std::io::Error::other(format!("unhandled URL {}", request.url))))),
+            _ => Err(Error::HttpClient(Box::new(std::io::Error::other(format!(
+                "unhandled URL {}",
+                request.url
+            ))))),
         }
     }
 
     fn new_request(&self, url: &str) -> Self::Request {
-        TestRequest{ url: url.to_owned() }
+        TestRequest {
+            url: url.to_owned(),
+        }
     }
 }
 


### PR DESCRIPTION
I personally disagree with several of rustfmt's decisions, but it's better to be consistent.

Generated code isn't being formatted because
1) it would have to get reformatted every time it gets generated; I'm
   not going to make the generator emit it so it matches rustfmt
2) rustfmt currently chokes on some of the generated code

<!--
Thank you for your pull request. Please provide a description below.
-->

## **Checklist**

**General Contributing**
<!-- Change [ ] to [x] if you have: -->
- [x] I have read the Code of Conduct and signed the [CLA](https://opensource.dropbox.com/cla/).
- [x] I have added an entry to the `RELEASE_NOTES.md` file, or believe it's not necessary for this change.

**Validation**
<!-- Describe which tests cover the changes you've made, and any additional manual validation you
     did to ensure the correctness of this change. Does this change warrant addition of new tests?
     Does this change have performance implications? Etc. -->
existing automated tests