### PR TITLE
rustfmt modules included from if_feature! macro

### DIFF
--- a/.github/workflows/cargo-test.yml
+++ b/.github/workflows/cargo-test.yml
@@ -20,9 +20,7 @@ jobs:
 
       - name: Run rustfmt
         run: |
-          echo "// empty module for rustfmt" > tests/generated.rs
-          rustup run nightly cargo fmt --check
-          rm tests/generated.rs
+          find . -path ./src/generated -prune -o -name '*.rs' -print | xargs rustup run nightly rustfmt --edition 2021 --check
 
       - name: Set up Python
         uses: actions/setup-python@v5.3.0


### PR DESCRIPTION
rustfmt has a known limitation (https://github.com/rust-lang/rustfmt/issues/3253) that modules declared inside macros are not processed when using 'cargo fmt'. So instead, let's brute-force 'find' all applicable rust sources and call rustfmt directly.

<!--
Thank you for your pull request. Please provide a description below.
-->

## **Checklist**

**General Contributing**
<!-- Change [ ] to [x] if you have: -->
- [x] I have read the Code of Conduct and signed the [CLA](https://opensource.dropbox.com/cla/).
- [x] I have added an entry to the `RELEASE_NOTES.md` file, or believe it's not necessary for this change.

**Validation**
<!-- Describe which tests cover the changes you've made, and any additional manual validation you
     did to ensure the correctness of this change. Does this change warrant addition of new tests?
     Does this change have performance implications? Etc. -->
review