### PR TITLE
correct some inconsistent match bindings

### DIFF
--- a/src/generated/types/account.rs
+++ b/src/generated/types/account.rs
@@ -57,8 +57,8 @@ impl ::serde::ser::Serialize for PhotoSourceArg {
     fn serialize<S: ::serde::ser::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
         // union serializer
         use serde::ser::SerializeStruct;
-        match *self {
-            PhotoSourceArg::Base64Data(ref x) => {
+        match self {
+            PhotoSourceArg::Base64Data(x) => {
                 // primitive
                 let mut s = serializer.serialize_struct("PhotoSourceArg", 2)?;
                 s.serialize_field(".tag", "base64_data")?;
@@ -220,7 +220,7 @@ impl ::serde::ser::Serialize for SetProfilePhotoError {
     fn serialize<S: ::serde::ser::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
         // union serializer
         use serde::ser::SerializeStruct;
-        match *self {
+        match self {
             SetProfilePhotoError::FileTypeError => {
                 // unit
                 let mut s = serializer.serialize_struct("SetProfilePhotoError", 1)?;

--- a/src/generated/types/auth.rs
+++ b/src/generated/types/auth.rs
@@ -68,15 +68,15 @@ impl ::serde::ser::Serialize for AccessError {
     fn serialize<S: ::serde::ser::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
         // union serializer
         use serde::ser::SerializeStruct;
-        match *self {
-            AccessError::InvalidAccountType(ref x) => {
+        match self {
+            AccessError::InvalidAccountType(x) => {
                 // union or polymporphic struct
                 let mut s = serializer.serialize_struct("AccessError", 2)?;
                 s.serialize_field(".tag", "invalid_account_type")?;
                 s.serialize_field("invalid_account_type", x)?;
                 s.end()
             }
-            AccessError::PaperAccessDenied(ref x) => {
+            AccessError::PaperAccessDenied(x) => {
                 // union or polymporphic struct
                 let mut s = serializer.serialize_struct("AccessError", 2)?;
                 s.serialize_field(".tag", "paper_access_denied")?;
@@ -176,7 +176,7 @@ impl ::serde::ser::Serialize for AuthError {
     fn serialize<S: ::serde::ser::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
         // union serializer
         use serde::ser::SerializeStruct;
-        match *self {
+        match self {
             AuthError::InvalidAccessToken => {
                 // unit
                 let mut s = serializer.serialize_struct("AuthError", 1)?;
@@ -207,7 +207,7 @@ impl ::serde::ser::Serialize for AuthError {
                 s.serialize_field(".tag", "expired_access_token")?;
                 s.end()
             }
-            AuthError::MissingScope(ref x) => {
+            AuthError::MissingScope(x) => {
                 // struct
                 let mut s = serializer.serialize_struct("AuthError", 2)?;
                 s.serialize_field(".tag", "missing_scope")?;
@@ -290,7 +290,7 @@ impl ::serde::ser::Serialize for InvalidAccountTypeError {
     fn serialize<S: ::serde::ser::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
         // union serializer
         use serde::ser::SerializeStruct;
-        match *self {
+        match self {
             InvalidAccountTypeError::Endpoint => {
                 // unit
                 let mut s = serializer.serialize_struct("InvalidAccountTypeError", 1)?;
@@ -368,7 +368,7 @@ impl ::serde::ser::Serialize for PaperAccessError {
     fn serialize<S: ::serde::ser::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
         // union serializer
         use serde::ser::SerializeStruct;
-        match *self {
+        match self {
             PaperAccessError::PaperDisabled => {
                 // unit
                 let mut s = serializer.serialize_struct("PaperAccessError", 1)?;
@@ -558,7 +558,7 @@ impl ::serde::ser::Serialize for RateLimitReason {
     fn serialize<S: ::serde::ser::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
         // union serializer
         use serde::ser::SerializeStruct;
-        match *self {
+        match self {
             RateLimitReason::TooManyRequests => {
                 // unit
                 let mut s = serializer.serialize_struct("RateLimitReason", 1)?;
@@ -737,7 +737,7 @@ impl ::serde::ser::Serialize for TokenFromOAuth1Error {
     fn serialize<S: ::serde::ser::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
         // union serializer
         use serde::ser::SerializeStruct;
-        match *self {
+        match self {
             TokenFromOAuth1Error::InvalidOauth1TokenInfo => {
                 // unit
                 let mut s = serializer.serialize_struct("TokenFromOAuth1Error", 1)?;

--- a/src/generated/types/common.rs
+++ b/src/generated/types/common.rs
@@ -86,21 +86,21 @@ impl ::serde::ser::Serialize for PathRoot {
     fn serialize<S: ::serde::ser::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
         // union serializer
         use serde::ser::SerializeStruct;
-        match *self {
+        match self {
             PathRoot::Home => {
                 // unit
                 let mut s = serializer.serialize_struct("PathRoot", 1)?;
                 s.serialize_field(".tag", "home")?;
                 s.end()
             }
-            PathRoot::Root(ref x) => {
+            PathRoot::Root(x) => {
                 // primitive
                 let mut s = serializer.serialize_struct("PathRoot", 2)?;
                 s.serialize_field(".tag", "root")?;
                 s.serialize_field("root", x)?;
                 s.end()
             }
-            PathRoot::NamespaceId(ref x) => {
+            PathRoot::NamespaceId(x) => {
                 // primitive
                 let mut s = serializer.serialize_struct("PathRoot", 2)?;
                 s.serialize_field(".tag", "namespace_id")?;
@@ -166,8 +166,8 @@ impl ::serde::ser::Serialize for PathRootError {
     fn serialize<S: ::serde::ser::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
         // union serializer
         use serde::ser::SerializeStruct;
-        match *self {
-            PathRootError::InvalidRoot(ref x) => {
+        match self {
+            PathRootError::InvalidRoot(x) => {
                 // union or polymporphic struct
                 let mut s = serializer.serialize_struct("PathRootError", 2)?;
                 s.serialize_field(".tag", "invalid_root")?;
@@ -244,14 +244,14 @@ impl ::serde::ser::Serialize for RootInfo {
     fn serialize<S: ::serde::ser::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
         // polymorphic struct serializer
         use serde::ser::SerializeStruct;
-        match *self {
-            RootInfo::Team(ref x) => {
+        match self {
+            RootInfo::Team(x) => {
                 let mut s = serializer.serialize_struct("RootInfo", 4)?;
                 s.serialize_field(".tag", "team")?;
                 x.internal_serialize::<S>(&mut s)?;
                 s.end()
             }
-            RootInfo::User(ref x) => {
+            RootInfo::User(x) => {
                 let mut s = serializer.serialize_struct("RootInfo", 3)?;
                 s.serialize_field(".tag", "user")?;
                 x.internal_serialize::<S>(&mut s)?;

--- a/src/generated/types/contacts.rs
+++ b/src/generated/types/contacts.rs
@@ -149,8 +149,8 @@ impl ::serde::ser::Serialize for DeleteManualContactsError {
     fn serialize<S: ::serde::ser::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
         // union serializer
         use serde::ser::SerializeStruct;
-        match *self {
-            DeleteManualContactsError::ContactsNotFound(ref x) => {
+        match self {
+            DeleteManualContactsError::ContactsNotFound(x) => {
                 // primitive
                 let mut s = serializer.serialize_struct("DeleteManualContactsError", 2)?;
                 s.serialize_field(".tag", "contacts_not_found")?;

--- a/src/generated/types/dbx_async.rs
+++ b/src/generated/types/dbx_async.rs
@@ -61,8 +61,8 @@ impl ::serde::ser::Serialize for LaunchEmptyResult {
     fn serialize<S: ::serde::ser::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
         // union serializer
         use serde::ser::SerializeStruct;
-        match *self {
-            LaunchEmptyResult::AsyncJobId(ref x) => {
+        match self {
+            LaunchEmptyResult::AsyncJobId(x) => {
                 // primitive
                 let mut s = serializer.serialize_struct("LaunchEmptyResult", 2)?;
                 s.serialize_field(".tag", "async_job_id")?;
@@ -136,8 +136,8 @@ impl ::serde::ser::Serialize for LaunchResultBase {
     fn serialize<S: ::serde::ser::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
         // union serializer
         use serde::ser::SerializeStruct;
-        match *self {
-            LaunchResultBase::AsyncJobId(ref x) => {
+        match self {
+            LaunchResultBase::AsyncJobId(x) => {
                 // primitive
                 let mut s = serializer.serialize_struct("LaunchResultBase", 2)?;
                 s.serialize_field(".tag", "async_job_id")?;
@@ -285,7 +285,7 @@ impl ::serde::ser::Serialize for PollEmptyResult {
     fn serialize<S: ::serde::ser::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
         // union serializer
         use serde::ser::SerializeStruct;
-        match *self {
+        match self {
             PollEmptyResult::InProgress => {
                 // unit
                 let mut s = serializer.serialize_struct("PollEmptyResult", 1)?;
@@ -359,7 +359,7 @@ impl ::serde::ser::Serialize for PollError {
     fn serialize<S: ::serde::ser::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
         // union serializer
         use serde::ser::SerializeStruct;
-        match *self {
+        match self {
             PollError::InvalidAsyncJobId => {
                 // unit
                 let mut s = serializer.serialize_struct("PollError", 1)?;
@@ -431,7 +431,7 @@ impl ::serde::ser::Serialize for PollResultBase {
     fn serialize<S: ::serde::ser::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
         // union serializer
         use serde::ser::SerializeStruct;
-        match *self {
+        match self {
             PollResultBase::InProgress => {
                 // unit
                 let mut s = serializer.serialize_struct("PollResultBase", 1)?;

--- a/src/generated/types/file_properties.rs
+++ b/src/generated/types/file_properties.rs
@@ -231,8 +231,8 @@ impl ::serde::ser::Serialize for AddPropertiesError {
     fn serialize<S: ::serde::ser::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
         // union serializer
         use serde::ser::SerializeStruct;
-        match *self {
-            AddPropertiesError::TemplateNotFound(ref x) => {
+        match self {
+            AddPropertiesError::TemplateNotFound(x) => {
                 // primitive
                 let mut s = serializer.serialize_struct("AddPropertiesError", 2)?;
                 s.serialize_field(".tag", "template_not_found")?;
@@ -245,7 +245,7 @@ impl ::serde::ser::Serialize for AddPropertiesError {
                 s.serialize_field(".tag", "restricted_content")?;
                 s.end()
             }
-            AddPropertiesError::Path(ref x) => {
+            AddPropertiesError::Path(x) => {
                 // union or polymporphic struct
                 let mut s = serializer.serialize_struct("AddPropertiesError", 2)?;
                 s.serialize_field(".tag", "path")?;
@@ -847,8 +847,8 @@ impl ::serde::ser::Serialize for InvalidPropertyGroupError {
     fn serialize<S: ::serde::ser::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
         // union serializer
         use serde::ser::SerializeStruct;
-        match *self {
-            InvalidPropertyGroupError::TemplateNotFound(ref x) => {
+        match self {
+            InvalidPropertyGroupError::TemplateNotFound(x) => {
                 // primitive
                 let mut s = serializer.serialize_struct("InvalidPropertyGroupError", 2)?;
                 s.serialize_field(".tag", "template_not_found")?;
@@ -861,7 +861,7 @@ impl ::serde::ser::Serialize for InvalidPropertyGroupError {
                 s.serialize_field(".tag", "restricted_content")?;
                 s.end()
             }
-            InvalidPropertyGroupError::Path(ref x) => {
+            InvalidPropertyGroupError::Path(x) => {
                 // union or polymporphic struct
                 let mut s = serializer.serialize_struct("InvalidPropertyGroupError", 2)?;
                 s.serialize_field(".tag", "path")?;
@@ -1070,7 +1070,7 @@ impl ::serde::ser::Serialize for LogicalOperator {
     fn serialize<S: ::serde::ser::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
         // union serializer
         use serde::ser::SerializeStruct;
-        match *self {
+        match self {
             LogicalOperator::OrOperator => {
                 // unit
                 let mut s = serializer.serialize_struct("LogicalOperator", 1)?;
@@ -1125,7 +1125,7 @@ impl ::serde::ser::Serialize for LookUpPropertiesError {
     fn serialize<S: ::serde::ser::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
         // union serializer
         use serde::ser::SerializeStruct;
-        match *self {
+        match self {
             LookUpPropertiesError::PropertyGroupNotFound => {
                 // unit
                 let mut s = serializer.serialize_struct("LookUpPropertiesError", 1)?;
@@ -1214,8 +1214,8 @@ impl ::serde::ser::Serialize for LookupError {
     fn serialize<S: ::serde::ser::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
         // union serializer
         use serde::ser::SerializeStruct;
-        match *self {
-            LookupError::MalformedPath(ref x) => {
+        match self {
+            LookupError::MalformedPath(x) => {
                 // primitive
                 let mut s = serializer.serialize_struct("LookupError", 2)?;
                 s.serialize_field(".tag", "malformed_path")?;
@@ -1337,8 +1337,8 @@ impl ::serde::ser::Serialize for ModifyTemplateError {
     fn serialize<S: ::serde::ser::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
         // union serializer
         use serde::ser::SerializeStruct;
-        match *self {
-            ModifyTemplateError::TemplateNotFound(ref x) => {
+        match self {
+            ModifyTemplateError::TemplateNotFound(x) => {
                 // primitive
                 let mut s = serializer.serialize_struct("ModifyTemplateError", 2)?;
                 s.serialize_field(".tag", "template_not_found")?;
@@ -1578,8 +1578,8 @@ impl ::serde::ser::Serialize for PropertiesError {
     fn serialize<S: ::serde::ser::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
         // union serializer
         use serde::ser::SerializeStruct;
-        match *self {
-            PropertiesError::TemplateNotFound(ref x) => {
+        match self {
+            PropertiesError::TemplateNotFound(x) => {
                 // primitive
                 let mut s = serializer.serialize_struct("PropertiesError", 2)?;
                 s.serialize_field(".tag", "template_not_found")?;
@@ -1592,7 +1592,7 @@ impl ::serde::ser::Serialize for PropertiesError {
                 s.serialize_field(".tag", "restricted_content")?;
                 s.end()
             }
-            PropertiesError::Path(ref x) => {
+            PropertiesError::Path(x) => {
                 // union or polymporphic struct
                 let mut s = serializer.serialize_struct("PropertiesError", 2)?;
                 s.serialize_field(".tag", "path")?;
@@ -1889,7 +1889,7 @@ impl ::serde::ser::Serialize for PropertiesSearchContinueError {
     fn serialize<S: ::serde::ser::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
         // union serializer
         use serde::ser::SerializeStruct;
-        match *self {
+        match self {
             PropertiesSearchContinueError::Reset => {
                 // unit
                 let mut s = serializer.serialize_struct("PropertiesSearchContinueError", 1)?;
@@ -1958,8 +1958,8 @@ impl ::serde::ser::Serialize for PropertiesSearchError {
     fn serialize<S: ::serde::ser::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
         // union serializer
         use serde::ser::SerializeStruct;
-        match *self {
-            PropertiesSearchError::PropertyGroupLookup(ref x) => {
+        match self {
+            PropertiesSearchError::PropertyGroupLookup(x) => {
                 // union or polymporphic struct
                 let mut s = serializer.serialize_struct("PropertiesSearchError", 2)?;
                 s.serialize_field(".tag", "property_group_lookup")?;
@@ -2173,8 +2173,8 @@ impl ::serde::ser::Serialize for PropertiesSearchMode {
     fn serialize<S: ::serde::ser::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
         // union serializer
         use serde::ser::SerializeStruct;
-        match *self {
-            PropertiesSearchMode::FieldName(ref x) => {
+        match self {
+            PropertiesSearchMode::FieldName(x) => {
                 // primitive
                 let mut s = serializer.serialize_struct("PropertiesSearchMode", 2)?;
                 s.serialize_field(".tag", "field_name")?;
@@ -3053,7 +3053,7 @@ impl ::serde::ser::Serialize for PropertyType {
     fn serialize<S: ::serde::ser::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
         // union serializer
         use serde::ser::SerializeStruct;
-        match *self {
+        match self {
             PropertyType::String => {
                 // unit
                 let mut s = serializer.serialize_struct("PropertyType", 1)?;
@@ -3246,8 +3246,8 @@ impl ::serde::ser::Serialize for RemovePropertiesError {
     fn serialize<S: ::serde::ser::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
         // union serializer
         use serde::ser::SerializeStruct;
-        match *self {
-            RemovePropertiesError::TemplateNotFound(ref x) => {
+        match self {
+            RemovePropertiesError::TemplateNotFound(x) => {
                 // primitive
                 let mut s = serializer.serialize_struct("RemovePropertiesError", 2)?;
                 s.serialize_field(".tag", "template_not_found")?;
@@ -3260,7 +3260,7 @@ impl ::serde::ser::Serialize for RemovePropertiesError {
                 s.serialize_field(".tag", "restricted_content")?;
                 s.end()
             }
-            RemovePropertiesError::Path(ref x) => {
+            RemovePropertiesError::Path(x) => {
                 // union or polymporphic struct
                 let mut s = serializer.serialize_struct("RemovePropertiesError", 2)?;
                 s.serialize_field(".tag", "path")?;
@@ -3273,7 +3273,7 @@ impl ::serde::ser::Serialize for RemovePropertiesError {
                 s.serialize_field(".tag", "unsupported_folder")?;
                 s.end()
             }
-            RemovePropertiesError::PropertyGroupLookup(ref x) => {
+            RemovePropertiesError::PropertyGroupLookup(x) => {
                 // union or polymporphic struct
                 let mut s = serializer.serialize_struct("RemovePropertiesError", 2)?;
                 s.serialize_field(".tag", "property_group_lookup")?;
@@ -3466,8 +3466,8 @@ impl ::serde::ser::Serialize for TemplateError {
     fn serialize<S: ::serde::ser::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
         // union serializer
         use serde::ser::SerializeStruct;
-        match *self {
-            TemplateError::TemplateNotFound(ref x) => {
+        match self {
+            TemplateError::TemplateNotFound(x) => {
                 // primitive
                 let mut s = serializer.serialize_struct("TemplateError", 2)?;
                 s.serialize_field(".tag", "template_not_found")?;
@@ -3552,8 +3552,8 @@ impl ::serde::ser::Serialize for TemplateFilter {
     fn serialize<S: ::serde::ser::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
         // union serializer
         use serde::ser::SerializeStruct;
-        match *self {
-            TemplateFilter::FilterSome(ref x) => {
+        match self {
+            TemplateFilter::FilterSome(x) => {
                 // primitive
                 let mut s = serializer.serialize_struct("TemplateFilter", 2)?;
                 s.serialize_field(".tag", "filter_some")?;
@@ -3630,8 +3630,8 @@ impl ::serde::ser::Serialize for TemplateFilterBase {
     fn serialize<S: ::serde::ser::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
         // union serializer
         use serde::ser::SerializeStruct;
-        match *self {
-            TemplateFilterBase::FilterSome(ref x) => {
+        match self {
+            TemplateFilterBase::FilterSome(x) => {
                 // primitive
                 let mut s = serializer.serialize_struct("TemplateFilterBase", 2)?;
                 s.serialize_field(".tag", "filter_some")?;
@@ -3690,7 +3690,7 @@ impl ::serde::ser::Serialize for TemplateOwnerType {
     fn serialize<S: ::serde::ser::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
         // union serializer
         use serde::ser::SerializeStruct;
-        match *self {
+        match self {
             TemplateOwnerType::User => {
                 // unit
                 let mut s = serializer.serialize_struct("TemplateOwnerType", 1)?;
@@ -3899,8 +3899,8 @@ impl ::serde::ser::Serialize for UpdatePropertiesError {
     fn serialize<S: ::serde::ser::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
         // union serializer
         use serde::ser::SerializeStruct;
-        match *self {
-            UpdatePropertiesError::TemplateNotFound(ref x) => {
+        match self {
+            UpdatePropertiesError::TemplateNotFound(x) => {
                 // primitive
                 let mut s = serializer.serialize_struct("UpdatePropertiesError", 2)?;
                 s.serialize_field(".tag", "template_not_found")?;
@@ -3913,7 +3913,7 @@ impl ::serde::ser::Serialize for UpdatePropertiesError {
                 s.serialize_field(".tag", "restricted_content")?;
                 s.end()
             }
-            UpdatePropertiesError::Path(ref x) => {
+            UpdatePropertiesError::Path(x) => {
                 // union or polymporphic struct
                 let mut s = serializer.serialize_struct("UpdatePropertiesError", 2)?;
                 s.serialize_field(".tag", "path")?;
@@ -3944,7 +3944,7 @@ impl ::serde::ser::Serialize for UpdatePropertiesError {
                 s.serialize_field(".tag", "duplicate_property_groups")?;
                 s.end()
             }
-            UpdatePropertiesError::PropertyGroupLookup(ref x) => {
+            UpdatePropertiesError::PropertyGroupLookup(x) => {
                 // union or polymporphic struct
                 let mut s = serializer.serialize_struct("UpdatePropertiesError", 2)?;
                 s.serialize_field(".tag", "property_group_lookup")?;

--- a/src/generated/types/file_requests.rs
+++ b/src/generated/types/file_requests.rs
@@ -57,7 +57,7 @@ impl ::serde::ser::Serialize for CountFileRequestsError {
     fn serialize<S: ::serde::ser::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
         // union serializer
         use serde::ser::SerializeStruct;
-        match *self {
+        match self {
             CountFileRequestsError::DisabledForTeam => {
                 // unit
                 let mut s = serializer.serialize_struct("CountFileRequestsError", 1)?;
@@ -431,7 +431,7 @@ impl ::serde::ser::Serialize for CreateFileRequestError {
     fn serialize<S: ::serde::ser::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
         // union serializer
         use serde::ser::SerializeStruct;
-        match *self {
+        match self {
             CreateFileRequestError::DisabledForTeam => {
                 // unit
                 let mut s = serializer.serialize_struct("CreateFileRequestError", 1)?;
@@ -597,7 +597,7 @@ impl ::serde::ser::Serialize for DeleteAllClosedFileRequestsError {
     fn serialize<S: ::serde::ser::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
         // union serializer
         use serde::ser::SerializeStruct;
-        match *self {
+        match self {
             DeleteAllClosedFileRequestsError::DisabledForTeam => {
                 // unit
                 let mut s = serializer.serialize_struct("DeleteAllClosedFileRequestsError", 1)?;
@@ -937,7 +937,7 @@ impl ::serde::ser::Serialize for DeleteFileRequestError {
     fn serialize<S: ::serde::ser::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
         // union serializer
         use serde::ser::SerializeStruct;
-        match *self {
+        match self {
             DeleteFileRequestError::DisabledForTeam => {
                 // unit
                 let mut s = serializer.serialize_struct("DeleteFileRequestError", 1)?;
@@ -1528,7 +1528,7 @@ impl ::serde::ser::Serialize for FileRequestError {
     fn serialize<S: ::serde::ser::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
         // union serializer
         use serde::ser::SerializeStruct;
-        match *self {
+        match self {
             FileRequestError::DisabledForTeam => {
                 // unit
                 let mut s = serializer.serialize_struct("FileRequestError", 1)?;
@@ -1646,7 +1646,7 @@ impl ::serde::ser::Serialize for GeneralFileRequestsError {
     fn serialize<S: ::serde::ser::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
         // union serializer
         use serde::ser::SerializeStruct;
-        match *self {
+        match self {
             GeneralFileRequestsError::DisabledForTeam => {
                 // unit
                 let mut s = serializer.serialize_struct("GeneralFileRequestsError", 1)?;
@@ -1834,7 +1834,7 @@ impl ::serde::ser::Serialize for GetFileRequestError {
     fn serialize<S: ::serde::ser::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
         // union serializer
         use serde::ser::SerializeStruct;
-        match *self {
+        match self {
             GetFileRequestError::DisabledForTeam => {
                 // unit
                 let mut s = serializer.serialize_struct("GetFileRequestError", 1)?;
@@ -1968,7 +1968,7 @@ impl ::serde::ser::Serialize for GracePeriod {
     fn serialize<S: ::serde::ser::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
         // union serializer
         use serde::ser::SerializeStruct;
-        match *self {
+        match self {
             GracePeriod::OneDay => {
                 // unit
                 let mut s = serializer.serialize_struct("GracePeriod", 1)?;
@@ -2233,7 +2233,7 @@ impl ::serde::ser::Serialize for ListFileRequestsContinueError {
     fn serialize<S: ::serde::ser::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
         // union serializer
         use serde::ser::SerializeStruct;
-        match *self {
+        match self {
             ListFileRequestsContinueError::DisabledForTeam => {
                 // unit
                 let mut s = serializer.serialize_struct("ListFileRequestsContinueError", 1)?;
@@ -2317,7 +2317,7 @@ impl ::serde::ser::Serialize for ListFileRequestsError {
     fn serialize<S: ::serde::ser::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
         // union serializer
         use serde::ser::SerializeStruct;
-        match *self {
+        match self {
             ListFileRequestsError::DisabledForTeam => {
                 // unit
                 let mut s = serializer.serialize_struct("ListFileRequestsError", 1)?;
@@ -2806,19 +2806,19 @@ impl ::serde::ser::Serialize for UpdateFileRequestDeadline {
     fn serialize<S: ::serde::ser::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
         // union serializer
         use serde::ser::SerializeStruct;
-        match *self {
+        match self {
             UpdateFileRequestDeadline::NoUpdate => {
                 // unit
                 let mut s = serializer.serialize_struct("UpdateFileRequestDeadline", 1)?;
                 s.serialize_field(".tag", "no_update")?;
                 s.end()
             }
-            UpdateFileRequestDeadline::Update(ref x) => {
+            UpdateFileRequestDeadline::Update(x) => {
                 // nullable (struct or primitive)
                 let n = if x.is_some() { 4 } else { 1 };
                 let mut s = serializer.serialize_struct("UpdateFileRequestDeadline", n)?;
                 s.serialize_field(".tag", "update")?;
-                if let Some(ref x) = x {
+                if let Some(x) = x {
                     x.internal_serialize::<S>(&mut s)?;
                 }
                 s.end()
@@ -2900,7 +2900,7 @@ impl ::serde::ser::Serialize for UpdateFileRequestError {
     fn serialize<S: ::serde::ser::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
         // union serializer
         use serde::ser::SerializeStruct;
-        match *self {
+        match self {
             UpdateFileRequestError::DisabledForTeam => {
                 // unit
                 let mut s = serializer.serialize_struct("UpdateFileRequestError", 1)?;

--- a/src/generated/types/files.rs
+++ b/src/generated/types/files.rs
@@ -184,8 +184,8 @@ impl ::serde::ser::Serialize for AddTagError {
     fn serialize<S: ::serde::ser::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
         // union serializer
         use serde::ser::SerializeStruct;
-        match *self {
-            AddTagError::Path(ref x) => {
+        match self {
+            AddTagError::Path(x) => {
                 // union or polymporphic struct
                 let mut s = serializer.serialize_struct("AddTagError", 2)?;
                 s.serialize_field(".tag", "path")?;
@@ -496,15 +496,15 @@ impl ::serde::ser::Serialize for AlphaGetMetadataError {
     fn serialize<S: ::serde::ser::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
         // union serializer
         use serde::ser::SerializeStruct;
-        match *self {
-            AlphaGetMetadataError::Path(ref x) => {
+        match self {
+            AlphaGetMetadataError::Path(x) => {
                 // union or polymporphic struct
                 let mut s = serializer.serialize_struct("AlphaGetMetadataError", 2)?;
                 s.serialize_field(".tag", "path")?;
                 s.serialize_field("path", x)?;
                 s.end()
             }
-            AlphaGetMetadataError::PropertiesError(ref x) => {
+            AlphaGetMetadataError::PropertiesError(x) => {
                 // union or polymporphic struct
                 let mut s = serializer.serialize_struct("AlphaGetMetadataError", 2)?;
                 s.serialize_field(".tag", "properties_error")?;
@@ -589,8 +589,8 @@ impl ::serde::ser::Serialize for BaseTagError {
     fn serialize<S: ::serde::ser::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
         // union serializer
         use serde::ser::SerializeStruct;
-        match *self {
-            BaseTagError::Path(ref x) => {
+        match self {
+            BaseTagError::Path(x) => {
                 // union or polymporphic struct
                 let mut s = serializer.serialize_struct("BaseTagError", 2)?;
                 s.serialize_field(".tag", "path")?;
@@ -1339,7 +1339,7 @@ impl ::serde::ser::Serialize for CreateFolderBatchError {
     fn serialize<S: ::serde::ser::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
         // union serializer
         use serde::ser::SerializeStruct;
-        match *self {
+        match self {
             CreateFolderBatchError::TooManyFiles => {
                 // unit
                 let mut s = serializer.serialize_struct("CreateFolderBatchError", 1)?;
@@ -1420,21 +1420,21 @@ impl ::serde::ser::Serialize for CreateFolderBatchJobStatus {
     fn serialize<S: ::serde::ser::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
         // union serializer
         use serde::ser::SerializeStruct;
-        match *self {
+        match self {
             CreateFolderBatchJobStatus::InProgress => {
                 // unit
                 let mut s = serializer.serialize_struct("CreateFolderBatchJobStatus", 1)?;
                 s.serialize_field(".tag", "in_progress")?;
                 s.end()
             }
-            CreateFolderBatchJobStatus::Complete(ref x) => {
+            CreateFolderBatchJobStatus::Complete(x) => {
                 // struct
                 let mut s = serializer.serialize_struct("CreateFolderBatchJobStatus", 2)?;
                 s.serialize_field(".tag", "complete")?;
                 x.internal_serialize::<S>(&mut s)?;
                 s.end()
             }
-            CreateFolderBatchJobStatus::Failed(ref x) => {
+            CreateFolderBatchJobStatus::Failed(x) => {
                 // union or polymporphic struct
                 let mut s = serializer.serialize_struct("CreateFolderBatchJobStatus", 2)?;
                 s.serialize_field(".tag", "failed")?;
@@ -1509,15 +1509,15 @@ impl ::serde::ser::Serialize for CreateFolderBatchLaunch {
     fn serialize<S: ::serde::ser::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
         // union serializer
         use serde::ser::SerializeStruct;
-        match *self {
-            CreateFolderBatchLaunch::AsyncJobId(ref x) => {
+        match self {
+            CreateFolderBatchLaunch::AsyncJobId(x) => {
                 // primitive
                 let mut s = serializer.serialize_struct("CreateFolderBatchLaunch", 2)?;
                 s.serialize_field(".tag", "async_job_id")?;
                 s.serialize_field("async_job_id", x)?;
                 s.end()
             }
-            CreateFolderBatchLaunch::Complete(ref x) => {
+            CreateFolderBatchLaunch::Complete(x) => {
                 // struct
                 let mut s = serializer.serialize_struct("CreateFolderBatchLaunch", 2)?;
                 s.serialize_field(".tag", "complete")?;
@@ -1681,15 +1681,15 @@ impl ::serde::ser::Serialize for CreateFolderBatchResultEntry {
     fn serialize<S: ::serde::ser::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
         // union serializer
         use serde::ser::SerializeStruct;
-        match *self {
-            CreateFolderBatchResultEntry::Success(ref x) => {
+        match self {
+            CreateFolderBatchResultEntry::Success(x) => {
                 // struct
                 let mut s = serializer.serialize_struct("CreateFolderBatchResultEntry", 2)?;
                 s.serialize_field(".tag", "success")?;
                 x.internal_serialize::<S>(&mut s)?;
                 s.end()
             }
-            CreateFolderBatchResultEntry::Failure(ref x) => {
+            CreateFolderBatchResultEntry::Failure(x) => {
                 // union or polymporphic struct
                 let mut s = serializer.serialize_struct("CreateFolderBatchResultEntry", 2)?;
                 s.serialize_field(".tag", "failure")?;
@@ -1748,8 +1748,8 @@ impl ::serde::ser::Serialize for CreateFolderEntryError {
     fn serialize<S: ::serde::ser::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
         // union serializer
         use serde::ser::SerializeStruct;
-        match *self {
-            CreateFolderEntryError::Path(ref x) => {
+        match self {
+            CreateFolderEntryError::Path(x) => {
                 // union or polymporphic struct
                 let mut s = serializer.serialize_struct("CreateFolderEntryError", 2)?;
                 s.serialize_field(".tag", "path")?;
@@ -1913,8 +1913,8 @@ impl ::serde::ser::Serialize for CreateFolderError {
     fn serialize<S: ::serde::ser::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
         // union serializer
         use serde::ser::SerializeStruct;
-        match *self {
-            CreateFolderError::Path(ref x) => {
+        match self {
+            CreateFolderError::Path(x) => {
                 // union or polymporphic struct
                 let mut s = serializer.serialize_struct("CreateFolderError", 2)?;
                 s.serialize_field(".tag", "path")?;
@@ -2284,7 +2284,7 @@ impl ::serde::ser::Serialize for DeleteBatchError {
     fn serialize<S: ::serde::ser::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
         // union serializer
         use serde::ser::SerializeStruct;
-        match *self {
+        match self {
             DeleteBatchError::TooManyWriteOperations => {
                 // unit
                 let mut s = serializer.serialize_struct("DeleteBatchError", 1)?;
@@ -2362,21 +2362,21 @@ impl ::serde::ser::Serialize for DeleteBatchJobStatus {
     fn serialize<S: ::serde::ser::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
         // union serializer
         use serde::ser::SerializeStruct;
-        match *self {
+        match self {
             DeleteBatchJobStatus::InProgress => {
                 // unit
                 let mut s = serializer.serialize_struct("DeleteBatchJobStatus", 1)?;
                 s.serialize_field(".tag", "in_progress")?;
                 s.end()
             }
-            DeleteBatchJobStatus::Complete(ref x) => {
+            DeleteBatchJobStatus::Complete(x) => {
                 // struct
                 let mut s = serializer.serialize_struct("DeleteBatchJobStatus", 2)?;
                 s.serialize_field(".tag", "complete")?;
                 x.internal_serialize::<S>(&mut s)?;
                 s.end()
             }
-            DeleteBatchJobStatus::Failed(ref x) => {
+            DeleteBatchJobStatus::Failed(x) => {
                 // union or polymporphic struct
                 let mut s = serializer.serialize_struct("DeleteBatchJobStatus", 2)?;
                 s.serialize_field(".tag", "failed")?;
@@ -2451,15 +2451,15 @@ impl ::serde::ser::Serialize for DeleteBatchLaunch {
     fn serialize<S: ::serde::ser::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
         // union serializer
         use serde::ser::SerializeStruct;
-        match *self {
-            DeleteBatchLaunch::AsyncJobId(ref x) => {
+        match self {
+            DeleteBatchLaunch::AsyncJobId(x) => {
                 // primitive
                 let mut s = serializer.serialize_struct("DeleteBatchLaunch", 2)?;
                 s.serialize_field(".tag", "async_job_id")?;
                 s.serialize_field("async_job_id", x)?;
                 s.end()
             }
-            DeleteBatchLaunch::Complete(ref x) => {
+            DeleteBatchLaunch::Complete(x) => {
                 // struct
                 let mut s = serializer.serialize_struct("DeleteBatchLaunch", 2)?;
                 s.serialize_field(".tag", "complete")?;
@@ -2714,15 +2714,15 @@ impl ::serde::ser::Serialize for DeleteBatchResultEntry {
     fn serialize<S: ::serde::ser::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
         // union serializer
         use serde::ser::SerializeStruct;
-        match *self {
-            DeleteBatchResultEntry::Success(ref x) => {
+        match self {
+            DeleteBatchResultEntry::Success(x) => {
                 // struct
                 let mut s = serializer.serialize_struct("DeleteBatchResultEntry", 2)?;
                 s.serialize_field(".tag", "success")?;
                 x.internal_serialize::<S>(&mut s)?;
                 s.end()
             }
-            DeleteBatchResultEntry::Failure(ref x) => {
+            DeleteBatchResultEntry::Failure(x) => {
                 // union or polymporphic struct
                 let mut s = serializer.serialize_struct("DeleteBatchResultEntry", 2)?;
                 s.serialize_field(".tag", "failure")?;
@@ -2798,15 +2798,15 @@ impl ::serde::ser::Serialize for DeleteError {
     fn serialize<S: ::serde::ser::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
         // union serializer
         use serde::ser::SerializeStruct;
-        match *self {
-            DeleteError::PathLookup(ref x) => {
+        match self {
+            DeleteError::PathLookup(x) => {
                 // union or polymporphic struct
                 let mut s = serializer.serialize_struct("DeleteError", 2)?;
                 s.serialize_field(".tag", "path_lookup")?;
                 s.serialize_field("path_lookup", x)?;
                 s.end()
             }
-            DeleteError::PathWrite(ref x) => {
+            DeleteError::PathWrite(x) => {
                 // union or polymporphic struct
                 let mut s = serializer.serialize_struct("DeleteError", 2)?;
                 s.serialize_field(".tag", "path_write")?;
@@ -3406,8 +3406,8 @@ impl ::serde::ser::Serialize for DownloadError {
     fn serialize<S: ::serde::ser::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
         // union serializer
         use serde::ser::SerializeStruct;
-        match *self {
-            DownloadError::Path(ref x) => {
+        match self {
+            DownloadError::Path(x) => {
                 // union or polymporphic struct
                 let mut s = serializer.serialize_struct("DownloadError", 2)?;
                 s.serialize_field(".tag", "path")?;
@@ -3590,8 +3590,8 @@ impl ::serde::ser::Serialize for DownloadZipError {
     fn serialize<S: ::serde::ser::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
         // union serializer
         use serde::ser::SerializeStruct;
-        match *self {
-            DownloadZipError::Path(ref x) => {
+        match self {
+            DownloadZipError::Path(x) => {
                 // union or polymporphic struct
                 let mut s = serializer.serialize_struct("DownloadZipError", 2)?;
                 s.serialize_field(".tag", "path")?;
@@ -3899,8 +3899,8 @@ impl ::serde::ser::Serialize for ExportError {
     fn serialize<S: ::serde::ser::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
         // union serializer
         use serde::ser::SerializeStruct;
-        match *self {
-            ExportError::Path(ref x) => {
+        match self {
+            ExportError::Path(x) => {
                 // union or polymporphic struct
                 let mut s = serializer.serialize_struct("ExportError", 2)?;
                 s.serialize_field(".tag", "path")?;
@@ -4382,7 +4382,7 @@ impl ::serde::ser::Serialize for FileCategory {
     fn serialize<S: ::serde::ser::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
         // union serializer
         use serde::ser::SerializeStruct;
-        match *self {
+        match self {
             FileCategory::Image => {
                 // unit
                 let mut s = serializer.serialize_struct("FileCategory", 1)?;
@@ -4586,14 +4586,14 @@ impl ::serde::ser::Serialize for FileLockContent {
     fn serialize<S: ::serde::ser::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
         // union serializer
         use serde::ser::SerializeStruct;
-        match *self {
+        match self {
             FileLockContent::Unlocked => {
                 // unit
                 let mut s = serializer.serialize_struct("FileLockContent", 1)?;
                 s.serialize_field(".tag", "unlocked")?;
                 s.end()
             }
-            FileLockContent::SingleUser(ref x) => {
+            FileLockContent::SingleUser(x) => {
                 // struct
                 let mut s = serializer.serialize_struct("FileLockContent", 4)?;
                 s.serialize_field(".tag", "single_user")?;
@@ -5429,7 +5429,7 @@ impl ::serde::ser::Serialize for FileStatus {
     fn serialize<S: ::serde::ser::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
         // union serializer
         use serde::ser::SerializeStruct;
-        match *self {
+        match self {
             FileStatus::Active => {
                 // unit
                 let mut s = serializer.serialize_struct("FileStatus", 1)?;
@@ -6038,8 +6038,8 @@ impl ::serde::ser::Serialize for GetCopyReferenceError {
     fn serialize<S: ::serde::ser::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
         // union serializer
         use serde::ser::SerializeStruct;
-        match *self {
-            GetCopyReferenceError::Path(ref x) => {
+        match self {
+            GetCopyReferenceError::Path(x) => {
                 // union or polymporphic struct
                 let mut s = serializer.serialize_struct("GetCopyReferenceError", 2)?;
                 s.serialize_field(".tag", "path")?;
@@ -6411,8 +6411,8 @@ impl ::serde::ser::Serialize for GetMetadataError {
     fn serialize<S: ::serde::ser::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
         // union serializer
         use serde::ser::SerializeStruct;
-        match *self {
-            GetMetadataError::Path(ref x) => {
+        match self {
+            GetMetadataError::Path(x) => {
                 // union or polymporphic struct
                 let mut s = serializer.serialize_struct("GetMetadataError", 2)?;
                 s.serialize_field(".tag", "path")?;
@@ -6776,8 +6776,8 @@ impl ::serde::ser::Serialize for GetTemporaryLinkError {
     fn serialize<S: ::serde::ser::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
         // union serializer
         use serde::ser::SerializeStruct;
-        match *self {
-            GetTemporaryLinkError::Path(ref x) => {
+        match self {
+            GetTemporaryLinkError::Path(x) => {
                 // union or polymporphic struct
                 let mut s = serializer.serialize_struct("GetTemporaryLinkError", 2)?;
                 s.serialize_field(".tag", "path")?;
@@ -7268,7 +7268,7 @@ impl ::serde::ser::Serialize for GetThumbnailBatchError {
     fn serialize<S: ::serde::ser::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
         // union serializer
         use serde::ser::SerializeStruct;
-        match *self {
+        match self {
             GetThumbnailBatchError::TooManyFiles => {
                 // unit
                 let mut s = serializer.serialize_struct("GetThumbnailBatchError", 1)?;
@@ -7538,15 +7538,15 @@ impl ::serde::ser::Serialize for GetThumbnailBatchResultEntry {
     fn serialize<S: ::serde::ser::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
         // union serializer
         use serde::ser::SerializeStruct;
-        match *self {
-            GetThumbnailBatchResultEntry::Success(ref x) => {
+        match self {
+            GetThumbnailBatchResultEntry::Success(x) => {
                 // struct
                 let mut s = serializer.serialize_struct("GetThumbnailBatchResultEntry", 3)?;
                 s.serialize_field(".tag", "success")?;
                 x.internal_serialize::<S>(&mut s)?;
                 s.end()
             }
-            GetThumbnailBatchResultEntry::Failure(ref x) => {
+            GetThumbnailBatchResultEntry::Failure(x) => {
                 // union or polymporphic struct
                 let mut s = serializer.serialize_struct("GetThumbnailBatchResultEntry", 2)?;
                 s.serialize_field(".tag", "failure")?;
@@ -7819,7 +7819,7 @@ impl ::serde::ser::Serialize for ImportFormat {
     fn serialize<S: ::serde::ser::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
         // union serializer
         use serde::ser::SerializeStruct;
-        match *self {
+        match self {
             ImportFormat::Html => {
                 // unit
                 let mut s = serializer.serialize_struct("ImportFormat", 1)?;
@@ -8271,8 +8271,8 @@ impl ::serde::ser::Serialize for ListFolderContinueError {
     fn serialize<S: ::serde::ser::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
         // union serializer
         use serde::ser::SerializeStruct;
-        match *self {
-            ListFolderContinueError::Path(ref x) => {
+        match self {
+            ListFolderContinueError::Path(x) => {
                 // union or polymporphic struct
                 let mut s = serializer.serialize_struct("ListFolderContinueError", 2)?;
                 s.serialize_field(".tag", "path")?;
@@ -8365,15 +8365,15 @@ impl ::serde::ser::Serialize for ListFolderError {
     fn serialize<S: ::serde::ser::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
         // union serializer
         use serde::ser::SerializeStruct;
-        match *self {
-            ListFolderError::Path(ref x) => {
+        match self {
+            ListFolderError::Path(x) => {
                 // union or polymporphic struct
                 let mut s = serializer.serialize_struct("ListFolderError", 2)?;
                 s.serialize_field(".tag", "path")?;
                 s.serialize_field("path", x)?;
                 s.end()
             }
-            ListFolderError::TemplateError(ref x) => {
+            ListFolderError::TemplateError(x) => {
                 // union or polymporphic struct
                 let mut s = serializer.serialize_struct("ListFolderError", 2)?;
                 s.serialize_field(".tag", "template_error")?;
@@ -8656,7 +8656,7 @@ impl ::serde::ser::Serialize for ListFolderLongpollError {
     fn serialize<S: ::serde::ser::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
         // union serializer
         use serde::ser::SerializeStruct;
-        match *self {
+        match self {
             ListFolderLongpollError::Reset => {
                 // unit
                 let mut s = serializer.serialize_struct("ListFolderLongpollError", 1)?;
@@ -9088,8 +9088,8 @@ impl ::serde::ser::Serialize for ListRevisionsError {
     fn serialize<S: ::serde::ser::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
         // union serializer
         use serde::ser::SerializeStruct;
-        match *self {
-            ListRevisionsError::Path(ref x) => {
+        match self {
+            ListRevisionsError::Path(x) => {
                 // union or polymporphic struct
                 let mut s = serializer.serialize_struct("ListRevisionsError", 2)?;
                 s.serialize_field(".tag", "path")?;
@@ -9168,7 +9168,7 @@ impl ::serde::ser::Serialize for ListRevisionsMode {
     fn serialize<S: ::serde::ser::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
         // union serializer
         use serde::ser::SerializeStruct;
-        match *self {
+        match self {
             ListRevisionsMode::Path => {
                 // unit
                 let mut s = serializer.serialize_struct("ListRevisionsMode", 1)?;
@@ -9760,8 +9760,8 @@ impl ::serde::ser::Serialize for LockFileError {
     fn serialize<S: ::serde::ser::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
         // union serializer
         use serde::ser::SerializeStruct;
-        match *self {
-            LockFileError::PathLookup(ref x) => {
+        match self {
+            LockFileError::PathLookup(x) => {
                 // union or polymporphic struct
                 let mut s = serializer.serialize_struct("LockFileError", 2)?;
                 s.serialize_field(".tag", "path_lookup")?;
@@ -9798,7 +9798,7 @@ impl ::serde::ser::Serialize for LockFileError {
                 s.serialize_field(".tag", "file_not_shared")?;
                 s.end()
             }
-            LockFileError::LockConflict(ref x) => {
+            LockFileError::LockConflict(x) => {
                 // struct
                 let mut s = serializer.serialize_struct("LockFileError", 2)?;
                 s.serialize_field(".tag", "lock_conflict")?;
@@ -9991,15 +9991,15 @@ impl ::serde::ser::Serialize for LockFileResultEntry {
     fn serialize<S: ::serde::ser::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
         // union serializer
         use serde::ser::SerializeStruct;
-        match *self {
-            LockFileResultEntry::Success(ref x) => {
+        match self {
+            LockFileResultEntry::Success(x) => {
                 // struct
                 let mut s = serializer.serialize_struct("LockFileResultEntry", 3)?;
                 s.serialize_field(".tag", "success")?;
                 x.internal_serialize::<S>(&mut s)?;
                 s.end()
             }
-            LockFileResultEntry::Failure(ref x) => {
+            LockFileResultEntry::Failure(x) => {
                 // union or polymporphic struct
                 let mut s = serializer.serialize_struct("LockFileResultEntry", 2)?;
                 s.serialize_field(".tag", "failure")?;
@@ -10086,13 +10086,13 @@ impl ::serde::ser::Serialize for LookupError {
     fn serialize<S: ::serde::ser::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
         // union serializer
         use serde::ser::SerializeStruct;
-        match *self {
-            LookupError::MalformedPath(ref x) => {
+        match self {
+            LookupError::MalformedPath(x) => {
                 // nullable (struct or primitive)
                 let n = if x.is_some() { 2 } else { 1 };
                 let mut s = serializer.serialize_struct("LookupError", n)?;
                 s.serialize_field(".tag", "malformed_path")?;
-                if let Some(ref x) = x {
+                if let Some(x) = x {
                     s.serialize_field("malformed_path", &x)?;
                 }
                 s.end()
@@ -10204,14 +10204,14 @@ impl ::serde::ser::Serialize for MediaInfo {
     fn serialize<S: ::serde::ser::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
         // union serializer
         use serde::ser::SerializeStruct;
-        match *self {
+        match self {
             MediaInfo::Pending => {
                 // unit
                 let mut s = serializer.serialize_struct("MediaInfo", 1)?;
                 s.serialize_field(".tag", "pending")?;
                 s.end()
             }
-            MediaInfo::Metadata(ref x) => {
+            MediaInfo::Metadata(x) => {
                 // union or polymporphic struct
                 let mut s = serializer.serialize_struct("MediaInfo", 2)?;
                 s.serialize_field(".tag", "metadata")?;
@@ -10261,14 +10261,14 @@ impl ::serde::ser::Serialize for MediaMetadata {
     fn serialize<S: ::serde::ser::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
         // polymorphic struct serializer
         use serde::ser::SerializeStruct;
-        match *self {
-            MediaMetadata::Photo(ref x) => {
+        match self {
+            MediaMetadata::Photo(x) => {
                 let mut s = serializer.serialize_struct("MediaMetadata", 4)?;
                 s.serialize_field(".tag", "photo")?;
                 x.internal_serialize::<S>(&mut s)?;
                 s.end()
             }
-            MediaMetadata::Video(ref x) => {
+            MediaMetadata::Video(x) => {
                 let mut s = serializer.serialize_struct("MediaMetadata", 5)?;
                 s.serialize_field(".tag", "video")?;
                 x.internal_serialize::<S>(&mut s)?;
@@ -10320,20 +10320,20 @@ impl ::serde::ser::Serialize for Metadata {
     fn serialize<S: ::serde::ser::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
         // polymorphic struct serializer
         use serde::ser::SerializeStruct;
-        match *self {
-            Metadata::File(ref x) => {
+        match self {
+            Metadata::File(x) => {
                 let mut s = serializer.serialize_struct("Metadata", 20)?;
                 s.serialize_field(".tag", "file")?;
                 x.internal_serialize::<S>(&mut s)?;
                 s.end()
             }
-            Metadata::Folder(ref x) => {
+            Metadata::Folder(x) => {
                 let mut s = serializer.serialize_struct("Metadata", 10)?;
                 s.serialize_field(".tag", "folder")?;
                 x.internal_serialize::<S>(&mut s)?;
                 s.end()
             }
-            Metadata::Deleted(ref x) => {
+            Metadata::Deleted(x) => {
                 let mut s = serializer.serialize_struct("Metadata", 6)?;
                 s.serialize_field(".tag", "deleted")?;
                 x.internal_serialize::<S>(&mut s)?;
@@ -10392,8 +10392,8 @@ impl ::serde::ser::Serialize for MetadataV2 {
     fn serialize<S: ::serde::ser::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
         // union serializer
         use serde::ser::SerializeStruct;
-        match *self {
-            MetadataV2::Metadata(ref x) => {
+        match self {
+            MetadataV2::Metadata(x) => {
                 // union or polymporphic struct
                 let mut s = serializer.serialize_struct("MetadataV2", 2)?;
                 s.serialize_field(".tag", "metadata")?;
@@ -10736,7 +10736,7 @@ impl ::serde::ser::Serialize for MoveIntoFamilyError {
     fn serialize<S: ::serde::ser::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
         // union serializer
         use serde::ser::SerializeStruct;
-        match *self {
+        match self {
             MoveIntoFamilyError::IsSharedFolder => {
                 // unit
                 let mut s = serializer.serialize_struct("MoveIntoFamilyError", 1)?;
@@ -10803,7 +10803,7 @@ impl ::serde::ser::Serialize for MoveIntoVaultError {
     fn serialize<S: ::serde::ser::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
         // union serializer
         use serde::ser::SerializeStruct;
-        match *self {
+        match self {
             MoveIntoVaultError::IsSharedFolder => {
                 // unit
                 let mut s = serializer.serialize_struct("MoveIntoVaultError", 1)?;
@@ -10883,7 +10883,7 @@ impl ::serde::ser::Serialize for PaperContentError {
     fn serialize<S: ::serde::ser::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
         // union serializer
         use serde::ser::SerializeStruct;
-        match *self {
+        match self {
             PaperContentError::InsufficientPermissions => {
                 // unit
                 let mut s = serializer.serialize_struct("PaperContentError", 1)?;
@@ -11105,7 +11105,7 @@ impl ::serde::ser::Serialize for PaperCreateError {
     fn serialize<S: ::serde::ser::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
         // union serializer
         use serde::ser::SerializeStruct;
-        match *self {
+        match self {
             PaperCreateError::InsufficientPermissions => {
                 // unit
                 let mut s = serializer.serialize_struct("PaperCreateError", 1)?;
@@ -11376,7 +11376,7 @@ impl ::serde::ser::Serialize for PaperDocUpdatePolicy {
     fn serialize<S: ::serde::ser::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
         // union serializer
         use serde::ser::SerializeStruct;
-        match *self {
+        match self {
             PaperDocUpdatePolicy::Update => {
                 // unit
                 let mut s = serializer.serialize_struct("PaperDocUpdatePolicy", 1)?;
@@ -11626,7 +11626,7 @@ impl ::serde::ser::Serialize for PaperUpdateError {
     fn serialize<S: ::serde::ser::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
         // union serializer
         use serde::ser::SerializeStruct;
-        match *self {
+        match self {
             PaperUpdateError::InsufficientPermissions => {
                 // unit
                 let mut s = serializer.serialize_struct("PaperUpdateError", 1)?;
@@ -11651,7 +11651,7 @@ impl ::serde::ser::Serialize for PaperUpdateError {
                 s.serialize_field(".tag", "image_size_exceeded")?;
                 s.end()
             }
-            PaperUpdateError::Path(ref x) => {
+            PaperUpdateError::Path(x) => {
                 // union or polymporphic struct
                 let mut s = serializer.serialize_struct("PaperUpdateError", 2)?;
                 s.serialize_field(".tag", "path")?;
@@ -11860,15 +11860,15 @@ impl ::serde::ser::Serialize for PathOrLink {
     fn serialize<S: ::serde::ser::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
         // union serializer
         use serde::ser::SerializeStruct;
-        match *self {
-            PathOrLink::Path(ref x) => {
+        match self {
+            PathOrLink::Path(x) => {
                 // primitive
                 let mut s = serializer.serialize_struct("PathOrLink", 2)?;
                 s.serialize_field(".tag", "path")?;
                 s.serialize_field("path", x)?;
                 s.end()
             }
-            PathOrLink::Link(ref x) => {
+            PathOrLink::Link(x) => {
                 // struct
                 let mut s = serializer.serialize_struct("PathOrLink", 4)?;
                 s.serialize_field(".tag", "link")?;
@@ -12277,8 +12277,8 @@ impl ::serde::ser::Serialize for PreviewError {
     fn serialize<S: ::serde::ser::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
         // union serializer
         use serde::ser::SerializeStruct;
-        match *self {
-            PreviewError::Path(ref x) => {
+        match self {
+            PreviewError::Path(x) => {
                 // union or polymporphic struct
                 let mut s = serializer.serialize_struct("PreviewError", 2)?;
                 s.serialize_field(".tag", "path")?;
@@ -13008,22 +13008,22 @@ impl ::serde::ser::Serialize for RelocationBatchError {
     fn serialize<S: ::serde::ser::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
         // union serializer
         use serde::ser::SerializeStruct;
-        match *self {
-            RelocationBatchError::FromLookup(ref x) => {
+        match self {
+            RelocationBatchError::FromLookup(x) => {
                 // union or polymporphic struct
                 let mut s = serializer.serialize_struct("RelocationBatchError", 2)?;
                 s.serialize_field(".tag", "from_lookup")?;
                 s.serialize_field("from_lookup", x)?;
                 s.end()
             }
-            RelocationBatchError::FromWrite(ref x) => {
+            RelocationBatchError::FromWrite(x) => {
                 // union or polymporphic struct
                 let mut s = serializer.serialize_struct("RelocationBatchError", 2)?;
                 s.serialize_field(".tag", "from_write")?;
                 s.serialize_field("from_write", x)?;
                 s.end()
             }
-            RelocationBatchError::To(ref x) => {
+            RelocationBatchError::To(x) => {
                 // union or polymporphic struct
                 let mut s = serializer.serialize_struct("RelocationBatchError", 2)?;
                 s.serialize_field(".tag", "to")?;
@@ -13084,14 +13084,14 @@ impl ::serde::ser::Serialize for RelocationBatchError {
                 s.serialize_field(".tag", "cant_move_shared_folder")?;
                 s.end()
             }
-            RelocationBatchError::CantMoveIntoVault(ref x) => {
+            RelocationBatchError::CantMoveIntoVault(x) => {
                 // union or polymporphic struct
                 let mut s = serializer.serialize_struct("RelocationBatchError", 2)?;
                 s.serialize_field(".tag", "cant_move_into_vault")?;
                 s.serialize_field("cant_move_into_vault", x)?;
                 s.end()
             }
-            RelocationBatchError::CantMoveIntoFamily(ref x) => {
+            RelocationBatchError::CantMoveIntoFamily(x) => {
                 // union or polymporphic struct
                 let mut s = serializer.serialize_struct("RelocationBatchError", 2)?;
                 s.serialize_field(".tag", "cant_move_into_family")?;
@@ -13223,8 +13223,8 @@ impl ::serde::ser::Serialize for RelocationBatchErrorEntry {
     fn serialize<S: ::serde::ser::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
         // union serializer
         use serde::ser::SerializeStruct;
-        match *self {
-            RelocationBatchErrorEntry::RelocationError(ref x) => {
+        match self {
+            RelocationBatchErrorEntry::RelocationError(x) => {
                 // union or polymporphic struct
                 let mut s = serializer.serialize_struct("RelocationBatchErrorEntry", 2)?;
                 s.serialize_field(".tag", "relocation_error")?;
@@ -13300,21 +13300,21 @@ impl ::serde::ser::Serialize for RelocationBatchJobStatus {
     fn serialize<S: ::serde::ser::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
         // union serializer
         use serde::ser::SerializeStruct;
-        match *self {
+        match self {
             RelocationBatchJobStatus::InProgress => {
                 // unit
                 let mut s = serializer.serialize_struct("RelocationBatchJobStatus", 1)?;
                 s.serialize_field(".tag", "in_progress")?;
                 s.end()
             }
-            RelocationBatchJobStatus::Complete(ref x) => {
+            RelocationBatchJobStatus::Complete(x) => {
                 // struct
                 let mut s = serializer.serialize_struct("RelocationBatchJobStatus", 2)?;
                 s.serialize_field(".tag", "complete")?;
                 x.internal_serialize::<S>(&mut s)?;
                 s.end()
             }
-            RelocationBatchJobStatus::Failed(ref x) => {
+            RelocationBatchJobStatus::Failed(x) => {
                 // union or polymporphic struct
                 let mut s = serializer.serialize_struct("RelocationBatchJobStatus", 2)?;
                 s.serialize_field(".tag", "failed")?;
@@ -13389,15 +13389,15 @@ impl ::serde::ser::Serialize for RelocationBatchLaunch {
     fn serialize<S: ::serde::ser::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
         // union serializer
         use serde::ser::SerializeStruct;
-        match *self {
-            RelocationBatchLaunch::AsyncJobId(ref x) => {
+        match self {
+            RelocationBatchLaunch::AsyncJobId(x) => {
                 // primitive
                 let mut s = serializer.serialize_struct("RelocationBatchLaunch", 2)?;
                 s.serialize_field(".tag", "async_job_id")?;
                 s.serialize_field("async_job_id", x)?;
                 s.end()
             }
-            RelocationBatchLaunch::Complete(ref x) => {
+            RelocationBatchLaunch::Complete(x) => {
                 // struct
                 let mut s = serializer.serialize_struct("RelocationBatchLaunch", 2)?;
                 s.serialize_field(".tag", "complete")?;
@@ -13661,15 +13661,15 @@ impl ::serde::ser::Serialize for RelocationBatchResultEntry {
     fn serialize<S: ::serde::ser::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
         // union serializer
         use serde::ser::SerializeStruct;
-        match *self {
-            RelocationBatchResultEntry::Success(ref x) => {
+        match self {
+            RelocationBatchResultEntry::Success(x) => {
                 // union or polymporphic struct
                 let mut s = serializer.serialize_struct("RelocationBatchResultEntry", 2)?;
                 s.serialize_field(".tag", "success")?;
                 s.serialize_field("success", x)?;
                 s.end()
             }
-            RelocationBatchResultEntry::Failure(ref x) => {
+            RelocationBatchResultEntry::Failure(x) => {
                 // union or polymporphic struct
                 let mut s = serializer.serialize_struct("RelocationBatchResultEntry", 2)?;
                 s.serialize_field(".tag", "failure")?;
@@ -13726,14 +13726,14 @@ impl ::serde::ser::Serialize for RelocationBatchV2JobStatus {
     fn serialize<S: ::serde::ser::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
         // union serializer
         use serde::ser::SerializeStruct;
-        match *self {
+        match self {
             RelocationBatchV2JobStatus::InProgress => {
                 // unit
                 let mut s = serializer.serialize_struct("RelocationBatchV2JobStatus", 1)?;
                 s.serialize_field(".tag", "in_progress")?;
                 s.end()
             }
-            RelocationBatchV2JobStatus::Complete(ref x) => {
+            RelocationBatchV2JobStatus::Complete(x) => {
                 // struct
                 let mut s = serializer.serialize_struct("RelocationBatchV2JobStatus", 2)?;
                 s.serialize_field(".tag", "complete")?;
@@ -13803,15 +13803,15 @@ impl ::serde::ser::Serialize for RelocationBatchV2Launch {
     fn serialize<S: ::serde::ser::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
         // union serializer
         use serde::ser::SerializeStruct;
-        match *self {
-            RelocationBatchV2Launch::AsyncJobId(ref x) => {
+        match self {
+            RelocationBatchV2Launch::AsyncJobId(x) => {
                 // primitive
                 let mut s = serializer.serialize_struct("RelocationBatchV2Launch", 2)?;
                 s.serialize_field(".tag", "async_job_id")?;
                 s.serialize_field("async_job_id", x)?;
                 s.end()
             }
-            RelocationBatchV2Launch::Complete(ref x) => {
+            RelocationBatchV2Launch::Complete(x) => {
                 // struct
                 let mut s = serializer.serialize_struct("RelocationBatchV2Launch", 2)?;
                 s.serialize_field(".tag", "complete")?;
@@ -14054,22 +14054,22 @@ impl ::serde::ser::Serialize for RelocationError {
     fn serialize<S: ::serde::ser::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
         // union serializer
         use serde::ser::SerializeStruct;
-        match *self {
-            RelocationError::FromLookup(ref x) => {
+        match self {
+            RelocationError::FromLookup(x) => {
                 // union or polymporphic struct
                 let mut s = serializer.serialize_struct("RelocationError", 2)?;
                 s.serialize_field(".tag", "from_lookup")?;
                 s.serialize_field("from_lookup", x)?;
                 s.end()
             }
-            RelocationError::FromWrite(ref x) => {
+            RelocationError::FromWrite(x) => {
                 // union or polymporphic struct
                 let mut s = serializer.serialize_struct("RelocationError", 2)?;
                 s.serialize_field(".tag", "from_write")?;
                 s.serialize_field("from_write", x)?;
                 s.end()
             }
-            RelocationError::To(ref x) => {
+            RelocationError::To(x) => {
                 // union or polymporphic struct
                 let mut s = serializer.serialize_struct("RelocationError", 2)?;
                 s.serialize_field(".tag", "to")?;
@@ -14130,14 +14130,14 @@ impl ::serde::ser::Serialize for RelocationError {
                 s.serialize_field(".tag", "cant_move_shared_folder")?;
                 s.end()
             }
-            RelocationError::CantMoveIntoVault(ref x) => {
+            RelocationError::CantMoveIntoVault(x) => {
                 // union or polymporphic struct
                 let mut s = serializer.serialize_struct("RelocationError", 2)?;
                 s.serialize_field(".tag", "cant_move_into_vault")?;
                 s.serialize_field("cant_move_into_vault", x)?;
                 s.end()
             }
-            RelocationError::CantMoveIntoFamily(ref x) => {
+            RelocationError::CantMoveIntoFamily(x) => {
                 // union or polymporphic struct
                 let mut s = serializer.serialize_struct("RelocationError", 2)?;
                 s.serialize_field(".tag", "cant_move_into_family")?;
@@ -14539,8 +14539,8 @@ impl ::serde::ser::Serialize for RemoveTagError {
     fn serialize<S: ::serde::ser::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
         // union serializer
         use serde::ser::SerializeStruct;
-        match *self {
-            RemoveTagError::Path(ref x) => {
+        match self {
+            RemoveTagError::Path(x) => {
                 // union or polymporphic struct
                 let mut s = serializer.serialize_struct("RemoveTagError", 2)?;
                 s.serialize_field(".tag", "path")?;
@@ -14757,15 +14757,15 @@ impl ::serde::ser::Serialize for RestoreError {
     fn serialize<S: ::serde::ser::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
         // union serializer
         use serde::ser::SerializeStruct;
-        match *self {
-            RestoreError::PathLookup(ref x) => {
+        match self {
+            RestoreError::PathLookup(x) => {
                 // union or polymporphic struct
                 let mut s = serializer.serialize_struct("RestoreError", 2)?;
                 s.serialize_field(".tag", "path_lookup")?;
                 s.serialize_field("path_lookup", x)?;
                 s.end()
             }
-            RestoreError::PathWrite(ref x) => {
+            RestoreError::PathWrite(x) => {
                 // union or polymporphic struct
                 let mut s = serializer.serialize_struct("RestoreError", 2)?;
                 s.serialize_field(".tag", "path_write")?;
@@ -14980,8 +14980,8 @@ impl ::serde::ser::Serialize for SaveCopyReferenceError {
     fn serialize<S: ::serde::ser::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
         // union serializer
         use serde::ser::SerializeStruct;
-        match *self {
-            SaveCopyReferenceError::Path(ref x) => {
+        match self {
+            SaveCopyReferenceError::Path(x) => {
                 // union or polymporphic struct
                 let mut s = serializer.serialize_struct("SaveCopyReferenceError", 2)?;
                 s.serialize_field(".tag", "path")?;
@@ -15295,8 +15295,8 @@ impl ::serde::ser::Serialize for SaveUrlError {
     fn serialize<S: ::serde::ser::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
         // union serializer
         use serde::ser::SerializeStruct;
-        match *self {
-            SaveUrlError::Path(ref x) => {
+        match self {
+            SaveUrlError::Path(x) => {
                 // union or polymporphic struct
                 let mut s = serializer.serialize_struct("SaveUrlError", 2)?;
                 s.serialize_field(".tag", "path")?;
@@ -15398,21 +15398,21 @@ impl ::serde::ser::Serialize for SaveUrlJobStatus {
     fn serialize<S: ::serde::ser::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
         // union serializer
         use serde::ser::SerializeStruct;
-        match *self {
+        match self {
             SaveUrlJobStatus::InProgress => {
                 // unit
                 let mut s = serializer.serialize_struct("SaveUrlJobStatus", 1)?;
                 s.serialize_field(".tag", "in_progress")?;
                 s.end()
             }
-            SaveUrlJobStatus::Complete(ref x) => {
+            SaveUrlJobStatus::Complete(x) => {
                 // struct
                 let mut s = serializer.serialize_struct("SaveUrlJobStatus", 20)?;
                 s.serialize_field(".tag", "complete")?;
                 x.internal_serialize::<S>(&mut s)?;
                 s.end()
             }
-            SaveUrlJobStatus::Failed(ref x) => {
+            SaveUrlJobStatus::Failed(x) => {
                 // union or polymporphic struct
                 let mut s = serializer.serialize_struct("SaveUrlJobStatus", 2)?;
                 s.serialize_field(".tag", "failed")?;
@@ -15480,15 +15480,15 @@ impl ::serde::ser::Serialize for SaveUrlResult {
     fn serialize<S: ::serde::ser::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
         // union serializer
         use serde::ser::SerializeStruct;
-        match *self {
-            SaveUrlResult::AsyncJobId(ref x) => {
+        match self {
+            SaveUrlResult::AsyncJobId(x) => {
                 // primitive
                 let mut s = serializer.serialize_struct("SaveUrlResult", 2)?;
                 s.serialize_field(".tag", "async_job_id")?;
                 s.serialize_field("async_job_id", x)?;
                 s.end()
             }
-            SaveUrlResult::Complete(ref x) => {
+            SaveUrlResult::Complete(x) => {
                 // struct
                 let mut s = serializer.serialize_struct("SaveUrlResult", 20)?;
                 s.serialize_field(".tag", "complete")?;
@@ -15735,20 +15735,20 @@ impl ::serde::ser::Serialize for SearchError {
     fn serialize<S: ::serde::ser::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
         // union serializer
         use serde::ser::SerializeStruct;
-        match *self {
-            SearchError::Path(ref x) => {
+        match self {
+            SearchError::Path(x) => {
                 // union or polymporphic struct
                 let mut s = serializer.serialize_struct("SearchError", 2)?;
                 s.serialize_field(".tag", "path")?;
                 s.serialize_field("path", x)?;
                 s.end()
             }
-            SearchError::InvalidArgument(ref x) => {
+            SearchError::InvalidArgument(x) => {
                 // nullable (struct or primitive)
                 let n = if x.is_some() { 2 } else { 1 };
                 let mut s = serializer.serialize_struct("SearchError", n)?;
                 s.serialize_field(".tag", "invalid_argument")?;
-                if let Some(ref x) = x {
+                if let Some(x) = x {
                     s.serialize_field("invalid_argument", &x)?;
                 }
                 s.end()
@@ -16017,7 +16017,7 @@ impl ::serde::ser::Serialize for SearchMatchType {
     fn serialize<S: ::serde::ser::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
         // union serializer
         use serde::ser::SerializeStruct;
-        match *self {
+        match self {
             SearchMatchType::Filename => {
                 // unit
                 let mut s = serializer.serialize_struct("SearchMatchType", 1)?;
@@ -16096,7 +16096,7 @@ impl ::serde::ser::Serialize for SearchMatchTypeV2 {
     fn serialize<S: ::serde::ser::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
         // union serializer
         use serde::ser::SerializeStruct;
-        match *self {
+        match self {
             SearchMatchTypeV2::Filename => {
                 // unit
                 let mut s = serializer.serialize_struct("SearchMatchTypeV2", 1)?;
@@ -16303,7 +16303,7 @@ impl ::serde::ser::Serialize for SearchMode {
     fn serialize<S: ::serde::ser::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
         // union serializer
         use serde::ser::SerializeStruct;
-        match *self {
+        match self {
             SearchMode::Filename => {
                 // unit
                 let mut s = serializer.serialize_struct("SearchMode", 1)?;
@@ -16603,7 +16603,7 @@ impl ::serde::ser::Serialize for SearchOrderBy {
     fn serialize<S: ::serde::ser::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
         // union serializer
         use serde::ser::SerializeStruct;
-        match *self {
+        match self {
             SearchOrderBy::Relevance => {
                 // unit
                 let mut s = serializer.serialize_struct("SearchOrderBy", 1)?;
@@ -17720,7 +17720,7 @@ impl ::serde::ser::Serialize for SyncSetting {
     fn serialize<S: ::serde::ser::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
         // union serializer
         use serde::ser::SerializeStruct;
-        match *self {
+        match self {
             SyncSetting::Default => {
                 // unit
                 let mut s = serializer.serialize_struct("SyncSetting", 1)?;
@@ -17793,7 +17793,7 @@ impl ::serde::ser::Serialize for SyncSettingArg {
     fn serialize<S: ::serde::ser::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
         // union serializer
         use serde::ser::SerializeStruct;
-        match *self {
+        match self {
             SyncSettingArg::Default => {
                 // unit
                 let mut s = serializer.serialize_struct("SyncSettingArg", 1)?;
@@ -17867,8 +17867,8 @@ impl ::serde::ser::Serialize for SyncSettingsError {
     fn serialize<S: ::serde::ser::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
         // union serializer
         use serde::ser::SerializeStruct;
-        match *self {
-            SyncSettingsError::Path(ref x) => {
+        match self {
+            SyncSettingsError::Path(x) => {
                 // union or polymporphic struct
                 let mut s = serializer.serialize_struct("SyncSettingsError", 2)?;
                 s.serialize_field(".tag", "path")?;
@@ -17956,8 +17956,8 @@ impl ::serde::ser::Serialize for Tag {
     fn serialize<S: ::serde::ser::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
         // union serializer
         use serde::ser::SerializeStruct;
-        match *self {
-            Tag::UserGeneratedTag(ref x) => {
+        match self {
+            Tag::UserGeneratedTag(x) => {
                 // struct
                 let mut s = serializer.serialize_struct("Tag", 2)?;
                 s.serialize_field(".tag", "user_generated_tag")?;
@@ -18177,8 +18177,8 @@ impl ::serde::ser::Serialize for ThumbnailError {
     fn serialize<S: ::serde::ser::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
         // union serializer
         use serde::ser::SerializeStruct;
-        match *self {
-            ThumbnailError::Path(ref x) => {
+        match self {
+            ThumbnailError::Path(x) => {
                 // union or polymporphic struct
                 let mut s = serializer.serialize_struct("ThumbnailError", 2)?;
                 s.serialize_field(".tag", "path")?;
@@ -18267,7 +18267,7 @@ impl ::serde::ser::Serialize for ThumbnailFormat {
     fn serialize<S: ::serde::ser::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
         // union serializer
         use serde::ser::SerializeStruct;
-        match *self {
+        match self {
             ThumbnailFormat::Jpeg => {
                 // unit
                 let mut s = serializer.serialize_struct("ThumbnailFormat", 1)?;
@@ -18330,7 +18330,7 @@ impl ::serde::ser::Serialize for ThumbnailMode {
     fn serialize<S: ::serde::ser::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
         // union serializer
         use serde::ser::SerializeStruct;
-        match *self {
+        match self {
             ThumbnailMode::Strict => {
                 // unit
                 let mut s = serializer.serialize_struct("ThumbnailMode", 1)?;
@@ -18423,7 +18423,7 @@ impl ::serde::ser::Serialize for ThumbnailSize {
     fn serialize<S: ::serde::ser::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
         // union serializer
         use serde::ser::SerializeStruct;
-        match *self {
+        match self {
             ThumbnailSize::W32h32 => {
                 // unit
                 let mut s = serializer.serialize_struct("ThumbnailSize", 1)?;
@@ -18704,8 +18704,8 @@ impl ::serde::ser::Serialize for ThumbnailV2Error {
     fn serialize<S: ::serde::ser::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
         // union serializer
         use serde::ser::SerializeStruct;
-        match *self {
-            ThumbnailV2Error::Path(ref x) => {
+        match self {
+            ThumbnailV2Error::Path(x) => {
                 // union or polymporphic struct
                 let mut s = serializer.serialize_struct("ThumbnailV2Error", 2)?;
                 s.serialize_field(".tag", "path")?;
@@ -19274,15 +19274,15 @@ impl ::serde::ser::Serialize for UploadError {
     fn serialize<S: ::serde::ser::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
         // union serializer
         use serde::ser::SerializeStruct;
-        match *self {
-            UploadError::Path(ref x) => {
+        match self {
+            UploadError::Path(x) => {
                 // struct
                 let mut s = serializer.serialize_struct("UploadError", 3)?;
                 s.serialize_field(".tag", "path")?;
                 x.internal_serialize::<S>(&mut s)?;
                 s.end()
             }
-            UploadError::PropertiesError(ref x) => {
+            UploadError::PropertiesError(x) => {
                 // union or polymporphic struct
                 let mut s = serializer.serialize_struct("UploadError", 2)?;
                 s.serialize_field(".tag", "properties_error")?;
@@ -19543,14 +19543,14 @@ impl ::serde::ser::Serialize for UploadSessionAppendError {
     fn serialize<S: ::serde::ser::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
         // union serializer
         use serde::ser::SerializeStruct;
-        match *self {
+        match self {
             UploadSessionAppendError::NotFound => {
                 // unit
                 let mut s = serializer.serialize_struct("UploadSessionAppendError", 1)?;
                 s.serialize_field(".tag", "not_found")?;
                 s.end()
             }
-            UploadSessionAppendError::IncorrectOffset(ref x) => {
+            UploadSessionAppendError::IncorrectOffset(x) => {
                 // struct
                 let mut s = serializer.serialize_struct("UploadSessionAppendError", 2)?;
                 s.serialize_field(".tag", "incorrect_offset")?;
@@ -20006,14 +20006,14 @@ impl ::serde::ser::Serialize for UploadSessionFinishBatchJobStatus {
     fn serialize<S: ::serde::ser::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
         // union serializer
         use serde::ser::SerializeStruct;
-        match *self {
+        match self {
             UploadSessionFinishBatchJobStatus::InProgress => {
                 // unit
                 let mut s = serializer.serialize_struct("UploadSessionFinishBatchJobStatus", 1)?;
                 s.serialize_field(".tag", "in_progress")?;
                 s.end()
             }
-            UploadSessionFinishBatchJobStatus::Complete(ref x) => {
+            UploadSessionFinishBatchJobStatus::Complete(x) => {
                 // struct
                 let mut s = serializer.serialize_struct("UploadSessionFinishBatchJobStatus", 2)?;
                 s.serialize_field(".tag", "complete")?;
@@ -20087,15 +20087,15 @@ impl ::serde::ser::Serialize for UploadSessionFinishBatchLaunch {
     fn serialize<S: ::serde::ser::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
         // union serializer
         use serde::ser::SerializeStruct;
-        match *self {
-            UploadSessionFinishBatchLaunch::AsyncJobId(ref x) => {
+        match self {
+            UploadSessionFinishBatchLaunch::AsyncJobId(x) => {
                 // primitive
                 let mut s = serializer.serialize_struct("UploadSessionFinishBatchLaunch", 2)?;
                 s.serialize_field(".tag", "async_job_id")?;
                 s.serialize_field("async_job_id", x)?;
                 s.end()
             }
-            UploadSessionFinishBatchLaunch::Complete(ref x) => {
+            UploadSessionFinishBatchLaunch::Complete(x) => {
                 // struct
                 let mut s = serializer.serialize_struct("UploadSessionFinishBatchLaunch", 2)?;
                 s.serialize_field(".tag", "complete")?;
@@ -20254,15 +20254,15 @@ impl ::serde::ser::Serialize for UploadSessionFinishBatchResultEntry {
     fn serialize<S: ::serde::ser::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
         // union serializer
         use serde::ser::SerializeStruct;
-        match *self {
-            UploadSessionFinishBatchResultEntry::Success(ref x) => {
+        match self {
+            UploadSessionFinishBatchResultEntry::Success(x) => {
                 // struct
                 let mut s = serializer.serialize_struct("UploadSessionFinishBatchResultEntry", 20)?;
                 s.serialize_field(".tag", "success")?;
                 x.internal_serialize::<S>(&mut s)?;
                 s.end()
             }
-            UploadSessionFinishBatchResultEntry::Failure(ref x) => {
+            UploadSessionFinishBatchResultEntry::Failure(x) => {
                 // union or polymporphic struct
                 let mut s = serializer.serialize_struct("UploadSessionFinishBatchResultEntry", 2)?;
                 s.serialize_field(".tag", "failure")?;
@@ -20374,22 +20374,22 @@ impl ::serde::ser::Serialize for UploadSessionFinishError {
     fn serialize<S: ::serde::ser::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
         // union serializer
         use serde::ser::SerializeStruct;
-        match *self {
-            UploadSessionFinishError::LookupFailed(ref x) => {
+        match self {
+            UploadSessionFinishError::LookupFailed(x) => {
                 // union or polymporphic struct
                 let mut s = serializer.serialize_struct("UploadSessionFinishError", 2)?;
                 s.serialize_field(".tag", "lookup_failed")?;
                 s.serialize_field("lookup_failed", x)?;
                 s.end()
             }
-            UploadSessionFinishError::Path(ref x) => {
+            UploadSessionFinishError::Path(x) => {
                 // union or polymporphic struct
                 let mut s = serializer.serialize_struct("UploadSessionFinishError", 2)?;
                 s.serialize_field(".tag", "path")?;
                 s.serialize_field("path", x)?;
                 s.end()
             }
-            UploadSessionFinishError::PropertiesError(ref x) => {
+            UploadSessionFinishError::PropertiesError(x) => {
                 // union or polymporphic struct
                 let mut s = serializer.serialize_struct("UploadSessionFinishError", 2)?;
                 s.serialize_field(".tag", "properties_error")?;
@@ -20548,14 +20548,14 @@ impl ::serde::ser::Serialize for UploadSessionLookupError {
     fn serialize<S: ::serde::ser::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
         // union serializer
         use serde::ser::SerializeStruct;
-        match *self {
+        match self {
             UploadSessionLookupError::NotFound => {
                 // unit
                 let mut s = serializer.serialize_struct("UploadSessionLookupError", 1)?;
                 s.serialize_field(".tag", "not_found")?;
                 s.end()
             }
-            UploadSessionLookupError::IncorrectOffset(ref x) => {
+            UploadSessionLookupError::IncorrectOffset(x) => {
                 // struct
                 let mut s = serializer.serialize_struct("UploadSessionLookupError", 2)?;
                 s.serialize_field(".tag", "incorrect_offset")?;
@@ -21098,7 +21098,7 @@ impl ::serde::ser::Serialize for UploadSessionStartError {
     fn serialize<S: ::serde::ser::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
         // union serializer
         use serde::ser::SerializeStruct;
-        match *self {
+        match self {
             UploadSessionStartError::ConcurrentSessionDataNotAllowed => {
                 // unit
                 let mut s = serializer.serialize_struct("UploadSessionStartError", 1)?;
@@ -21283,7 +21283,7 @@ impl ::serde::ser::Serialize for UploadSessionType {
     fn serialize<S: ::serde::ser::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
         // union serializer
         use serde::ser::SerializeStruct;
-        match *self {
+        match self {
             UploadSessionType::Sequential => {
                 // unit
                 let mut s = serializer.serialize_struct("UploadSessionType", 1)?;
@@ -21693,7 +21693,7 @@ impl ::serde::ser::Serialize for WriteConflictError {
     fn serialize<S: ::serde::ser::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
         // union serializer
         use serde::ser::SerializeStruct;
-        match *self {
+        match self {
             WriteConflictError::File => {
                 // unit
                 let mut s = serializer.serialize_struct("WriteConflictError", 1)?;
@@ -21816,18 +21816,18 @@ impl ::serde::ser::Serialize for WriteError {
     fn serialize<S: ::serde::ser::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
         // union serializer
         use serde::ser::SerializeStruct;
-        match *self {
-            WriteError::MalformedPath(ref x) => {
+        match self {
+            WriteError::MalformedPath(x) => {
                 // nullable (struct or primitive)
                 let n = if x.is_some() { 2 } else { 1 };
                 let mut s = serializer.serialize_struct("WriteError", n)?;
                 s.serialize_field(".tag", "malformed_path")?;
-                if let Some(ref x) = x {
+                if let Some(x) = x {
                     s.serialize_field("malformed_path", &x)?;
                 }
                 s.end()
             }
-            WriteError::Conflict(ref x) => {
+            WriteError::Conflict(x) => {
                 // union or polymporphic struct
                 let mut s = serializer.serialize_struct("WriteError", 2)?;
                 s.serialize_field(".tag", "conflict")?;
@@ -21968,7 +21968,7 @@ impl ::serde::ser::Serialize for WriteMode {
     fn serialize<S: ::serde::ser::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
         // union serializer
         use serde::ser::SerializeStruct;
-        match *self {
+        match self {
             WriteMode::Add => {
                 // unit
                 let mut s = serializer.serialize_struct("WriteMode", 1)?;
@@ -21981,7 +21981,7 @@ impl ::serde::ser::Serialize for WriteMode {
                 s.serialize_field(".tag", "overwrite")?;
                 s.end()
             }
-            WriteMode::Update(ref x) => {
+            WriteMode::Update(x) => {
                 // primitive
                 let mut s = serializer.serialize_struct("WriteMode", 2)?;
                 s.serialize_field(".tag", "update")?;

--- a/src/generated/types/openid.rs
+++ b/src/generated/types/openid.rs
@@ -51,7 +51,7 @@ impl ::serde::ser::Serialize for OpenIdError {
     fn serialize<S: ::serde::ser::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
         // union serializer
         use serde::ser::SerializeStruct;
-        match *self {
+        match self {
             OpenIdError::IncorrectOpenidScopes => {
                 // unit
                 let mut s = serializer.serialize_struct("OpenIdError", 1)?;
@@ -167,8 +167,8 @@ impl ::serde::ser::Serialize for UserInfoError {
     fn serialize<S: ::serde::ser::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
         // union serializer
         use serde::ser::SerializeStruct;
-        match *self {
-            UserInfoError::OpenidError(ref x) => {
+        match self {
+            UserInfoError::OpenidError(x) => {
                 // union or polymporphic struct
                 let mut s = serializer.serialize_struct("UserInfoError", 2)?;
                 s.serialize_field(".tag", "openid_error")?;

--- a/src/generated/types/paper.rs
+++ b/src/generated/types/paper.rs
@@ -456,7 +456,7 @@ impl ::serde::ser::Serialize for AddPaperDocUserResult {
     fn serialize<S: ::serde::ser::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
         // union serializer
         use serde::ser::SerializeStruct;
-        match *self {
+        match self {
             AddPaperDocUserResult::Success => {
                 // unit
                 let mut s = serializer.serialize_struct("AddPaperDocUserResult", 1)?;
@@ -674,7 +674,7 @@ impl ::serde::ser::Serialize for DocLookupError {
     fn serialize<S: ::serde::ser::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
         // union serializer
         use serde::ser::SerializeStruct;
-        match *self {
+        match self {
             DocLookupError::InsufficientPermissions => {
                 // unit
                 let mut s = serializer.serialize_struct("DocLookupError", 1)?;
@@ -764,7 +764,7 @@ impl ::serde::ser::Serialize for DocSubscriptionLevel {
     fn serialize<S: ::serde::ser::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
         // union serializer
         use serde::ser::SerializeStruct;
-        match *self {
+        match self {
             DocSubscriptionLevel::Default => {
                 // unit
                 let mut s = serializer.serialize_struct("DocSubscriptionLevel", 1)?;
@@ -841,7 +841,7 @@ impl ::serde::ser::Serialize for ExportFormat {
     fn serialize<S: ::serde::ser::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
         // union serializer
         use serde::ser::SerializeStruct;
-        match *self {
+        match self {
             ExportFormat::Html => {
                 // unit
                 let mut s = serializer.serialize_struct("ExportFormat", 1)?;
@@ -1008,7 +1008,7 @@ impl ::serde::ser::Serialize for FolderSharingPolicyType {
     fn serialize<S: ::serde::ser::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
         // union serializer
         use serde::ser::SerializeStruct;
-        match *self {
+        match self {
             FolderSharingPolicyType::Team => {
                 // unit
                 let mut s = serializer.serialize_struct("FolderSharingPolicyType", 1)?;
@@ -1076,7 +1076,7 @@ impl ::serde::ser::Serialize for FolderSubscriptionLevel {
     fn serialize<S: ::serde::ser::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
         // union serializer
         use serde::ser::SerializeStruct;
-        match *self {
+        match self {
             FolderSubscriptionLevel::None => {
                 // unit
                 let mut s = serializer.serialize_struct("FolderSubscriptionLevel", 1)?;
@@ -1260,7 +1260,7 @@ impl ::serde::ser::Serialize for ImportFormat {
     fn serialize<S: ::serde::ser::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
         // union serializer
         use serde::ser::SerializeStruct;
-        match *self {
+        match self {
             ImportFormat::Html => {
                 // unit
                 let mut s = serializer.serialize_struct("ImportFormat", 1)?;
@@ -1439,8 +1439,8 @@ impl ::serde::ser::Serialize for ListDocsCursorError {
     fn serialize<S: ::serde::ser::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
         // union serializer
         use serde::ser::SerializeStruct;
-        match *self {
-            ListDocsCursorError::CursorError(ref x) => {
+        match self {
+            ListDocsCursorError::CursorError(x) => {
                 // union or polymporphic struct
                 let mut s = serializer.serialize_struct("ListDocsCursorError", 2)?;
                 s.serialize_field(".tag", "cursor_error")?;
@@ -1759,7 +1759,7 @@ impl ::serde::ser::Serialize for ListPaperDocsFilterBy {
     fn serialize<S: ::serde::ser::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
         // union serializer
         use serde::ser::SerializeStruct;
-        match *self {
+        match self {
             ListPaperDocsFilterBy::DocsAccessed => {
                 // unit
                 let mut s = serializer.serialize_struct("ListPaperDocsFilterBy", 1)?;
@@ -1952,7 +1952,7 @@ impl ::serde::ser::Serialize for ListPaperDocsSortBy {
     fn serialize<S: ::serde::ser::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
         // union serializer
         use serde::ser::SerializeStruct;
-        match *self {
+        match self {
             ListPaperDocsSortBy::Accessed => {
                 // unit
                 let mut s = serializer.serialize_struct("ListPaperDocsSortBy", 1)?;
@@ -2023,7 +2023,7 @@ impl ::serde::ser::Serialize for ListPaperDocsSortOrder {
     fn serialize<S: ::serde::ser::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
         // union serializer
         use serde::ser::SerializeStruct;
-        match *self {
+        match self {
             ListPaperDocsSortOrder::Ascending => {
                 // unit
                 let mut s = serializer.serialize_struct("ListPaperDocsSortOrder", 1)?;
@@ -2100,7 +2100,7 @@ impl ::serde::ser::Serialize for ListUsersCursorError {
     fn serialize<S: ::serde::ser::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
         // union serializer
         use serde::ser::SerializeStruct;
-        match *self {
+        match self {
             ListUsersCursorError::InsufficientPermissions => {
                 // unit
                 let mut s = serializer.serialize_struct("ListUsersCursorError", 1)?;
@@ -2113,7 +2113,7 @@ impl ::serde::ser::Serialize for ListUsersCursorError {
                 s.serialize_field(".tag", "doc_not_found")?;
                 s.end()
             }
-            ListUsersCursorError::CursorError(ref x) => {
+            ListUsersCursorError::CursorError(x) => {
                 // union or polymporphic struct
                 let mut s = serializer.serialize_struct("ListUsersCursorError", 2)?;
                 s.serialize_field(".tag", "cursor_error")?;
@@ -2984,7 +2984,7 @@ impl ::serde::ser::Serialize for PaperApiBaseError {
     fn serialize<S: ::serde::ser::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
         // union serializer
         use serde::ser::SerializeStruct;
-        match *self {
+        match self {
             PaperApiBaseError::InsufficientPermissions => {
                 // unit
                 let mut s = serializer.serialize_struct("PaperApiBaseError", 1)?;
@@ -3061,7 +3061,7 @@ impl ::serde::ser::Serialize for PaperApiCursorError {
     fn serialize<S: ::serde::ser::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
         // union serializer
         use serde::ser::SerializeStruct;
-        match *self {
+        match self {
             PaperApiCursorError::ExpiredCursor => {
                 // unit
                 let mut s = serializer.serialize_struct("PaperApiCursorError", 1)?;
@@ -3281,7 +3281,7 @@ impl ::serde::ser::Serialize for PaperDocCreateError {
     fn serialize<S: ::serde::ser::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
         // union serializer
         use serde::ser::SerializeStruct;
-        match *self {
+        match self {
             PaperDocCreateError::InsufficientPermissions => {
                 // unit
                 let mut s = serializer.serialize_struct("PaperDocCreateError", 1)?;
@@ -3746,7 +3746,7 @@ impl ::serde::ser::Serialize for PaperDocPermissionLevel {
     fn serialize<S: ::serde::ser::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
         // union serializer
         use serde::ser::SerializeStruct;
-        match *self {
+        match self {
             PaperDocPermissionLevel::Edit => {
                 // unit
                 let mut s = serializer.serialize_struct("PaperDocPermissionLevel", 1)?;
@@ -4095,7 +4095,7 @@ impl ::serde::ser::Serialize for PaperDocUpdateError {
     fn serialize<S: ::serde::ser::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
         // union serializer
         use serde::ser::SerializeStruct;
-        match *self {
+        match self {
             PaperDocUpdateError::InsufficientPermissions => {
                 // unit
                 let mut s = serializer.serialize_struct("PaperDocUpdateError", 1)?;
@@ -4228,7 +4228,7 @@ impl ::serde::ser::Serialize for PaperDocUpdatePolicy {
     fn serialize<S: ::serde::ser::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
         // union serializer
         use serde::ser::SerializeStruct;
-        match *self {
+        match self {
             PaperDocUpdatePolicy::Append => {
                 // unit
                 let mut s = serializer.serialize_struct("PaperDocUpdatePolicy", 1)?;
@@ -4442,7 +4442,7 @@ impl ::serde::ser::Serialize for PaperFolderCreateError {
     fn serialize<S: ::serde::ser::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
         // union serializer
         use serde::ser::SerializeStruct;
-        match *self {
+        match self {
             PaperFolderCreateError::InsufficientPermissions => {
                 // unit
                 let mut s = serializer.serialize_struct("PaperFolderCreateError", 1)?;
@@ -4934,7 +4934,7 @@ impl ::serde::ser::Serialize for SharingPublicPolicyType {
     fn serialize<S: ::serde::ser::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
         // union serializer
         use serde::ser::SerializeStruct;
-        match *self {
+        match self {
             SharingPublicPolicyType::PeopleWithLinkCanEdit => {
                 // unit
                 let mut s = serializer.serialize_struct("SharingPublicPolicyType", 1)?;
@@ -5020,7 +5020,7 @@ impl ::serde::ser::Serialize for SharingTeamPolicyType {
     fn serialize<S: ::serde::ser::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
         // union serializer
         use serde::ser::SerializeStruct;
-        match *self {
+        match self {
             SharingTeamPolicyType::PeopleWithLinkCanEdit => {
                 // unit
                 let mut s = serializer.serialize_struct("SharingTeamPolicyType", 1)?;
@@ -5198,7 +5198,7 @@ impl ::serde::ser::Serialize for UserOnPaperDocFilter {
     fn serialize<S: ::serde::ser::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
         // union serializer
         use serde::ser::SerializeStruct;
-        match *self {
+        match self {
             UserOnPaperDocFilter::Visited => {
                 // unit
                 let mut s = serializer.serialize_struct("UserOnPaperDocFilter", 1)?;

--- a/src/generated/types/seen_state.rs
+++ b/src/generated/types/seen_state.rs
@@ -77,7 +77,7 @@ impl ::serde::ser::Serialize for PlatformType {
     fn serialize<S: ::serde::ser::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
         // union serializer
         use serde::ser::SerializeStruct;
-        match *self {
+        match self {
             PlatformType::Web => {
                 // unit
                 let mut s = serializer.serialize_struct("PlatformType", 1)?;

--- a/src/generated/types/sharing.rs
+++ b/src/generated/types/sharing.rs
@@ -68,7 +68,7 @@ impl ::serde::ser::Serialize for AccessInheritance {
     fn serialize<S: ::serde::ser::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
         // union serializer
         use serde::ser::SerializeStruct;
-        match *self {
+        match self {
             AccessInheritance::Inherit => {
                 // unit
                 let mut s = serializer.serialize_struct("AccessInheritance", 1)?;
@@ -154,7 +154,7 @@ impl ::serde::ser::Serialize for AccessLevel {
     fn serialize<S: ::serde::ser::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
         // union serializer
         use serde::ser::SerializeStruct;
-        match *self {
+        match self {
             AccessLevel::Owner => {
                 // unit
                 let mut s = serializer.serialize_struct("AccessLevel", 1)?;
@@ -245,7 +245,7 @@ impl ::serde::ser::Serialize for AclUpdatePolicy {
     fn serialize<S: ::serde::ser::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
         // union serializer
         use serde::ser::SerializeStruct;
-        match *self {
+        match self {
             AclUpdatePolicy::Owner => {
                 // unit
                 let mut s = serializer.serialize_struct("AclUpdatePolicy", 1)?;
@@ -516,15 +516,15 @@ impl ::serde::ser::Serialize for AddFileMemberError {
     fn serialize<S: ::serde::ser::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
         // union serializer
         use serde::ser::SerializeStruct;
-        match *self {
-            AddFileMemberError::UserError(ref x) => {
+        match self {
+            AddFileMemberError::UserError(x) => {
                 // union or polymporphic struct
                 let mut s = serializer.serialize_struct("AddFileMemberError", 2)?;
                 s.serialize_field(".tag", "user_error")?;
                 s.serialize_field("user_error", x)?;
                 s.end()
             }
-            AddFileMemberError::AccessError(ref x) => {
+            AddFileMemberError::AccessError(x) => {
                 // union or polymporphic struct
                 let mut s = serializer.serialize_struct("AddFileMemberError", 2)?;
                 s.serialize_field(".tag", "access_error")?;
@@ -837,8 +837,8 @@ impl ::serde::ser::Serialize for AddFolderMemberError {
     fn serialize<S: ::serde::ser::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
         // union serializer
         use serde::ser::SerializeStruct;
-        match *self {
-            AddFolderMemberError::AccessError(ref x) => {
+        match self {
+            AddFolderMemberError::AccessError(x) => {
                 // union or polymporphic struct
                 let mut s = serializer.serialize_struct("AddFolderMemberError", 2)?;
                 s.serialize_field(".tag", "access_error")?;
@@ -857,7 +857,7 @@ impl ::serde::ser::Serialize for AddFolderMemberError {
                 s.serialize_field(".tag", "banned_member")?;
                 s.end()
             }
-            AddFolderMemberError::BadMember(ref x) => {
+            AddFolderMemberError::BadMember(x) => {
                 // union or polymporphic struct
                 let mut s = serializer.serialize_struct("AddFolderMemberError", 2)?;
                 s.serialize_field(".tag", "bad_member")?;
@@ -870,14 +870,14 @@ impl ::serde::ser::Serialize for AddFolderMemberError {
                 s.serialize_field(".tag", "cant_share_outside_team")?;
                 s.end()
             }
-            AddFolderMemberError::TooManyMembers(ref x) => {
+            AddFolderMemberError::TooManyMembers(x) => {
                 // primitive
                 let mut s = serializer.serialize_struct("AddFolderMemberError", 2)?;
                 s.serialize_field(".tag", "too_many_members")?;
                 s.serialize_field("too_many_members", x)?;
                 s.end()
             }
-            AddFolderMemberError::TooManyPendingInvites(ref x) => {
+            AddFolderMemberError::TooManyPendingInvites(x) => {
                 // primitive
                 let mut s = serializer.serialize_struct("AddFolderMemberError", 2)?;
                 s.serialize_field(".tag", "too_many_pending_invites")?;
@@ -1151,28 +1151,28 @@ impl ::serde::ser::Serialize for AddMemberSelectorError {
     fn serialize<S: ::serde::ser::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
         // union serializer
         use serde::ser::SerializeStruct;
-        match *self {
+        match self {
             AddMemberSelectorError::AutomaticGroup => {
                 // unit
                 let mut s = serializer.serialize_struct("AddMemberSelectorError", 1)?;
                 s.serialize_field(".tag", "automatic_group")?;
                 s.end()
             }
-            AddMemberSelectorError::InvalidDropboxId(ref x) => {
+            AddMemberSelectorError::InvalidDropboxId(x) => {
                 // primitive
                 let mut s = serializer.serialize_struct("AddMemberSelectorError", 2)?;
                 s.serialize_field(".tag", "invalid_dropbox_id")?;
                 s.serialize_field("invalid_dropbox_id", x)?;
                 s.end()
             }
-            AddMemberSelectorError::InvalidEmail(ref x) => {
+            AddMemberSelectorError::InvalidEmail(x) => {
                 // primitive
                 let mut s = serializer.serialize_struct("AddMemberSelectorError", 2)?;
                 s.serialize_field(".tag", "invalid_email")?;
                 s.serialize_field("invalid_email", x)?;
                 s.end()
             }
-            AddMemberSelectorError::UnverifiedDropboxId(ref x) => {
+            AddMemberSelectorError::UnverifiedDropboxId(x) => {
                 // primitive
                 let mut s = serializer.serialize_struct("AddMemberSelectorError", 2)?;
                 s.serialize_field(".tag", "unverified_dropbox_id")?;
@@ -1284,7 +1284,7 @@ impl ::serde::ser::Serialize for AlphaResolvedVisibility {
     fn serialize<S: ::serde::ser::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
         // union serializer
         use serde::ser::SerializeStruct;
-        match *self {
+        match self {
             AlphaResolvedVisibility::Public => {
                 // unit
                 let mut s = serializer.serialize_struct("AlphaResolvedVisibility", 1)?;
@@ -1980,8 +1980,8 @@ impl ::serde::ser::Serialize for CreateSharedLinkError {
     fn serialize<S: ::serde::ser::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
         // union serializer
         use serde::ser::SerializeStruct;
-        match *self {
-            CreateSharedLinkError::Path(ref x) => {
+        match self {
+            CreateSharedLinkError::Path(x) => {
                 // union or polymporphic struct
                 let mut s = serializer.serialize_struct("CreateSharedLinkError", 2)?;
                 s.serialize_field(".tag", "path")?;
@@ -2199,8 +2199,8 @@ impl ::serde::ser::Serialize for CreateSharedLinkWithSettingsError {
     fn serialize<S: ::serde::ser::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
         // union serializer
         use serde::ser::SerializeStruct;
-        match *self {
-            CreateSharedLinkWithSettingsError::Path(ref x) => {
+        match self {
+            CreateSharedLinkWithSettingsError::Path(x) => {
                 // union or polymporphic struct
                 let mut s = serializer.serialize_struct("CreateSharedLinkWithSettingsError", 2)?;
                 s.serialize_field(".tag", "path")?;
@@ -2213,14 +2213,14 @@ impl ::serde::ser::Serialize for CreateSharedLinkWithSettingsError {
                 s.serialize_field(".tag", "email_not_verified")?;
                 s.end()
             }
-            CreateSharedLinkWithSettingsError::SharedLinkAlreadyExists(ref x) => {
+            CreateSharedLinkWithSettingsError::SharedLinkAlreadyExists(x) => {
                 // union or polymporphic struct
                 let mut s = serializer.serialize_struct("CreateSharedLinkWithSettingsError", 2)?;
                 s.serialize_field(".tag", "shared_link_already_exists")?;
                 s.serialize_field("shared_link_already_exists", x)?;
                 s.end()
             }
-            CreateSharedLinkWithSettingsError::SettingsError(ref x) => {
+            CreateSharedLinkWithSettingsError::SettingsError(x) => {
                 // union or polymporphic struct
                 let mut s = serializer.serialize_struct("CreateSharedLinkWithSettingsError", 2)?;
                 s.serialize_field(".tag", "settings_error")?;
@@ -2565,7 +2565,7 @@ impl ::serde::ser::Serialize for FileAction {
     fn serialize<S: ::serde::ser::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
         // union serializer
         use serde::ser::SerializeStruct;
-        match *self {
+        match self {
             FileAction::DisableViewerInfo => {
                 // unit
                 let mut s = serializer.serialize_struct("FileAction", 1)?;
@@ -2712,22 +2712,22 @@ impl ::serde::ser::Serialize for FileErrorResult {
     fn serialize<S: ::serde::ser::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
         // union serializer
         use serde::ser::SerializeStruct;
-        match *self {
-            FileErrorResult::FileNotFoundError(ref x) => {
+        match self {
+            FileErrorResult::FileNotFoundError(x) => {
                 // primitive
                 let mut s = serializer.serialize_struct("FileErrorResult", 2)?;
                 s.serialize_field(".tag", "file_not_found_error")?;
                 s.serialize_field("file_not_found_error", x)?;
                 s.end()
             }
-            FileErrorResult::InvalidFileActionError(ref x) => {
+            FileErrorResult::InvalidFileActionError(x) => {
                 // primitive
                 let mut s = serializer.serialize_struct("FileErrorResult", 2)?;
                 s.serialize_field(".tag", "invalid_file_action_error")?;
                 s.serialize_field("invalid_file_action_error", x)?;
                 s.end()
             }
-            FileErrorResult::PermissionDeniedError(ref x) => {
+            FileErrorResult::PermissionDeniedError(x) => {
                 // primitive
                 let mut s = serializer.serialize_struct("FileErrorResult", 2)?;
                 s.serialize_field(".tag", "permission_denied_error")?;
@@ -3094,7 +3094,7 @@ impl ::serde::ser::Serialize for FileMemberActionError {
     fn serialize<S: ::serde::ser::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
         // union serializer
         use serde::ser::SerializeStruct;
-        match *self {
+        match self {
             FileMemberActionError::InvalidMember => {
                 // unit
                 let mut s = serializer.serialize_struct("FileMemberActionError", 1)?;
@@ -3107,14 +3107,14 @@ impl ::serde::ser::Serialize for FileMemberActionError {
                 s.serialize_field(".tag", "no_permission")?;
                 s.end()
             }
-            FileMemberActionError::AccessError(ref x) => {
+            FileMemberActionError::AccessError(x) => {
                 // union or polymporphic struct
                 let mut s = serializer.serialize_struct("FileMemberActionError", 2)?;
                 s.serialize_field(".tag", "access_error")?;
                 s.serialize_field("access_error", x)?;
                 s.end()
             }
-            FileMemberActionError::NoExplicitAccess(ref x) => {
+            FileMemberActionError::NoExplicitAccess(x) => {
                 // struct
                 let mut s = serializer.serialize_struct("FileMemberActionError", 4)?;
                 s.serialize_field(".tag", "no_explicit_access")?;
@@ -3204,15 +3204,15 @@ impl ::serde::ser::Serialize for FileMemberActionIndividualResult {
     fn serialize<S: ::serde::ser::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
         // union serializer
         use serde::ser::SerializeStruct;
-        match *self {
-            FileMemberActionIndividualResult::Success(ref x) => {
+        match self {
+            FileMemberActionIndividualResult::Success(x) => {
                 // union or polymporphic struct
                 let mut s = serializer.serialize_struct("FileMemberActionIndividualResult", 2)?;
                 s.serialize_field(".tag", "success")?;
                 s.serialize_field("success", x)?;
                 s.end()
             }
-            FileMemberActionIndividualResult::MemberError(ref x) => {
+            FileMemberActionIndividualResult::MemberError(x) => {
                 // union or polymporphic struct
                 let mut s = serializer.serialize_struct("FileMemberActionIndividualResult", 2)?;
                 s.serialize_field(".tag", "member_error")?;
@@ -3422,15 +3422,15 @@ impl ::serde::ser::Serialize for FileMemberRemoveActionResult {
     fn serialize<S: ::serde::ser::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
         // union serializer
         use serde::ser::SerializeStruct;
-        match *self {
-            FileMemberRemoveActionResult::Success(ref x) => {
+        match self {
+            FileMemberRemoveActionResult::Success(x) => {
                 // struct
                 let mut s = serializer.serialize_struct("FileMemberRemoveActionResult", 4)?;
                 s.serialize_field(".tag", "success")?;
                 x.internal_serialize::<S>(&mut s)?;
                 s.end()
             }
-            FileMemberRemoveActionResult::MemberError(ref x) => {
+            FileMemberRemoveActionResult::MemberError(x) => {
                 // union or polymporphic struct
                 let mut s = serializer.serialize_struct("FileMemberRemoveActionResult", 2)?;
                 s.serialize_field(".tag", "member_error")?;
@@ -3663,7 +3663,7 @@ impl ::serde::ser::Serialize for FolderAction {
     fn serialize<S: ::serde::ser::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
         // union serializer
         use serde::ser::SerializeStruct;
-        match *self {
+        match self {
             FolderAction::ChangeOptions => {
                 // unit
                 let mut s = serializer.serialize_struct("FolderAction", 1)?;
@@ -4668,15 +4668,15 @@ impl ::serde::ser::Serialize for GetFileMetadataError {
     fn serialize<S: ::serde::ser::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
         // union serializer
         use serde::ser::SerializeStruct;
-        match *self {
-            GetFileMetadataError::UserError(ref x) => {
+        match self {
+            GetFileMetadataError::UserError(x) => {
                 // union or polymporphic struct
                 let mut s = serializer.serialize_struct("GetFileMetadataError", 2)?;
                 s.serialize_field(".tag", "user_error")?;
                 s.serialize_field("user_error", x)?;
                 s.end()
             }
-            GetFileMetadataError::AccessError(ref x) => {
+            GetFileMetadataError::AccessError(x) => {
                 // union or polymporphic struct
                 let mut s = serializer.serialize_struct("GetFileMetadataError", 2)?;
                 s.serialize_field(".tag", "access_error")?;
@@ -4761,15 +4761,15 @@ impl ::serde::ser::Serialize for GetFileMetadataIndividualResult {
     fn serialize<S: ::serde::ser::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
         // union serializer
         use serde::ser::SerializeStruct;
-        match *self {
-            GetFileMetadataIndividualResult::Metadata(ref x) => {
+        match self {
+            GetFileMetadataIndividualResult::Metadata(x) => {
                 // struct
                 let mut s = serializer.serialize_struct("GetFileMetadataIndividualResult", 15)?;
                 s.serialize_field(".tag", "metadata")?;
                 x.internal_serialize::<S>(&mut s)?;
                 s.end()
             }
-            GetFileMetadataIndividualResult::AccessError(ref x) => {
+            GetFileMetadataIndividualResult::AccessError(x) => {
                 // union or polymporphic struct
                 let mut s = serializer.serialize_struct("GetFileMetadataIndividualResult", 2)?;
                 s.serialize_field(".tag", "access_error")?;
@@ -4949,7 +4949,7 @@ impl ::serde::ser::Serialize for GetSharedLinkFileError {
     fn serialize<S: ::serde::ser::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
         // union serializer
         use serde::ser::SerializeStruct;
-        match *self {
+        match self {
             GetSharedLinkFileError::SharedLinkNotFound => {
                 // unit
                 let mut s = serializer.serialize_struct("GetSharedLinkFileError", 1)?;
@@ -5265,13 +5265,13 @@ impl ::serde::ser::Serialize for GetSharedLinksError {
     fn serialize<S: ::serde::ser::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
         // union serializer
         use serde::ser::SerializeStruct;
-        match *self {
-            GetSharedLinksError::Path(ref x) => {
+        match self {
+            GetSharedLinksError::Path(x) => {
                 // nullable (struct or primitive)
                 let n = if x.is_some() { 2 } else { 1 };
                 let mut s = serializer.serialize_struct("GetSharedLinksError", n)?;
                 s.serialize_field(".tag", "path")?;
-                if let Some(ref x) = x {
+                if let Some(x) = x {
                     s.serialize_field("path", &x)?;
                 }
                 s.end()
@@ -6073,8 +6073,8 @@ impl ::serde::ser::Serialize for InviteeInfo {
     fn serialize<S: ::serde::ser::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
         // union serializer
         use serde::ser::SerializeStruct;
-        match *self {
-            InviteeInfo::Email(ref x) => {
+        match self {
+            InviteeInfo::Email(x) => {
                 // primitive
                 let mut s = serializer.serialize_struct("InviteeInfo", 2)?;
                 s.serialize_field(".tag", "email")?;
@@ -6358,22 +6358,22 @@ impl ::serde::ser::Serialize for JobError {
     fn serialize<S: ::serde::ser::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
         // union serializer
         use serde::ser::SerializeStruct;
-        match *self {
-            JobError::UnshareFolderError(ref x) => {
+        match self {
+            JobError::UnshareFolderError(x) => {
                 // union or polymporphic struct
                 let mut s = serializer.serialize_struct("JobError", 2)?;
                 s.serialize_field(".tag", "unshare_folder_error")?;
                 s.serialize_field("unshare_folder_error", x)?;
                 s.end()
             }
-            JobError::RemoveFolderMemberError(ref x) => {
+            JobError::RemoveFolderMemberError(x) => {
                 // union or polymporphic struct
                 let mut s = serializer.serialize_struct("JobError", 2)?;
                 s.serialize_field(".tag", "remove_folder_member_error")?;
                 s.serialize_field("remove_folder_member_error", x)?;
                 s.end()
             }
-            JobError::RelinquishFolderMembershipError(ref x) => {
+            JobError::RelinquishFolderMembershipError(x) => {
                 // union or polymporphic struct
                 let mut s = serializer.serialize_struct("JobError", 2)?;
                 s.serialize_field(".tag", "relinquish_folder_membership_error")?;
@@ -6459,7 +6459,7 @@ impl ::serde::ser::Serialize for JobStatus {
     fn serialize<S: ::serde::ser::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
         // union serializer
         use serde::ser::SerializeStruct;
-        match *self {
+        match self {
             JobStatus::InProgress => {
                 // unit
                 let mut s = serializer.serialize_struct("JobStatus", 1)?;
@@ -6472,7 +6472,7 @@ impl ::serde::ser::Serialize for JobStatus {
                 s.serialize_field(".tag", "complete")?;
                 s.end()
             }
-            JobStatus::Failed(ref x) => {
+            JobStatus::Failed(x) => {
                 // union or polymporphic struct
                 let mut s = serializer.serialize_struct("JobStatus", 2)?;
                 s.serialize_field(".tag", "failed")?;
@@ -6538,7 +6538,7 @@ impl ::serde::ser::Serialize for LinkAccessLevel {
     fn serialize<S: ::serde::ser::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
         // union serializer
         use serde::ser::SerializeStruct;
-        match *self {
+        match self {
             LinkAccessLevel::Viewer => {
                 // unit
                 let mut s = serializer.serialize_struct("LinkAccessLevel", 1)?;
@@ -6620,7 +6620,7 @@ impl ::serde::ser::Serialize for LinkAction {
     fn serialize<S: ::serde::ser::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
         // union serializer
         use serde::ser::SerializeStruct;
-        match *self {
+        match self {
             LinkAction::ChangeAccessLevel => {
                 // unit
                 let mut s = serializer.serialize_struct("LinkAction", 1)?;
@@ -6724,7 +6724,7 @@ impl ::serde::ser::Serialize for LinkAudience {
     fn serialize<S: ::serde::ser::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
         // union serializer
         use serde::ser::SerializeStruct;
-        match *self {
+        match self {
             LinkAudience::Public => {
                 // unit
                 let mut s = serializer.serialize_struct("LinkAudience", 1)?;
@@ -6825,7 +6825,7 @@ impl ::serde::ser::Serialize for LinkAudienceDisallowedReason {
     fn serialize<S: ::serde::ser::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
         // union serializer
         use serde::ser::SerializeStruct;
-        match *self {
+        match self {
             LinkAudienceDisallowedReason::DeleteAndRecreate => {
                 // unit
                 let mut s = serializer.serialize_struct("LinkAudienceDisallowedReason", 1)?;
@@ -7059,14 +7059,14 @@ impl ::serde::ser::Serialize for LinkExpiry {
     fn serialize<S: ::serde::ser::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
         // union serializer
         use serde::ser::SerializeStruct;
-        match *self {
+        match self {
             LinkExpiry::RemoveExpiry => {
                 // unit
                 let mut s = serializer.serialize_struct("LinkExpiry", 1)?;
                 s.serialize_field(".tag", "remove_expiry")?;
                 s.end()
             }
-            LinkExpiry::SetExpiry(ref x) => {
+            LinkExpiry::SetExpiry(x) => {
                 // primitive
                 let mut s = serializer.serialize_struct("LinkExpiry", 2)?;
                 s.serialize_field(".tag", "set_expiry")?;
@@ -7125,14 +7125,14 @@ impl ::serde::ser::Serialize for LinkMetadata {
     fn serialize<S: ::serde::ser::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
         // polymorphic struct serializer
         use serde::ser::SerializeStruct;
-        match *self {
-            LinkMetadata::Path(ref x) => {
+        match self {
+            LinkMetadata::Path(x) => {
                 let mut s = serializer.serialize_struct("LinkMetadata", 5)?;
                 s.serialize_field(".tag", "path")?;
                 x.internal_serialize::<S>(&mut s)?;
                 s.end()
             }
-            LinkMetadata::Collection(ref x) => {
+            LinkMetadata::Collection(x) => {
                 let mut s = serializer.serialize_struct("LinkMetadata", 4)?;
                 s.serialize_field(".tag", "collection")?;
                 x.internal_serialize::<S>(&mut s)?;
@@ -7196,14 +7196,14 @@ impl ::serde::ser::Serialize for LinkPassword {
     fn serialize<S: ::serde::ser::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
         // union serializer
         use serde::ser::SerializeStruct;
-        match *self {
+        match self {
             LinkPassword::RemovePassword => {
                 // unit
                 let mut s = serializer.serialize_struct("LinkPassword", 1)?;
                 s.serialize_field(".tag", "remove_password")?;
                 s.end()
             }
-            LinkPassword::SetPassword(ref x) => {
+            LinkPassword::SetPassword(x) => {
                 // primitive
                 let mut s = serializer.serialize_struct("LinkPassword", 2)?;
                 s.serialize_field(".tag", "set_password")?;
@@ -8426,15 +8426,15 @@ impl ::serde::ser::Serialize for ListFileMembersContinueError {
     fn serialize<S: ::serde::ser::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
         // union serializer
         use serde::ser::SerializeStruct;
-        match *self {
-            ListFileMembersContinueError::UserError(ref x) => {
+        match self {
+            ListFileMembersContinueError::UserError(x) => {
                 // union or polymporphic struct
                 let mut s = serializer.serialize_struct("ListFileMembersContinueError", 2)?;
                 s.serialize_field(".tag", "user_error")?;
                 s.serialize_field("user_error", x)?;
                 s.end()
             }
-            ListFileMembersContinueError::AccessError(ref x) => {
+            ListFileMembersContinueError::AccessError(x) => {
                 // union or polymporphic struct
                 let mut s = serializer.serialize_struct("ListFileMembersContinueError", 2)?;
                 s.serialize_field(".tag", "access_error")?;
@@ -8634,15 +8634,15 @@ impl ::serde::ser::Serialize for ListFileMembersError {
     fn serialize<S: ::serde::ser::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
         // union serializer
         use serde::ser::SerializeStruct;
-        match *self {
-            ListFileMembersError::UserError(ref x) => {
+        match self {
+            ListFileMembersError::UserError(x) => {
                 // union or polymporphic struct
                 let mut s = serializer.serialize_struct("ListFileMembersError", 2)?;
                 s.serialize_field(".tag", "user_error")?;
                 s.serialize_field("user_error", x)?;
                 s.end()
             }
-            ListFileMembersError::AccessError(ref x) => {
+            ListFileMembersError::AccessError(x) => {
                 // union or polymporphic struct
                 let mut s = serializer.serialize_struct("ListFileMembersError", 2)?;
                 s.serialize_field(".tag", "access_error")?;
@@ -8727,15 +8727,15 @@ impl ::serde::ser::Serialize for ListFileMembersIndividualResult {
     fn serialize<S: ::serde::ser::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
         // union serializer
         use serde::ser::SerializeStruct;
-        match *self {
-            ListFileMembersIndividualResult::Result(ref x) => {
+        match self {
+            ListFileMembersIndividualResult::Result(x) => {
                 // struct
                 let mut s = serializer.serialize_struct("ListFileMembersIndividualResult", 3)?;
                 s.serialize_field(".tag", "result")?;
                 x.internal_serialize::<S>(&mut s)?;
                 s.end()
             }
-            ListFileMembersIndividualResult::AccessError(ref x) => {
+            ListFileMembersIndividualResult::AccessError(x) => {
                 // union or polymporphic struct
                 let mut s = serializer.serialize_struct("ListFileMembersIndividualResult", 2)?;
                 s.serialize_field(".tag", "access_error")?;
@@ -9006,8 +9006,8 @@ impl ::serde::ser::Serialize for ListFilesContinueError {
     fn serialize<S: ::serde::ser::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
         // union serializer
         use serde::ser::SerializeStruct;
-        match *self {
-            ListFilesContinueError::UserError(ref x) => {
+        match self {
+            ListFilesContinueError::UserError(x) => {
                 // union or polymporphic struct
                 let mut s = serializer.serialize_struct("ListFilesContinueError", 2)?;
                 s.serialize_field(".tag", "user_error")?;
@@ -9443,8 +9443,8 @@ impl ::serde::ser::Serialize for ListFolderMembersContinueError {
     fn serialize<S: ::serde::ser::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
         // union serializer
         use serde::ser::SerializeStruct;
-        match *self {
-            ListFolderMembersContinueError::AccessError(ref x) => {
+        match self {
+            ListFolderMembersContinueError::AccessError(x) => {
                 // union or polymporphic struct
                 let mut s = serializer.serialize_struct("ListFolderMembersContinueError", 2)?;
                 s.serialize_field(".tag", "access_error")?;
@@ -9837,7 +9837,7 @@ impl ::serde::ser::Serialize for ListFoldersContinueError {
     fn serialize<S: ::serde::ser::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
         // union serializer
         use serde::ser::SerializeStruct;
-        match *self {
+        match self {
             ListFoldersContinueError::InvalidCursor => {
                 // unit
                 let mut s = serializer.serialize_struct("ListFoldersContinueError", 1)?;
@@ -10150,8 +10150,8 @@ impl ::serde::ser::Serialize for ListSharedLinksError {
     fn serialize<S: ::serde::ser::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
         // union serializer
         use serde::ser::SerializeStruct;
-        match *self {
-            ListSharedLinksError::Path(ref x) => {
+        match self {
+            ListSharedLinksError::Path(x) => {
                 // union or polymporphic struct
                 let mut s = serializer.serialize_struct("ListSharedLinksError", 2)?;
                 s.serialize_field(".tag", "path")?;
@@ -10499,7 +10499,7 @@ impl ::serde::ser::Serialize for MemberAction {
     fn serialize<S: ::serde::ser::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
         // union serializer
         use serde::ser::SerializeStruct;
-        match *self {
+        match self {
             MemberAction::LeaveACopy => {
                 // unit
                 let mut s = serializer.serialize_struct("MemberAction", 1)?;
@@ -10715,7 +10715,7 @@ impl ::serde::ser::Serialize for MemberPolicy {
     fn serialize<S: ::serde::ser::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
         // union serializer
         use serde::ser::SerializeStruct;
-        match *self {
+        match self {
             MemberPolicy::Team => {
                 // unit
                 let mut s = serializer.serialize_struct("MemberPolicy", 1)?;
@@ -10793,15 +10793,15 @@ impl ::serde::ser::Serialize for MemberSelector {
     fn serialize<S: ::serde::ser::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
         // union serializer
         use serde::ser::SerializeStruct;
-        match *self {
-            MemberSelector::DropboxId(ref x) => {
+        match self {
+            MemberSelector::DropboxId(x) => {
                 // primitive
                 let mut s = serializer.serialize_struct("MemberSelector", 2)?;
                 s.serialize_field(".tag", "dropbox_id")?;
                 s.serialize_field("dropbox_id", x)?;
                 s.end()
             }
-            MemberSelector::Email(ref x) => {
+            MemberSelector::Email(x) => {
                 // primitive
                 let mut s = serializer.serialize_struct("MemberSelector", 2)?;
                 s.serialize_field(".tag", "email")?;
@@ -11158,7 +11158,7 @@ impl ::serde::ser::Serialize for ModifySharedLinkSettingsError {
     fn serialize<S: ::serde::ser::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
         // union serializer
         use serde::ser::SerializeStruct;
-        match *self {
+        match self {
             ModifySharedLinkSettingsError::SharedLinkNotFound => {
                 // unit
                 let mut s = serializer.serialize_struct("ModifySharedLinkSettingsError", 1)?;
@@ -11177,7 +11177,7 @@ impl ::serde::ser::Serialize for ModifySharedLinkSettingsError {
                 s.serialize_field(".tag", "unsupported_link_type")?;
                 s.end()
             }
-            ModifySharedLinkSettingsError::SettingsError(ref x) => {
+            ModifySharedLinkSettingsError::SettingsError(x) => {
                 // union or polymporphic struct
                 let mut s = serializer.serialize_struct("ModifySharedLinkSettingsError", 2)?;
                 s.serialize_field(".tag", "settings_error")?;
@@ -11386,8 +11386,8 @@ impl ::serde::ser::Serialize for MountFolderError {
     fn serialize<S: ::serde::ser::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
         // union serializer
         use serde::ser::SerializeStruct;
-        match *self {
-            MountFolderError::AccessError(ref x) => {
+        match self {
+            MountFolderError::AccessError(x) => {
                 // union or polymporphic struct
                 let mut s = serializer.serialize_struct("MountFolderError", 2)?;
                 s.serialize_field(".tag", "access_error")?;
@@ -11400,7 +11400,7 @@ impl ::serde::ser::Serialize for MountFolderError {
                 s.serialize_field(".tag", "inside_shared_folder")?;
                 s.end()
             }
-            MountFolderError::InsufficientQuota(ref x) => {
+            MountFolderError::InsufficientQuota(x) => {
                 // struct
                 let mut s = serializer.serialize_struct("MountFolderError", 4)?;
                 s.serialize_field(".tag", "insufficient_quota")?;
@@ -11776,7 +11776,7 @@ impl ::serde::ser::Serialize for PendingUploadMode {
     fn serialize<S: ::serde::ser::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
         // union serializer
         use serde::ser::SerializeStruct;
-        match *self {
+        match self {
             PendingUploadMode::File => {
                 // unit
                 let mut s = serializer.serialize_struct("PendingUploadMode", 1)?;
@@ -11892,7 +11892,7 @@ impl ::serde::ser::Serialize for PermissionDeniedReason {
     fn serialize<S: ::serde::ser::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
         // union serializer
         use serde::ser::SerializeStruct;
-        match *self {
+        match self {
             PermissionDeniedReason::UserNotSameTeamAsOwner => {
                 // unit
                 let mut s = serializer.serialize_struct("PermissionDeniedReason", 1)?;
@@ -11977,7 +11977,7 @@ impl ::serde::ser::Serialize for PermissionDeniedReason {
                 s.serialize_field(".tag", "restricted_by_parent_folder")?;
                 s.end()
             }
-            PermissionDeniedReason::InsufficientPlan(ref x) => {
+            PermissionDeniedReason::InsufficientPlan(x) => {
                 // struct
                 let mut s = serializer.serialize_struct("PermissionDeniedReason", 3)?;
                 s.serialize_field(".tag", "insufficient_plan")?;
@@ -12137,8 +12137,8 @@ impl ::serde::ser::Serialize for RelinquishFileMembershipError {
     fn serialize<S: ::serde::ser::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
         // union serializer
         use serde::ser::SerializeStruct;
-        match *self {
-            RelinquishFileMembershipError::AccessError(ref x) => {
+        match self {
+            RelinquishFileMembershipError::AccessError(x) => {
                 // union or polymporphic struct
                 let mut s = serializer.serialize_struct("RelinquishFileMembershipError", 2)?;
                 s.serialize_field(".tag", "access_error")?;
@@ -12370,8 +12370,8 @@ impl ::serde::ser::Serialize for RelinquishFolderMembershipError {
     fn serialize<S: ::serde::ser::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
         // union serializer
         use serde::ser::SerializeStruct;
-        match *self {
-            RelinquishFolderMembershipError::AccessError(ref x) => {
+        match self {
+            RelinquishFolderMembershipError::AccessError(x) => {
                 // union or polymporphic struct
                 let mut s = serializer.serialize_struct("RelinquishFolderMembershipError", 2)?;
                 s.serialize_field(".tag", "access_error")?;
@@ -12613,22 +12613,22 @@ impl ::serde::ser::Serialize for RemoveFileMemberError {
     fn serialize<S: ::serde::ser::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
         // union serializer
         use serde::ser::SerializeStruct;
-        match *self {
-            RemoveFileMemberError::UserError(ref x) => {
+        match self {
+            RemoveFileMemberError::UserError(x) => {
                 // union or polymporphic struct
                 let mut s = serializer.serialize_struct("RemoveFileMemberError", 2)?;
                 s.serialize_field(".tag", "user_error")?;
                 s.serialize_field("user_error", x)?;
                 s.end()
             }
-            RemoveFileMemberError::AccessError(ref x) => {
+            RemoveFileMemberError::AccessError(x) => {
                 // union or polymporphic struct
                 let mut s = serializer.serialize_struct("RemoveFileMemberError", 2)?;
                 s.serialize_field(".tag", "access_error")?;
                 s.serialize_field("access_error", x)?;
                 s.end()
             }
-            RemoveFileMemberError::NoExplicitAccess(ref x) => {
+            RemoveFileMemberError::NoExplicitAccess(x) => {
                 // struct
                 let mut s = serializer.serialize_struct("RemoveFileMemberError", 4)?;
                 s.serialize_field(".tag", "no_explicit_access")?;
@@ -12863,15 +12863,15 @@ impl ::serde::ser::Serialize for RemoveFolderMemberError {
     fn serialize<S: ::serde::ser::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
         // union serializer
         use serde::ser::SerializeStruct;
-        match *self {
-            RemoveFolderMemberError::AccessError(ref x) => {
+        match self {
+            RemoveFolderMemberError::AccessError(x) => {
                 // union or polymporphic struct
                 let mut s = serializer.serialize_struct("RemoveFolderMemberError", 2)?;
                 s.serialize_field(".tag", "access_error")?;
                 s.serialize_field("access_error", x)?;
                 s.end()
             }
-            RemoveFolderMemberError::MemberError(ref x) => {
+            RemoveFolderMemberError::MemberError(x) => {
                 // union or polymporphic struct
                 let mut s = serializer.serialize_struct("RemoveFolderMemberError", 2)?;
                 s.serialize_field(".tag", "member_error")?;
@@ -12990,21 +12990,21 @@ impl ::serde::ser::Serialize for RemoveMemberJobStatus {
     fn serialize<S: ::serde::ser::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
         // union serializer
         use serde::ser::SerializeStruct;
-        match *self {
+        match self {
             RemoveMemberJobStatus::InProgress => {
                 // unit
                 let mut s = serializer.serialize_struct("RemoveMemberJobStatus", 1)?;
                 s.serialize_field(".tag", "in_progress")?;
                 s.end()
             }
-            RemoveMemberJobStatus::Complete(ref x) => {
+            RemoveMemberJobStatus::Complete(x) => {
                 // struct
                 let mut s = serializer.serialize_struct("RemoveMemberJobStatus", 4)?;
                 s.serialize_field(".tag", "complete")?;
                 x.internal_serialize::<S>(&mut s)?;
                 s.end()
             }
-            RemoveMemberJobStatus::Failed(ref x) => {
+            RemoveMemberJobStatus::Failed(x) => {
                 // union or polymporphic struct
                 let mut s = serializer.serialize_struct("RemoveMemberJobStatus", 2)?;
                 s.serialize_field(".tag", "failed")?;
@@ -13079,7 +13079,7 @@ impl ::serde::ser::Serialize for RequestedLinkAccessLevel {
     fn serialize<S: ::serde::ser::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
         // union serializer
         use serde::ser::SerializeStruct;
-        match *self {
+        match self {
             RequestedLinkAccessLevel::Viewer => {
                 // unit
                 let mut s = serializer.serialize_struct("RequestedLinkAccessLevel", 1)?;
@@ -13159,7 +13159,7 @@ impl ::serde::ser::Serialize for RequestedVisibility {
     fn serialize<S: ::serde::ser::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
         // union serializer
         use serde::ser::SerializeStruct;
-        match *self {
+        match self {
             RequestedVisibility::Public => {
                 // unit
                 let mut s = serializer.serialize_struct("RequestedVisibility", 1)?;
@@ -13256,7 +13256,7 @@ impl ::serde::ser::Serialize for ResolvedVisibility {
     fn serialize<S: ::serde::ser::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
         // union serializer
         use serde::ser::SerializeStruct;
-        match *self {
+        match self {
             ResolvedVisibility::Public => {
                 // unit
                 let mut s = serializer.serialize_struct("ResolvedVisibility", 1)?;
@@ -13460,7 +13460,7 @@ impl ::serde::ser::Serialize for RevokeSharedLinkError {
     fn serialize<S: ::serde::ser::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
         // union serializer
         use serde::ser::SerializeStruct;
-        match *self {
+        match self {
             RevokeSharedLinkError::SharedLinkNotFound => {
                 // unit
                 let mut s = serializer.serialize_struct("RevokeSharedLinkError", 1)?;
@@ -13679,8 +13679,8 @@ impl ::serde::ser::Serialize for SetAccessInheritanceError {
     fn serialize<S: ::serde::ser::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
         // union serializer
         use serde::ser::SerializeStruct;
-        match *self {
-            SetAccessInheritanceError::AccessError(ref x) => {
+        match self {
+            SetAccessInheritanceError::AccessError(x) => {
                 // union or polymporphic struct
                 let mut s = serializer.serialize_struct("SetAccessInheritanceError", 2)?;
                 s.serialize_field(".tag", "access_error")?;
@@ -14267,14 +14267,14 @@ impl ::serde::ser::Serialize for ShareFolderError {
     fn serialize<S: ::serde::ser::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
         // union serializer
         use serde::ser::SerializeStruct;
-        match *self {
+        match self {
             ShareFolderError::EmailUnverified => {
                 // unit
                 let mut s = serializer.serialize_struct("ShareFolderError", 1)?;
                 s.serialize_field(".tag", "email_unverified")?;
                 s.end()
             }
-            ShareFolderError::BadPath(ref x) => {
+            ShareFolderError::BadPath(x) => {
                 // union or polymporphic struct
                 let mut s = serializer.serialize_struct("ShareFolderError", 2)?;
                 s.serialize_field(".tag", "bad_path")?;
@@ -14399,14 +14399,14 @@ impl ::serde::ser::Serialize for ShareFolderErrorBase {
     fn serialize<S: ::serde::ser::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
         // union serializer
         use serde::ser::SerializeStruct;
-        match *self {
+        match self {
             ShareFolderErrorBase::EmailUnverified => {
                 // unit
                 let mut s = serializer.serialize_struct("ShareFolderErrorBase", 1)?;
                 s.serialize_field(".tag", "email_unverified")?;
                 s.end()
             }
-            ShareFolderErrorBase::BadPath(ref x) => {
+            ShareFolderErrorBase::BadPath(x) => {
                 // union or polymporphic struct
                 let mut s = serializer.serialize_struct("ShareFolderErrorBase", 2)?;
                 s.serialize_field(".tag", "bad_path")?;
@@ -14481,21 +14481,21 @@ impl ::serde::ser::Serialize for ShareFolderJobStatus {
     fn serialize<S: ::serde::ser::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
         // union serializer
         use serde::ser::SerializeStruct;
-        match *self {
+        match self {
             ShareFolderJobStatus::InProgress => {
                 // unit
                 let mut s = serializer.serialize_struct("ShareFolderJobStatus", 1)?;
                 s.serialize_field(".tag", "in_progress")?;
                 s.end()
             }
-            ShareFolderJobStatus::Complete(ref x) => {
+            ShareFolderJobStatus::Complete(x) => {
                 // struct
                 let mut s = serializer.serialize_struct("ShareFolderJobStatus", 18)?;
                 s.serialize_field(".tag", "complete")?;
                 x.internal_serialize::<S>(&mut s)?;
                 s.end()
             }
-            ShareFolderJobStatus::Failed(ref x) => {
+            ShareFolderJobStatus::Failed(x) => {
                 // union or polymporphic struct
                 let mut s = serializer.serialize_struct("ShareFolderJobStatus", 2)?;
                 s.serialize_field(".tag", "failed")?;
@@ -14562,15 +14562,15 @@ impl ::serde::ser::Serialize for ShareFolderLaunch {
     fn serialize<S: ::serde::ser::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
         // union serializer
         use serde::ser::SerializeStruct;
-        match *self {
-            ShareFolderLaunch::AsyncJobId(ref x) => {
+        match self {
+            ShareFolderLaunch::AsyncJobId(x) => {
                 // primitive
                 let mut s = serializer.serialize_struct("ShareFolderLaunch", 2)?;
                 s.serialize_field(".tag", "async_job_id")?;
                 s.serialize_field("async_job_id", x)?;
                 s.end()
             }
-            ShareFolderLaunch::Complete(ref x) => {
+            ShareFolderLaunch::Complete(x) => {
                 // struct
                 let mut s = serializer.serialize_struct("ShareFolderLaunch", 18)?;
                 s.serialize_field(".tag", "complete")?;
@@ -14692,7 +14692,7 @@ impl ::serde::ser::Serialize for SharePathError {
     fn serialize<S: ::serde::ser::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
         // union serializer
         use serde::ser::SerializeStruct;
-        match *self {
+        match self {
             SharePathError::IsFile => {
                 // unit
                 let mut s = serializer.serialize_struct("SharePathError", 1)?;
@@ -14747,7 +14747,7 @@ impl ::serde::ser::Serialize for SharePathError {
                 s.serialize_field(".tag", "inside_public_folder")?;
                 s.end()
             }
-            SharePathError::AlreadyShared(ref x) => {
+            SharePathError::AlreadyShared(x) => {
                 // struct
                 let mut s = serializer.serialize_struct("SharePathError", 18)?;
                 s.serialize_field(".tag", "already_shared")?;
@@ -15837,7 +15837,7 @@ impl ::serde::ser::Serialize for SharedFolderAccessError {
     fn serialize<S: ::serde::ser::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
         // union serializer
         use serde::ser::SerializeStruct;
-        match *self {
+        match self {
             SharedFolderAccessError::InvalidId => {
                 // unit
                 let mut s = serializer.serialize_struct("SharedFolderAccessError", 1)?;
@@ -15940,7 +15940,7 @@ impl ::serde::ser::Serialize for SharedFolderMemberError {
     fn serialize<S: ::serde::ser::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
         // union serializer
         use serde::ser::SerializeStruct;
-        match *self {
+        match self {
             SharedFolderMemberError::InvalidDropboxId => {
                 // unit
                 let mut s = serializer.serialize_struct("SharedFolderMemberError", 1)?;
@@ -15953,7 +15953,7 @@ impl ::serde::ser::Serialize for SharedFolderMemberError {
                 s.serialize_field(".tag", "not_a_member")?;
                 s.end()
             }
-            SharedFolderMemberError::NoExplicitAccess(ref x) => {
+            SharedFolderMemberError::NoExplicitAccess(x) => {
                 // struct
                 let mut s = serializer.serialize_struct("SharedFolderMemberError", 4)?;
                 s.serialize_field(".tag", "no_explicit_access")?;
@@ -16831,7 +16831,7 @@ impl ::serde::ser::Serialize for SharedLinkAccessFailureReason {
     fn serialize<S: ::serde::ser::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
         // union serializer
         use serde::ser::SerializeStruct;
-        match *self {
+        match self {
             SharedLinkAccessFailureReason::LoginRequired => {
                 // unit
                 let mut s = serializer.serialize_struct("SharedLinkAccessFailureReason", 1)?;
@@ -16916,8 +16916,8 @@ impl ::serde::ser::Serialize for SharedLinkAlreadyExistsMetadata {
     fn serialize<S: ::serde::ser::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
         // union serializer
         use serde::ser::SerializeStruct;
-        match *self {
-            SharedLinkAlreadyExistsMetadata::Metadata(ref x) => {
+        match self {
+            SharedLinkAlreadyExistsMetadata::Metadata(x) => {
                 // union or polymporphic struct
                 let mut s = serializer.serialize_struct("SharedLinkAlreadyExistsMetadata", 2)?;
                 s.serialize_field(".tag", "metadata")?;
@@ -16980,7 +16980,7 @@ impl ::serde::ser::Serialize for SharedLinkError {
     fn serialize<S: ::serde::ser::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
         // union serializer
         use serde::ser::SerializeStruct;
-        match *self {
+        match self {
             SharedLinkError::SharedLinkNotFound => {
                 // unit
                 let mut s = serializer.serialize_struct("SharedLinkError", 1)?;
@@ -17063,14 +17063,14 @@ impl ::serde::ser::Serialize for SharedLinkMetadata {
     fn serialize<S: ::serde::ser::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
         // polymorphic struct serializer
         use serde::ser::SerializeStruct;
-        match *self {
-            SharedLinkMetadata::File(ref x) => {
+        match self {
+            SharedLinkMetadata::File(x) => {
                 let mut s = serializer.serialize_struct("SharedLinkMetadata", 13)?;
                 s.serialize_field(".tag", "file")?;
                 x.internal_serialize::<S>(&mut s)?;
                 s.end()
             }
-            SharedLinkMetadata::Folder(ref x) => {
+            SharedLinkMetadata::Folder(x) => {
                 let mut s = serializer.serialize_struct("SharedLinkMetadata", 9)?;
                 s.serialize_field(".tag", "folder")?;
                 x.internal_serialize::<S>(&mut s)?;
@@ -17133,7 +17133,7 @@ impl ::serde::ser::Serialize for SharedLinkPolicy {
     fn serialize<S: ::serde::ser::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
         // union serializer
         use serde::ser::SerializeStruct;
-        match *self {
+        match self {
             SharedLinkPolicy::Anyone => {
                 // unit
                 let mut s = serializer.serialize_struct("SharedLinkPolicy", 1)?;
@@ -17404,7 +17404,7 @@ impl ::serde::ser::Serialize for SharedLinkSettingsError {
     fn serialize<S: ::serde::ser::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
         // union serializer
         use serde::ser::SerializeStruct;
-        match *self {
+        match self {
             SharedLinkSettingsError::InvalidSettings => {
                 // unit
                 let mut s = serializer.serialize_struct("SharedLinkSettingsError", 1)?;
@@ -17490,7 +17490,7 @@ impl ::serde::ser::Serialize for SharingFileAccessError {
     fn serialize<S: ::serde::ser::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
         // union serializer
         use serde::ser::SerializeStruct;
-        match *self {
+        match self {
             SharingFileAccessError::NoPermission => {
                 // unit
                 let mut s = serializer.serialize_struct("SharingFileAccessError", 1)?;
@@ -17588,7 +17588,7 @@ impl ::serde::ser::Serialize for SharingUserError {
     fn serialize<S: ::serde::ser::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
         // union serializer
         use serde::ser::SerializeStruct;
-        match *self {
+        match self {
             SharingUserError::EmailUnverified => {
                 // unit
                 let mut s = serializer.serialize_struct("SharingUserError", 1)?;
@@ -17916,8 +17916,8 @@ impl ::serde::ser::Serialize for TransferFolderError {
     fn serialize<S: ::serde::ser::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
         // union serializer
         use serde::ser::SerializeStruct;
-        match *self {
-            TransferFolderError::AccessError(ref x) => {
+        match self {
+            TransferFolderError::AccessError(x) => {
                 // union or polymporphic struct
                 let mut s = serializer.serialize_struct("TransferFolderError", 2)?;
                 s.serialize_field(".tag", "access_error")?;
@@ -18135,8 +18135,8 @@ impl ::serde::ser::Serialize for UnmountFolderError {
     fn serialize<S: ::serde::ser::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
         // union serializer
         use serde::ser::SerializeStruct;
-        match *self {
-            UnmountFolderError::AccessError(ref x) => {
+        match self {
+            UnmountFolderError::AccessError(x) => {
                 // union or polymporphic struct
                 let mut s = serializer.serialize_struct("UnmountFolderError", 2)?;
                 s.serialize_field(".tag", "access_error")?;
@@ -18330,15 +18330,15 @@ impl ::serde::ser::Serialize for UnshareFileError {
     fn serialize<S: ::serde::ser::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
         // union serializer
         use serde::ser::SerializeStruct;
-        match *self {
-            UnshareFileError::UserError(ref x) => {
+        match self {
+            UnshareFileError::UserError(x) => {
                 // union or polymporphic struct
                 let mut s = serializer.serialize_struct("UnshareFileError", 2)?;
                 s.serialize_field(".tag", "user_error")?;
                 s.serialize_field("user_error", x)?;
                 s.end()
             }
-            UnshareFileError::AccessError(ref x) => {
+            UnshareFileError::AccessError(x) => {
                 // union or polymporphic struct
                 let mut s = serializer.serialize_struct("UnshareFileError", 2)?;
                 s.serialize_field(".tag", "access_error")?;
@@ -18543,8 +18543,8 @@ impl ::serde::ser::Serialize for UnshareFolderError {
     fn serialize<S: ::serde::ser::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
         // union serializer
         use serde::ser::SerializeStruct;
-        match *self {
-            UnshareFolderError::AccessError(ref x) => {
+        match self {
+            UnshareFolderError::AccessError(x) => {
                 // union or polymporphic struct
                 let mut s = serializer.serialize_struct("UnshareFolderError", 2)?;
                 s.serialize_field(".tag", "access_error")?;
@@ -18913,22 +18913,22 @@ impl ::serde::ser::Serialize for UpdateFolderMemberError {
     fn serialize<S: ::serde::ser::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
         // union serializer
         use serde::ser::SerializeStruct;
-        match *self {
-            UpdateFolderMemberError::AccessError(ref x) => {
+        match self {
+            UpdateFolderMemberError::AccessError(x) => {
                 // union or polymporphic struct
                 let mut s = serializer.serialize_struct("UpdateFolderMemberError", 2)?;
                 s.serialize_field(".tag", "access_error")?;
                 s.serialize_field("access_error", x)?;
                 s.end()
             }
-            UpdateFolderMemberError::MemberError(ref x) => {
+            UpdateFolderMemberError::MemberError(x) => {
                 // union or polymporphic struct
                 let mut s = serializer.serialize_struct("UpdateFolderMemberError", 2)?;
                 s.serialize_field(".tag", "member_error")?;
                 s.serialize_field("member_error", x)?;
                 s.end()
             }
-            UpdateFolderMemberError::NoExplicitAccess(ref x) => {
+            UpdateFolderMemberError::NoExplicitAccess(x) => {
                 // union or polymporphic struct
                 let mut s = serializer.serialize_struct("UpdateFolderMemberError", 2)?;
                 s.serialize_field(".tag", "no_explicit_access")?;
@@ -19261,8 +19261,8 @@ impl ::serde::ser::Serialize for UpdateFolderPolicyError {
     fn serialize<S: ::serde::ser::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
         // union serializer
         use serde::ser::SerializeStruct;
-        match *self {
-            UpdateFolderPolicyError::AccessError(ref x) => {
+        match self {
+            UpdateFolderPolicyError::AccessError(x) => {
                 // union or polymporphic struct
                 let mut s = serializer.serialize_struct("UpdateFolderPolicyError", 2)?;
                 s.serialize_field(".tag", "access_error")?;
@@ -19927,7 +19927,7 @@ impl ::serde::ser::Serialize for ViewerInfoPolicy {
     fn serialize<S: ::serde::ser::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
         // union serializer
         use serde::ser::SerializeStruct;
-        match *self {
+        match self {
             ViewerInfoPolicy::Enabled => {
                 // unit
                 let mut s = serializer.serialize_struct("ViewerInfoPolicy", 1)?;
@@ -20007,7 +20007,7 @@ impl ::serde::ser::Serialize for Visibility {
     fn serialize<S: ::serde::ser::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
         // union serializer
         use serde::ser::SerializeStruct;
-        match *self {
+        match self {
             Visibility::Public => {
                 // unit
                 let mut s = serializer.serialize_struct("Visibility", 1)?;
@@ -20251,7 +20251,7 @@ impl ::serde::ser::Serialize for VisibilityPolicyDisallowedReason {
     fn serialize<S: ::serde::ser::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
         // union serializer
         use serde::ser::SerializeStruct;
-        match *self {
+        match self {
             VisibilityPolicyDisallowedReason::DeleteAndRecreate => {
                 // unit
                 let mut s = serializer.serialize_struct("VisibilityPolicyDisallowedReason", 1)?;

--- a/src/generated/types/team.rs
+++ b/src/generated/types/team.rs
@@ -392,64 +392,64 @@ impl ::serde::ser::Serialize for AddSecondaryEmailResult {
     fn serialize<S: ::serde::ser::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
         // union serializer
         use serde::ser::SerializeStruct;
-        match *self {
-            AddSecondaryEmailResult::Success(ref x) => {
+        match self {
+            AddSecondaryEmailResult::Success(x) => {
                 // struct
                 let mut s = serializer.serialize_struct("AddSecondaryEmailResult", 3)?;
                 s.serialize_field(".tag", "success")?;
                 x.internal_serialize::<S>(&mut s)?;
                 s.end()
             }
-            AddSecondaryEmailResult::Unavailable(ref x) => {
+            AddSecondaryEmailResult::Unavailable(x) => {
                 // primitive
                 let mut s = serializer.serialize_struct("AddSecondaryEmailResult", 2)?;
                 s.serialize_field(".tag", "unavailable")?;
                 s.serialize_field("unavailable", x)?;
                 s.end()
             }
-            AddSecondaryEmailResult::AlreadyPending(ref x) => {
+            AddSecondaryEmailResult::AlreadyPending(x) => {
                 // primitive
                 let mut s = serializer.serialize_struct("AddSecondaryEmailResult", 2)?;
                 s.serialize_field(".tag", "already_pending")?;
                 s.serialize_field("already_pending", x)?;
                 s.end()
             }
-            AddSecondaryEmailResult::AlreadyOwnedByUser(ref x) => {
+            AddSecondaryEmailResult::AlreadyOwnedByUser(x) => {
                 // primitive
                 let mut s = serializer.serialize_struct("AddSecondaryEmailResult", 2)?;
                 s.serialize_field(".tag", "already_owned_by_user")?;
                 s.serialize_field("already_owned_by_user", x)?;
                 s.end()
             }
-            AddSecondaryEmailResult::ReachedLimit(ref x) => {
+            AddSecondaryEmailResult::ReachedLimit(x) => {
                 // primitive
                 let mut s = serializer.serialize_struct("AddSecondaryEmailResult", 2)?;
                 s.serialize_field(".tag", "reached_limit")?;
                 s.serialize_field("reached_limit", x)?;
                 s.end()
             }
-            AddSecondaryEmailResult::TransientError(ref x) => {
+            AddSecondaryEmailResult::TransientError(x) => {
                 // primitive
                 let mut s = serializer.serialize_struct("AddSecondaryEmailResult", 2)?;
                 s.serialize_field(".tag", "transient_error")?;
                 s.serialize_field("transient_error", x)?;
                 s.end()
             }
-            AddSecondaryEmailResult::TooManyUpdates(ref x) => {
+            AddSecondaryEmailResult::TooManyUpdates(x) => {
                 // primitive
                 let mut s = serializer.serialize_struct("AddSecondaryEmailResult", 2)?;
                 s.serialize_field(".tag", "too_many_updates")?;
                 s.serialize_field("too_many_updates", x)?;
                 s.end()
             }
-            AddSecondaryEmailResult::UnknownError(ref x) => {
+            AddSecondaryEmailResult::UnknownError(x) => {
                 // primitive
                 let mut s = serializer.serialize_struct("AddSecondaryEmailResult", 2)?;
                 s.serialize_field(".tag", "unknown_error")?;
                 s.serialize_field("unknown_error", x)?;
                 s.end()
             }
-            AddSecondaryEmailResult::RateLimited(ref x) => {
+            AddSecondaryEmailResult::RateLimited(x) => {
                 // primitive
                 let mut s = serializer.serialize_struct("AddSecondaryEmailResult", 2)?;
                 s.serialize_field(".tag", "rate_limited")?;
@@ -600,7 +600,7 @@ impl ::serde::ser::Serialize for AddSecondaryEmailsError {
     fn serialize<S: ::serde::ser::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
         // union serializer
         use serde::ser::SerializeStruct;
-        match *self {
+        match self {
             AddSecondaryEmailsError::SecondaryEmailsDisabled => {
                 // unit
                 let mut s = serializer.serialize_struct("AddSecondaryEmailsError", 1)?;
@@ -774,7 +774,7 @@ impl ::serde::ser::Serialize for AdminTier {
     fn serialize<S: ::serde::ser::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
         // union serializer
         use serde::ser::SerializeStruct;
-        match *self {
+        match self {
             AdminTier::TeamAdmin => {
                 // unit
                 let mut s = serializer.serialize_struct("AdminTier", 1)?;
@@ -1140,22 +1140,22 @@ impl ::serde::ser::Serialize for BaseTeamFolderError {
     fn serialize<S: ::serde::ser::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
         // union serializer
         use serde::ser::SerializeStruct;
-        match *self {
-            BaseTeamFolderError::AccessError(ref x) => {
+        match self {
+            BaseTeamFolderError::AccessError(x) => {
                 // union or polymporphic struct
                 let mut s = serializer.serialize_struct("BaseTeamFolderError", 2)?;
                 s.serialize_field(".tag", "access_error")?;
                 s.serialize_field("access_error", x)?;
                 s.end()
             }
-            BaseTeamFolderError::StatusError(ref x) => {
+            BaseTeamFolderError::StatusError(x) => {
                 // union or polymporphic struct
                 let mut s = serializer.serialize_struct("BaseTeamFolderError", 2)?;
                 s.serialize_field(".tag", "status_error")?;
                 s.serialize_field("status_error", x)?;
                 s.end()
             }
-            BaseTeamFolderError::TeamSharedDropboxError(ref x) => {
+            BaseTeamFolderError::TeamSharedDropboxError(x) => {
                 // union or polymporphic struct
                 let mut s = serializer.serialize_struct("BaseTeamFolderError", 2)?;
                 s.serialize_field(".tag", "team_shared_dropbox_error")?;
@@ -1233,7 +1233,7 @@ impl ::serde::ser::Serialize for CustomQuotaError {
     fn serialize<S: ::serde::ser::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
         // union serializer
         use serde::ser::SerializeStruct;
-        match *self {
+        match self {
             CustomQuotaError::TooManyUsers => {
                 // unit
                 let mut s = serializer.serialize_struct("CustomQuotaError", 1)?;
@@ -1311,15 +1311,15 @@ impl ::serde::ser::Serialize for CustomQuotaResult {
     fn serialize<S: ::serde::ser::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
         // union serializer
         use serde::ser::SerializeStruct;
-        match *self {
-            CustomQuotaResult::Success(ref x) => {
+        match self {
+            CustomQuotaResult::Success(x) => {
                 // struct
                 let mut s = serializer.serialize_struct("CustomQuotaResult", 3)?;
                 s.serialize_field(".tag", "success")?;
                 x.internal_serialize::<S>(&mut s)?;
                 s.end()
             }
-            CustomQuotaResult::InvalidUser(ref x) => {
+            CustomQuotaResult::InvalidUser(x) => {
                 // union or polymporphic struct
                 let mut s = serializer.serialize_struct("CustomQuotaResult", 2)?;
                 s.serialize_field(".tag", "invalid_user")?;
@@ -1648,22 +1648,22 @@ impl ::serde::ser::Serialize for DeleteSecondaryEmailResult {
     fn serialize<S: ::serde::ser::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
         // union serializer
         use serde::ser::SerializeStruct;
-        match *self {
-            DeleteSecondaryEmailResult::Success(ref x) => {
+        match self {
+            DeleteSecondaryEmailResult::Success(x) => {
                 // primitive
                 let mut s = serializer.serialize_struct("DeleteSecondaryEmailResult", 2)?;
                 s.serialize_field(".tag", "success")?;
                 s.serialize_field("success", x)?;
                 s.end()
             }
-            DeleteSecondaryEmailResult::NotFound(ref x) => {
+            DeleteSecondaryEmailResult::NotFound(x) => {
                 // primitive
                 let mut s = serializer.serialize_struct("DeleteSecondaryEmailResult", 2)?;
                 s.serialize_field(".tag", "not_found")?;
                 s.serialize_field("not_found", x)?;
                 s.end()
             }
-            DeleteSecondaryEmailResult::CannotRemovePrimary(ref x) => {
+            DeleteSecondaryEmailResult::CannotRemovePrimary(x) => {
                 // primitive
                 let mut s = serializer.serialize_struct("DeleteSecondaryEmailResult", 2)?;
                 s.serialize_field(".tag", "cannot_remove_primary")?;
@@ -2163,7 +2163,7 @@ impl ::serde::ser::Serialize for DesktopPlatform {
     fn serialize<S: ::serde::ser::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
         // union serializer
         use serde::ser::SerializeStruct;
-        match *self {
+        match self {
             DesktopPlatform::Windows => {
                 // unit
                 let mut s = serializer.serialize_struct("DesktopPlatform", 1)?;
@@ -2868,7 +2868,7 @@ impl ::serde::ser::Serialize for ExcludedUsersListContinueError {
     fn serialize<S: ::serde::ser::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
         // union serializer
         use serde::ser::SerializeStruct;
-        match *self {
+        match self {
             ExcludedUsersListContinueError::InvalidCursor => {
                 // unit
                 let mut s = serializer.serialize_struct("ExcludedUsersListContinueError", 1)?;
@@ -2936,7 +2936,7 @@ impl ::serde::ser::Serialize for ExcludedUsersListError {
     fn serialize<S: ::serde::ser::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
         // union serializer
         use serde::ser::SerializeStruct;
-        match *self {
+        match self {
             ExcludedUsersListError::ListError => {
                 // unit
                 let mut s = serializer.serialize_struct("ExcludedUsersListError", 1)?;
@@ -3220,7 +3220,7 @@ impl ::serde::ser::Serialize for ExcludedUsersUpdateError {
     fn serialize<S: ::serde::ser::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
         // union serializer
         use serde::ser::SerializeStruct;
-        match *self {
+        match self {
             ExcludedUsersUpdateError::UsersNotInTeam => {
                 // unit
                 let mut s = serializer.serialize_struct("ExcludedUsersUpdateError", 1)?;
@@ -3387,7 +3387,7 @@ impl ::serde::ser::Serialize for ExcludedUsersUpdateStatus {
     fn serialize<S: ::serde::ser::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
         // union serializer
         use serde::ser::SerializeStruct;
-        match *self {
+        match self {
             ExcludedUsersUpdateStatus::Success => {
                 // unit
                 let mut s = serializer.serialize_struct("ExcludedUsersUpdateStatus", 1)?;
@@ -3455,7 +3455,7 @@ impl ::serde::ser::Serialize for Feature {
     fn serialize<S: ::serde::ser::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
         // union serializer
         use serde::ser::SerializeStruct;
-        match *self {
+        match self {
             Feature::UploadApiRateLimit => {
                 // unit
                 let mut s = serializer.serialize_struct("Feature", 1)?;
@@ -3562,29 +3562,29 @@ impl ::serde::ser::Serialize for FeatureValue {
     fn serialize<S: ::serde::ser::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
         // union serializer
         use serde::ser::SerializeStruct;
-        match *self {
-            FeatureValue::UploadApiRateLimit(ref x) => {
+        match self {
+            FeatureValue::UploadApiRateLimit(x) => {
                 // union or polymporphic struct
                 let mut s = serializer.serialize_struct("FeatureValue", 2)?;
                 s.serialize_field(".tag", "upload_api_rate_limit")?;
                 s.serialize_field("upload_api_rate_limit", x)?;
                 s.end()
             }
-            FeatureValue::HasTeamSharedDropbox(ref x) => {
+            FeatureValue::HasTeamSharedDropbox(x) => {
                 // union or polymporphic struct
                 let mut s = serializer.serialize_struct("FeatureValue", 2)?;
                 s.serialize_field(".tag", "has_team_shared_dropbox")?;
                 s.serialize_field("has_team_shared_dropbox", x)?;
                 s.end()
             }
-            FeatureValue::HasTeamFileEvents(ref x) => {
+            FeatureValue::HasTeamFileEvents(x) => {
                 // union or polymporphic struct
                 let mut s = serializer.serialize_struct("FeatureValue", 2)?;
                 s.serialize_field(".tag", "has_team_file_events")?;
                 s.serialize_field("has_team_file_events", x)?;
                 s.end()
             }
-            FeatureValue::HasTeamSelectiveSync(ref x) => {
+            FeatureValue::HasTeamSelectiveSync(x) => {
                 // union or polymporphic struct
                 let mut s = serializer.serialize_struct("FeatureValue", 2)?;
                 s.serialize_field(".tag", "has_team_selective_sync")?;
@@ -3732,7 +3732,7 @@ impl ::serde::ser::Serialize for FeaturesGetValuesBatchError {
     fn serialize<S: ::serde::ser::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
         // union serializer
         use serde::ser::SerializeStruct;
-        match *self {
+        match self {
             FeaturesGetValuesBatchError::EmptyFeaturesList => {
                 // unit
                 let mut s = serializer.serialize_struct("FeaturesGetValuesBatchError", 1)?;
@@ -4682,7 +4682,7 @@ impl ::serde::ser::Serialize for GroupAccessType {
     fn serialize<S: ::serde::ser::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
         // union serializer
         use serde::ser::SerializeStruct;
-        match *self {
+        match self {
             GroupAccessType::Member => {
                 // unit
                 let mut s = serializer.serialize_struct("GroupAccessType", 1)?;
@@ -4911,7 +4911,7 @@ impl ::serde::ser::Serialize for GroupCreateError {
     fn serialize<S: ::serde::ser::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
         // union serializer
         use serde::ser::SerializeStruct;
-        match *self {
+        match self {
             GroupCreateError::GroupNameAlreadyUsed => {
                 // unit
                 let mut s = serializer.serialize_struct("GroupCreateError", 1)?;
@@ -5007,7 +5007,7 @@ impl ::serde::ser::Serialize for GroupDeleteError {
     fn serialize<S: ::serde::ser::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
         // union serializer
         use serde::ser::SerializeStruct;
-        match *self {
+        match self {
             GroupDeleteError::GroupNotFound => {
                 // unit
                 let mut s = serializer.serialize_struct("GroupDeleteError", 1)?;
@@ -5527,7 +5527,7 @@ impl ::serde::ser::Serialize for GroupMemberSelectorError {
     fn serialize<S: ::serde::ser::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
         // union serializer
         use serde::ser::SerializeStruct;
-        match *self {
+        match self {
             GroupMemberSelectorError::GroupNotFound => {
                 // unit
                 let mut s = serializer.serialize_struct("GroupMemberSelectorError", 1)?;
@@ -5630,7 +5630,7 @@ impl ::serde::ser::Serialize for GroupMemberSetAccessTypeError {
     fn serialize<S: ::serde::ser::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
         // union serializer
         use serde::ser::SerializeStruct;
-        match *self {
+        match self {
             GroupMemberSetAccessTypeError::GroupNotFound => {
                 // unit
                 let mut s = serializer.serialize_struct("GroupMemberSetAccessTypeError", 1)?;
@@ -5913,7 +5913,7 @@ impl ::serde::ser::Serialize for GroupMembersAddError {
     fn serialize<S: ::serde::ser::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
         // union serializer
         use serde::ser::SerializeStruct;
-        match *self {
+        match self {
             GroupMembersAddError::GroupNotFound => {
                 // unit
                 let mut s = serializer.serialize_struct("GroupMembersAddError", 1)?;
@@ -5938,14 +5938,14 @@ impl ::serde::ser::Serialize for GroupMembersAddError {
                 s.serialize_field(".tag", "group_not_in_team")?;
                 s.end()
             }
-            GroupMembersAddError::MembersNotInTeam(ref x) => {
+            GroupMembersAddError::MembersNotInTeam(x) => {
                 // primitive
                 let mut s = serializer.serialize_struct("GroupMembersAddError", 2)?;
                 s.serialize_field(".tag", "members_not_in_team")?;
                 s.serialize_field("members_not_in_team", x)?;
                 s.end()
             }
-            GroupMembersAddError::UsersNotFound(ref x) => {
+            GroupMembersAddError::UsersNotFound(x) => {
                 // primitive
                 let mut s = serializer.serialize_struct("GroupMembersAddError", 2)?;
                 s.serialize_field(".tag", "users_not_found")?;
@@ -5958,7 +5958,7 @@ impl ::serde::ser::Serialize for GroupMembersAddError {
                 s.serialize_field(".tag", "user_must_be_active_to_be_owner")?;
                 s.end()
             }
-            GroupMembersAddError::UserCannotBeManagerOfCompanyManagedGroup(ref x) => {
+            GroupMembersAddError::UserCannotBeManagerOfCompanyManagedGroup(x) => {
                 // primitive
                 let mut s = serializer.serialize_struct("GroupMembersAddError", 2)?;
                 s.serialize_field(".tag", "user_cannot_be_manager_of_company_managed_group")?;
@@ -6319,7 +6319,7 @@ impl ::serde::ser::Serialize for GroupMembersRemoveError {
     fn serialize<S: ::serde::ser::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
         // union serializer
         use serde::ser::SerializeStruct;
-        match *self {
+        match self {
             GroupMembersRemoveError::GroupNotFound => {
                 // unit
                 let mut s = serializer.serialize_struct("GroupMembersRemoveError", 1)?;
@@ -6344,14 +6344,14 @@ impl ::serde::ser::Serialize for GroupMembersRemoveError {
                 s.serialize_field(".tag", "group_not_in_team")?;
                 s.end()
             }
-            GroupMembersRemoveError::MembersNotInTeam(ref x) => {
+            GroupMembersRemoveError::MembersNotInTeam(x) => {
                 // primitive
                 let mut s = serializer.serialize_struct("GroupMembersRemoveError", 2)?;
                 s.serialize_field(".tag", "members_not_in_team")?;
                 s.serialize_field("members_not_in_team", x)?;
                 s.end()
             }
-            GroupMembersRemoveError::UsersNotFound(ref x) => {
+            GroupMembersRemoveError::UsersNotFound(x) => {
                 // primitive
                 let mut s = serializer.serialize_struct("GroupMembersRemoveError", 2)?;
                 s.serialize_field(".tag", "users_not_found")?;
@@ -6549,7 +6549,7 @@ impl ::serde::ser::Serialize for GroupMembersSelectorError {
     fn serialize<S: ::serde::ser::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
         // union serializer
         use serde::ser::SerializeStruct;
-        match *self {
+        match self {
             GroupMembersSelectorError::GroupNotFound => {
                 // unit
                 let mut s = serializer.serialize_struct("GroupMembersSelectorError", 1)?;
@@ -6800,15 +6800,15 @@ impl ::serde::ser::Serialize for GroupSelector {
     fn serialize<S: ::serde::ser::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
         // union serializer
         use serde::ser::SerializeStruct;
-        match *self {
-            GroupSelector::GroupId(ref x) => {
+        match self {
+            GroupSelector::GroupId(x) => {
                 // primitive
                 let mut s = serializer.serialize_struct("GroupSelector", 2)?;
                 s.serialize_field(".tag", "group_id")?;
                 s.serialize_field("group_id", x)?;
                 s.end()
             }
-            GroupSelector::GroupExternalId(ref x) => {
+            GroupSelector::GroupExternalId(x) => {
                 // primitive
                 let mut s = serializer.serialize_struct("GroupSelector", 2)?;
                 s.serialize_field(".tag", "group_external_id")?;
@@ -6863,7 +6863,7 @@ impl ::serde::ser::Serialize for GroupSelectorError {
     fn serialize<S: ::serde::ser::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
         // union serializer
         use serde::ser::SerializeStruct;
-        match *self {
+        match self {
             GroupSelectorError::GroupNotFound => {
                 // unit
                 let mut s = serializer.serialize_struct("GroupSelectorError", 1)?;
@@ -6936,7 +6936,7 @@ impl ::serde::ser::Serialize for GroupSelectorWithTeamGroupError {
     fn serialize<S: ::serde::ser::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
         // union serializer
         use serde::ser::SerializeStruct;
-        match *self {
+        match self {
             GroupSelectorWithTeamGroupError::GroupNotFound => {
                 // unit
                 let mut s = serializer.serialize_struct("GroupSelectorWithTeamGroupError", 1)?;
@@ -7223,7 +7223,7 @@ impl ::serde::ser::Serialize for GroupUpdateError {
     fn serialize<S: ::serde::ser::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
         // union serializer
         use serde::ser::SerializeStruct;
-        match *self {
+        match self {
             GroupUpdateError::GroupNotFound => {
                 // unit
                 let mut s = serializer.serialize_struct("GroupUpdateError", 1)?;
@@ -7328,7 +7328,7 @@ impl ::serde::ser::Serialize for GroupsGetInfoError {
     fn serialize<S: ::serde::ser::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
         // union serializer
         use serde::ser::SerializeStruct;
-        match *self {
+        match self {
             GroupsGetInfoError::GroupNotOnTeam => {
                 // unit
                 let mut s = serializer.serialize_struct("GroupsGetInfoError", 1)?;
@@ -7402,15 +7402,15 @@ impl ::serde::ser::Serialize for GroupsGetInfoItem {
     fn serialize<S: ::serde::ser::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
         // union serializer
         use serde::ser::SerializeStruct;
-        match *self {
-            GroupsGetInfoItem::IdNotFound(ref x) => {
+        match self {
+            GroupsGetInfoItem::IdNotFound(x) => {
                 // primitive
                 let mut s = serializer.serialize_struct("GroupsGetInfoItem", 2)?;
                 s.serialize_field(".tag", "id_not_found")?;
                 s.serialize_field("id_not_found", x)?;
                 s.end()
             }
-            GroupsGetInfoItem::GroupInfo(ref x) => {
+            GroupsGetInfoItem::GroupInfo(x) => {
                 // struct
                 let mut s = serializer.serialize_struct("GroupsGetInfoItem", 8)?;
                 s.serialize_field(".tag", "group_info")?;
@@ -7644,7 +7644,7 @@ impl ::serde::ser::Serialize for GroupsListContinueError {
     fn serialize<S: ::serde::ser::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
         // union serializer
         use serde::ser::SerializeStruct;
-        match *self {
+        match self {
             GroupsListContinueError::InvalidCursor => {
                 // unit
                 let mut s = serializer.serialize_struct("GroupsListContinueError", 1)?;
@@ -8035,7 +8035,7 @@ impl ::serde::ser::Serialize for GroupsMembersListContinueError {
     fn serialize<S: ::serde::ser::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
         // union serializer
         use serde::ser::SerializeStruct;
-        match *self {
+        match self {
             GroupsMembersListContinueError::InvalidCursor => {
                 // unit
                 let mut s = serializer.serialize_struct("GroupsMembersListContinueError", 1)?;
@@ -8231,7 +8231,7 @@ impl ::serde::ser::Serialize for GroupsPollError {
     fn serialize<S: ::serde::ser::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
         // union serializer
         use serde::ser::SerializeStruct;
-        match *self {
+        match self {
             GroupsPollError::InvalidAsyncJobId => {
                 // unit
                 let mut s = serializer.serialize_struct("GroupsPollError", 1)?;
@@ -8334,15 +8334,15 @@ impl ::serde::ser::Serialize for GroupsSelector {
     fn serialize<S: ::serde::ser::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
         // union serializer
         use serde::ser::SerializeStruct;
-        match *self {
-            GroupsSelector::GroupIds(ref x) => {
+        match self {
+            GroupsSelector::GroupIds(x) => {
                 // primitive
                 let mut s = serializer.serialize_struct("GroupsSelector", 2)?;
                 s.serialize_field(".tag", "group_ids")?;
                 s.serialize_field("group_ids", x)?;
                 s.end()
             }
-            GroupsSelector::GroupExternalIds(ref x) => {
+            GroupsSelector::GroupExternalIds(x) => {
                 // primitive
                 let mut s = serializer.serialize_struct("GroupsSelector", 2)?;
                 s.serialize_field(".tag", "group_external_ids")?;
@@ -8403,8 +8403,8 @@ impl ::serde::ser::Serialize for HasTeamFileEventsValue {
     fn serialize<S: ::serde::ser::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
         // union serializer
         use serde::ser::SerializeStruct;
-        match *self {
-            HasTeamFileEventsValue::Enabled(ref x) => {
+        match self {
+            HasTeamFileEventsValue::Enabled(x) => {
                 // primitive
                 let mut s = serializer.serialize_struct("HasTeamFileEventsValue", 2)?;
                 s.serialize_field(".tag", "enabled")?;
@@ -8466,8 +8466,8 @@ impl ::serde::ser::Serialize for HasTeamSelectiveSyncValue {
     fn serialize<S: ::serde::ser::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
         // union serializer
         use serde::ser::SerializeStruct;
-        match *self {
-            HasTeamSelectiveSyncValue::HasTeamSelectiveSync(ref x) => {
+        match self {
+            HasTeamSelectiveSyncValue::HasTeamSelectiveSync(x) => {
                 // primitive
                 let mut s = serializer.serialize_struct("HasTeamSelectiveSyncValue", 2)?;
                 s.serialize_field(".tag", "has_team_selective_sync")?;
@@ -8529,8 +8529,8 @@ impl ::serde::ser::Serialize for HasTeamSharedDropboxValue {
     fn serialize<S: ::serde::ser::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
         // union serializer
         use serde::ser::SerializeStruct;
-        match *self {
-            HasTeamSharedDropboxValue::HasTeamSharedDropbox(ref x) => {
+        match self {
+            HasTeamSharedDropboxValue::HasTeamSharedDropbox(x) => {
                 // primitive
                 let mut s = serializer.serialize_struct("HasTeamSharedDropboxValue", 2)?;
                 s.serialize_field(".tag", "has_team_shared_dropbox")?;
@@ -9126,7 +9126,7 @@ impl ::serde::ser::Serialize for LegalHoldStatus {
     fn serialize<S: ::serde::ser::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
         // union serializer
         use serde::ser::SerializeStruct;
-        match *self {
+        match self {
             LegalHoldStatus::Active => {
                 // unit
                 let mut s = serializer.serialize_struct("LegalHoldStatus", 1)?;
@@ -9215,7 +9215,7 @@ impl ::serde::ser::Serialize for LegalHoldsError {
     fn serialize<S: ::serde::ser::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
         // union serializer
         use serde::ser::SerializeStruct;
-        match *self {
+        match self {
             LegalHoldsError::UnknownLegalHoldError => {
                 // unit
                 let mut s = serializer.serialize_struct("LegalHoldsError", 1)?;
@@ -9388,7 +9388,7 @@ impl ::serde::ser::Serialize for LegalHoldsGetPolicyError {
     fn serialize<S: ::serde::ser::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
         // union serializer
         use serde::ser::SerializeStruct;
-        match *self {
+        match self {
             LegalHoldsGetPolicyError::UnknownLegalHoldError => {
                 // unit
                 let mut s = serializer.serialize_struct("LegalHoldsGetPolicyError", 1)?;
@@ -9818,7 +9818,7 @@ impl ::serde::ser::Serialize for LegalHoldsListHeldRevisionsContinueError {
     fn serialize<S: ::serde::ser::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
         // union serializer
         use serde::ser::SerializeStruct;
-        match *self {
+        match self {
             LegalHoldsListHeldRevisionsContinueError::UnknownLegalHoldError => {
                 // unit
                 let mut s = serializer.serialize_struct("LegalHoldsListHeldRevisionsContinueError", 1)?;
@@ -9914,7 +9914,7 @@ impl ::serde::ser::Serialize for LegalHoldsListHeldRevisionsError {
     fn serialize<S: ::serde::ser::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
         // union serializer
         use serde::ser::SerializeStruct;
-        match *self {
+        match self {
             LegalHoldsListHeldRevisionsError::UnknownLegalHoldError => {
                 // unit
                 let mut s = serializer.serialize_struct("LegalHoldsListHeldRevisionsError", 1)?;
@@ -10108,7 +10108,7 @@ impl ::serde::ser::Serialize for LegalHoldsListPoliciesError {
     fn serialize<S: ::serde::ser::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
         // union serializer
         use serde::ser::SerializeStruct;
-        match *self {
+        match self {
             LegalHoldsListPoliciesError::UnknownLegalHoldError => {
                 // unit
                 let mut s = serializer.serialize_struct("LegalHoldsListPoliciesError", 1)?;
@@ -10492,7 +10492,7 @@ impl ::serde::ser::Serialize for LegalHoldsPolicyCreateError {
     fn serialize<S: ::serde::ser::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
         // union serializer
         use serde::ser::SerializeStruct;
-        match *self {
+        match self {
             LegalHoldsPolicyCreateError::UnknownLegalHoldError => {
                 // unit
                 let mut s = serializer.serialize_struct("LegalHoldsPolicyCreateError", 1)?;
@@ -10740,7 +10740,7 @@ impl ::serde::ser::Serialize for LegalHoldsPolicyReleaseError {
     fn serialize<S: ::serde::ser::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
         // union serializer
         use serde::ser::SerializeStruct;
-        match *self {
+        match self {
             LegalHoldsPolicyReleaseError::UnknownLegalHoldError => {
                 // unit
                 let mut s = serializer.serialize_struct("LegalHoldsPolicyReleaseError", 1)?;
@@ -11032,7 +11032,7 @@ impl ::serde::ser::Serialize for LegalHoldsPolicyUpdateError {
     fn serialize<S: ::serde::ser::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
         // union serializer
         use serde::ser::SerializeStruct;
-        match *self {
+        match self {
             LegalHoldsPolicyUpdateError::UnknownLegalHoldError => {
                 // unit
                 let mut s = serializer.serialize_struct("LegalHoldsPolicyUpdateError", 1)?;
@@ -11264,7 +11264,7 @@ impl ::serde::ser::Serialize for ListMemberAppsError {
     fn serialize<S: ::serde::ser::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
         // union serializer
         use serde::ser::SerializeStruct;
-        match *self {
+        match self {
             ListMemberAppsError::MemberNotFound => {
                 // unit
                 let mut s = serializer.serialize_struct("ListMemberAppsError", 1)?;
@@ -11573,7 +11573,7 @@ impl ::serde::ser::Serialize for ListMemberDevicesError {
     fn serialize<S: ::serde::ser::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
         // union serializer
         use serde::ser::SerializeStruct;
-        match *self {
+        match self {
             ListMemberDevicesError::MemberNotFound => {
                 // unit
                 let mut s = serializer.serialize_struct("ListMemberDevicesError", 1)?;
@@ -11850,7 +11850,7 @@ impl ::serde::ser::Serialize for ListMembersAppsError {
     fn serialize<S: ::serde::ser::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
         // union serializer
         use serde::ser::SerializeStruct;
-        match *self {
+        match self {
             ListMembersAppsError::Reset => {
                 // unit
                 let mut s = serializer.serialize_struct("ListMembersAppsError", 1)?;
@@ -12199,7 +12199,7 @@ impl ::serde::ser::Serialize for ListMembersDevicesError {
     fn serialize<S: ::serde::ser::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
         // union serializer
         use serde::ser::SerializeStruct;
-        match *self {
+        match self {
             ListMembersDevicesError::Reset => {
                 // unit
                 let mut s = serializer.serialize_struct("ListMembersDevicesError", 1)?;
@@ -12482,7 +12482,7 @@ impl ::serde::ser::Serialize for ListTeamAppsError {
     fn serialize<S: ::serde::ser::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
         // union serializer
         use serde::ser::SerializeStruct;
-        match *self {
+        match self {
             ListTeamAppsError::Reset => {
                 // unit
                 let mut s = serializer.serialize_struct("ListTeamAppsError", 1)?;
@@ -12830,7 +12830,7 @@ impl ::serde::ser::Serialize for ListTeamDevicesError {
     fn serialize<S: ::serde::ser::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
         // union serializer
         use serde::ser::SerializeStruct;
-        match *self {
+        match self {
             ListTeamDevicesError::Reset => {
                 // unit
                 let mut s = serializer.serialize_struct("ListTeamDevicesError", 1)?;
@@ -13700,78 +13700,78 @@ impl ::serde::ser::Serialize for MemberAddResult {
     fn serialize<S: ::serde::ser::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
         // union serializer
         use serde::ser::SerializeStruct;
-        match *self {
-            MemberAddResult::TeamLicenseLimit(ref x) => {
+        match self {
+            MemberAddResult::TeamLicenseLimit(x) => {
                 // primitive
                 let mut s = serializer.serialize_struct("MemberAddResult", 2)?;
                 s.serialize_field(".tag", "team_license_limit")?;
                 s.serialize_field("team_license_limit", x)?;
                 s.end()
             }
-            MemberAddResult::FreeTeamMemberLimitReached(ref x) => {
+            MemberAddResult::FreeTeamMemberLimitReached(x) => {
                 // primitive
                 let mut s = serializer.serialize_struct("MemberAddResult", 2)?;
                 s.serialize_field(".tag", "free_team_member_limit_reached")?;
                 s.serialize_field("free_team_member_limit_reached", x)?;
                 s.end()
             }
-            MemberAddResult::UserAlreadyOnTeam(ref x) => {
+            MemberAddResult::UserAlreadyOnTeam(x) => {
                 // primitive
                 let mut s = serializer.serialize_struct("MemberAddResult", 2)?;
                 s.serialize_field(".tag", "user_already_on_team")?;
                 s.serialize_field("user_already_on_team", x)?;
                 s.end()
             }
-            MemberAddResult::UserOnAnotherTeam(ref x) => {
+            MemberAddResult::UserOnAnotherTeam(x) => {
                 // primitive
                 let mut s = serializer.serialize_struct("MemberAddResult", 2)?;
                 s.serialize_field(".tag", "user_on_another_team")?;
                 s.serialize_field("user_on_another_team", x)?;
                 s.end()
             }
-            MemberAddResult::UserAlreadyPaired(ref x) => {
+            MemberAddResult::UserAlreadyPaired(x) => {
                 // primitive
                 let mut s = serializer.serialize_struct("MemberAddResult", 2)?;
                 s.serialize_field(".tag", "user_already_paired")?;
                 s.serialize_field("user_already_paired", x)?;
                 s.end()
             }
-            MemberAddResult::UserMigrationFailed(ref x) => {
+            MemberAddResult::UserMigrationFailed(x) => {
                 // primitive
                 let mut s = serializer.serialize_struct("MemberAddResult", 2)?;
                 s.serialize_field(".tag", "user_migration_failed")?;
                 s.serialize_field("user_migration_failed", x)?;
                 s.end()
             }
-            MemberAddResult::DuplicateExternalMemberId(ref x) => {
+            MemberAddResult::DuplicateExternalMemberId(x) => {
                 // primitive
                 let mut s = serializer.serialize_struct("MemberAddResult", 2)?;
                 s.serialize_field(".tag", "duplicate_external_member_id")?;
                 s.serialize_field("duplicate_external_member_id", x)?;
                 s.end()
             }
-            MemberAddResult::DuplicateMemberPersistentId(ref x) => {
+            MemberAddResult::DuplicateMemberPersistentId(x) => {
                 // primitive
                 let mut s = serializer.serialize_struct("MemberAddResult", 2)?;
                 s.serialize_field(".tag", "duplicate_member_persistent_id")?;
                 s.serialize_field("duplicate_member_persistent_id", x)?;
                 s.end()
             }
-            MemberAddResult::PersistentIdDisabled(ref x) => {
+            MemberAddResult::PersistentIdDisabled(x) => {
                 // primitive
                 let mut s = serializer.serialize_struct("MemberAddResult", 2)?;
                 s.serialize_field(".tag", "persistent_id_disabled")?;
                 s.serialize_field("persistent_id_disabled", x)?;
                 s.end()
             }
-            MemberAddResult::UserCreationFailed(ref x) => {
+            MemberAddResult::UserCreationFailed(x) => {
                 // primitive
                 let mut s = serializer.serialize_struct("MemberAddResult", 2)?;
                 s.serialize_field(".tag", "user_creation_failed")?;
                 s.serialize_field("user_creation_failed", x)?;
                 s.end()
             }
-            MemberAddResult::Success(ref x) => {
+            MemberAddResult::Success(x) => {
                 // struct
                 let mut s = serializer.serialize_struct("MemberAddResult", 3)?;
                 s.serialize_field(".tag", "success")?;
@@ -13938,71 +13938,71 @@ impl ::serde::ser::Serialize for MemberAddResultBase {
     fn serialize<S: ::serde::ser::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
         // union serializer
         use serde::ser::SerializeStruct;
-        match *self {
-            MemberAddResultBase::TeamLicenseLimit(ref x) => {
+        match self {
+            MemberAddResultBase::TeamLicenseLimit(x) => {
                 // primitive
                 let mut s = serializer.serialize_struct("MemberAddResultBase", 2)?;
                 s.serialize_field(".tag", "team_license_limit")?;
                 s.serialize_field("team_license_limit", x)?;
                 s.end()
             }
-            MemberAddResultBase::FreeTeamMemberLimitReached(ref x) => {
+            MemberAddResultBase::FreeTeamMemberLimitReached(x) => {
                 // primitive
                 let mut s = serializer.serialize_struct("MemberAddResultBase", 2)?;
                 s.serialize_field(".tag", "free_team_member_limit_reached")?;
                 s.serialize_field("free_team_member_limit_reached", x)?;
                 s.end()
             }
-            MemberAddResultBase::UserAlreadyOnTeam(ref x) => {
+            MemberAddResultBase::UserAlreadyOnTeam(x) => {
                 // primitive
                 let mut s = serializer.serialize_struct("MemberAddResultBase", 2)?;
                 s.serialize_field(".tag", "user_already_on_team")?;
                 s.serialize_field("user_already_on_team", x)?;
                 s.end()
             }
-            MemberAddResultBase::UserOnAnotherTeam(ref x) => {
+            MemberAddResultBase::UserOnAnotherTeam(x) => {
                 // primitive
                 let mut s = serializer.serialize_struct("MemberAddResultBase", 2)?;
                 s.serialize_field(".tag", "user_on_another_team")?;
                 s.serialize_field("user_on_another_team", x)?;
                 s.end()
             }
-            MemberAddResultBase::UserAlreadyPaired(ref x) => {
+            MemberAddResultBase::UserAlreadyPaired(x) => {
                 // primitive
                 let mut s = serializer.serialize_struct("MemberAddResultBase", 2)?;
                 s.serialize_field(".tag", "user_already_paired")?;
                 s.serialize_field("user_already_paired", x)?;
                 s.end()
             }
-            MemberAddResultBase::UserMigrationFailed(ref x) => {
+            MemberAddResultBase::UserMigrationFailed(x) => {
                 // primitive
                 let mut s = serializer.serialize_struct("MemberAddResultBase", 2)?;
                 s.serialize_field(".tag", "user_migration_failed")?;
                 s.serialize_field("user_migration_failed", x)?;
                 s.end()
             }
-            MemberAddResultBase::DuplicateExternalMemberId(ref x) => {
+            MemberAddResultBase::DuplicateExternalMemberId(x) => {
                 // primitive
                 let mut s = serializer.serialize_struct("MemberAddResultBase", 2)?;
                 s.serialize_field(".tag", "duplicate_external_member_id")?;
                 s.serialize_field("duplicate_external_member_id", x)?;
                 s.end()
             }
-            MemberAddResultBase::DuplicateMemberPersistentId(ref x) => {
+            MemberAddResultBase::DuplicateMemberPersistentId(x) => {
                 // primitive
                 let mut s = serializer.serialize_struct("MemberAddResultBase", 2)?;
                 s.serialize_field(".tag", "duplicate_member_persistent_id")?;
                 s.serialize_field("duplicate_member_persistent_id", x)?;
                 s.end()
             }
-            MemberAddResultBase::PersistentIdDisabled(ref x) => {
+            MemberAddResultBase::PersistentIdDisabled(x) => {
                 // primitive
                 let mut s = serializer.serialize_struct("MemberAddResultBase", 2)?;
                 s.serialize_field(".tag", "persistent_id_disabled")?;
                 s.serialize_field("persistent_id_disabled", x)?;
                 s.end()
             }
-            MemberAddResultBase::UserCreationFailed(ref x) => {
+            MemberAddResultBase::UserCreationFailed(x) => {
                 // primitive
                 let mut s = serializer.serialize_struct("MemberAddResultBase", 2)?;
                 s.serialize_field(".tag", "user_creation_failed")?;
@@ -14416,78 +14416,78 @@ impl ::serde::ser::Serialize for MemberAddV2Result {
     fn serialize<S: ::serde::ser::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
         // union serializer
         use serde::ser::SerializeStruct;
-        match *self {
-            MemberAddV2Result::TeamLicenseLimit(ref x) => {
+        match self {
+            MemberAddV2Result::TeamLicenseLimit(x) => {
                 // primitive
                 let mut s = serializer.serialize_struct("MemberAddV2Result", 2)?;
                 s.serialize_field(".tag", "team_license_limit")?;
                 s.serialize_field("team_license_limit", x)?;
                 s.end()
             }
-            MemberAddV2Result::FreeTeamMemberLimitReached(ref x) => {
+            MemberAddV2Result::FreeTeamMemberLimitReached(x) => {
                 // primitive
                 let mut s = serializer.serialize_struct("MemberAddV2Result", 2)?;
                 s.serialize_field(".tag", "free_team_member_limit_reached")?;
                 s.serialize_field("free_team_member_limit_reached", x)?;
                 s.end()
             }
-            MemberAddV2Result::UserAlreadyOnTeam(ref x) => {
+            MemberAddV2Result::UserAlreadyOnTeam(x) => {
                 // primitive
                 let mut s = serializer.serialize_struct("MemberAddV2Result", 2)?;
                 s.serialize_field(".tag", "user_already_on_team")?;
                 s.serialize_field("user_already_on_team", x)?;
                 s.end()
             }
-            MemberAddV2Result::UserOnAnotherTeam(ref x) => {
+            MemberAddV2Result::UserOnAnotherTeam(x) => {
                 // primitive
                 let mut s = serializer.serialize_struct("MemberAddV2Result", 2)?;
                 s.serialize_field(".tag", "user_on_another_team")?;
                 s.serialize_field("user_on_another_team", x)?;
                 s.end()
             }
-            MemberAddV2Result::UserAlreadyPaired(ref x) => {
+            MemberAddV2Result::UserAlreadyPaired(x) => {
                 // primitive
                 let mut s = serializer.serialize_struct("MemberAddV2Result", 2)?;
                 s.serialize_field(".tag", "user_already_paired")?;
                 s.serialize_field("user_already_paired", x)?;
                 s.end()
             }
-            MemberAddV2Result::UserMigrationFailed(ref x) => {
+            MemberAddV2Result::UserMigrationFailed(x) => {
                 // primitive
                 let mut s = serializer.serialize_struct("MemberAddV2Result", 2)?;
                 s.serialize_field(".tag", "user_migration_failed")?;
                 s.serialize_field("user_migration_failed", x)?;
                 s.end()
             }
-            MemberAddV2Result::DuplicateExternalMemberId(ref x) => {
+            MemberAddV2Result::DuplicateExternalMemberId(x) => {
                 // primitive
                 let mut s = serializer.serialize_struct("MemberAddV2Result", 2)?;
                 s.serialize_field(".tag", "duplicate_external_member_id")?;
                 s.serialize_field("duplicate_external_member_id", x)?;
                 s.end()
             }
-            MemberAddV2Result::DuplicateMemberPersistentId(ref x) => {
+            MemberAddV2Result::DuplicateMemberPersistentId(x) => {
                 // primitive
                 let mut s = serializer.serialize_struct("MemberAddV2Result", 2)?;
                 s.serialize_field(".tag", "duplicate_member_persistent_id")?;
                 s.serialize_field("duplicate_member_persistent_id", x)?;
                 s.end()
             }
-            MemberAddV2Result::PersistentIdDisabled(ref x) => {
+            MemberAddV2Result::PersistentIdDisabled(x) => {
                 // primitive
                 let mut s = serializer.serialize_struct("MemberAddV2Result", 2)?;
                 s.serialize_field(".tag", "persistent_id_disabled")?;
                 s.serialize_field("persistent_id_disabled", x)?;
                 s.end()
             }
-            MemberAddV2Result::UserCreationFailed(ref x) => {
+            MemberAddV2Result::UserCreationFailed(x) => {
                 // primitive
                 let mut s = serializer.serialize_struct("MemberAddV2Result", 2)?;
                 s.serialize_field(".tag", "user_creation_failed")?;
                 s.serialize_field("user_creation_failed", x)?;
                 s.end()
             }
-            MemberAddV2Result::Success(ref x) => {
+            MemberAddV2Result::Success(x) => {
                 // struct
                 let mut s = serializer.serialize_struct("MemberAddV2Result", 3)?;
                 s.serialize_field(".tag", "success")?;
@@ -15168,7 +15168,7 @@ impl ::serde::ser::Serialize for MemberSelectorError {
     fn serialize<S: ::serde::ser::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
         // union serializer
         use serde::ser::SerializeStruct;
-        match *self {
+        match self {
             MemberSelectorError::UserNotFound => {
                 // unit
                 let mut s = serializer.serialize_struct("MemberSelectorError", 1)?;
@@ -15465,21 +15465,21 @@ impl ::serde::ser::Serialize for MembersAddJobStatus {
     fn serialize<S: ::serde::ser::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
         // union serializer
         use serde::ser::SerializeStruct;
-        match *self {
+        match self {
             MembersAddJobStatus::InProgress => {
                 // unit
                 let mut s = serializer.serialize_struct("MembersAddJobStatus", 1)?;
                 s.serialize_field(".tag", "in_progress")?;
                 s.end()
             }
-            MembersAddJobStatus::Complete(ref x) => {
+            MembersAddJobStatus::Complete(x) => {
                 // primitive
                 let mut s = serializer.serialize_struct("MembersAddJobStatus", 2)?;
                 s.serialize_field(".tag", "complete")?;
                 s.serialize_field("complete", x)?;
                 s.end()
             }
-            MembersAddJobStatus::Failed(ref x) => {
+            MembersAddJobStatus::Failed(x) => {
                 // primitive
                 let mut s = serializer.serialize_struct("MembersAddJobStatus", 2)?;
                 s.serialize_field(".tag", "failed")?;
@@ -15563,21 +15563,21 @@ impl ::serde::ser::Serialize for MembersAddJobStatusV2Result {
     fn serialize<S: ::serde::ser::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
         // union serializer
         use serde::ser::SerializeStruct;
-        match *self {
+        match self {
             MembersAddJobStatusV2Result::InProgress => {
                 // unit
                 let mut s = serializer.serialize_struct("MembersAddJobStatusV2Result", 1)?;
                 s.serialize_field(".tag", "in_progress")?;
                 s.end()
             }
-            MembersAddJobStatusV2Result::Complete(ref x) => {
+            MembersAddJobStatusV2Result::Complete(x) => {
                 // primitive
                 let mut s = serializer.serialize_struct("MembersAddJobStatusV2Result", 2)?;
                 s.serialize_field(".tag", "complete")?;
                 s.serialize_field("complete", x)?;
                 s.end()
             }
-            MembersAddJobStatusV2Result::Failed(ref x) => {
+            MembersAddJobStatusV2Result::Failed(x) => {
                 // primitive
                 let mut s = serializer.serialize_struct("MembersAddJobStatusV2Result", 2)?;
                 s.serialize_field(".tag", "failed")?;
@@ -15651,15 +15651,15 @@ impl ::serde::ser::Serialize for MembersAddLaunch {
     fn serialize<S: ::serde::ser::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
         // union serializer
         use serde::ser::SerializeStruct;
-        match *self {
-            MembersAddLaunch::AsyncJobId(ref x) => {
+        match self {
+            MembersAddLaunch::AsyncJobId(x) => {
                 // primitive
                 let mut s = serializer.serialize_struct("MembersAddLaunch", 2)?;
                 s.serialize_field(".tag", "async_job_id")?;
                 s.serialize_field("async_job_id", x)?;
                 s.end()
             }
-            MembersAddLaunch::Complete(ref x) => {
+            MembersAddLaunch::Complete(x) => {
                 // primitive
                 let mut s = serializer.serialize_struct("MembersAddLaunch", 2)?;
                 s.serialize_field(".tag", "complete")?;
@@ -15737,15 +15737,15 @@ impl ::serde::ser::Serialize for MembersAddLaunchV2Result {
     fn serialize<S: ::serde::ser::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
         // union serializer
         use serde::ser::SerializeStruct;
-        match *self {
-            MembersAddLaunchV2Result::AsyncJobId(ref x) => {
+        match self {
+            MembersAddLaunchV2Result::AsyncJobId(x) => {
                 // primitive
                 let mut s = serializer.serialize_struct("MembersAddLaunchV2Result", 2)?;
                 s.serialize_field(".tag", "async_job_id")?;
                 s.serialize_field("async_job_id", x)?;
                 s.end()
             }
-            MembersAddLaunchV2Result::Complete(ref x) => {
+            MembersAddLaunchV2Result::Complete(x) => {
                 // primitive
                 let mut s = serializer.serialize_struct("MembersAddLaunchV2Result", 2)?;
                 s.serialize_field(".tag", "complete")?;
@@ -16273,7 +16273,7 @@ impl ::serde::ser::Serialize for MembersDeactivateError {
     fn serialize<S: ::serde::ser::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
         // union serializer
         use serde::ser::SerializeStruct;
-        match *self {
+        match self {
             MembersDeactivateError::UserNotFound => {
                 // unit
                 let mut s = serializer.serialize_struct("MembersDeactivateError", 1)?;
@@ -16455,7 +16455,7 @@ impl ::serde::ser::Serialize for MembersDeleteProfilePhotoError {
     fn serialize<S: ::serde::ser::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
         // union serializer
         use serde::ser::SerializeStruct;
-        match *self {
+        match self {
             MembersDeleteProfilePhotoError::UserNotFound => {
                 // unit
                 let mut s = serializer.serialize_struct("MembersDeleteProfilePhotoError", 1)?;
@@ -16792,15 +16792,15 @@ impl ::serde::ser::Serialize for MembersGetInfoItem {
     fn serialize<S: ::serde::ser::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
         // union serializer
         use serde::ser::SerializeStruct;
-        match *self {
-            MembersGetInfoItem::IdNotFound(ref x) => {
+        match self {
+            MembersGetInfoItem::IdNotFound(x) => {
                 // primitive
                 let mut s = serializer.serialize_struct("MembersGetInfoItem", 2)?;
                 s.serialize_field(".tag", "id_not_found")?;
                 s.serialize_field("id_not_found", x)?;
                 s.end()
             }
-            MembersGetInfoItem::MemberInfo(ref x) => {
+            MembersGetInfoItem::MemberInfo(x) => {
                 // struct
                 let mut s = serializer.serialize_struct("MembersGetInfoItem", 3)?;
                 s.serialize_field(".tag", "member_info")?;
@@ -16867,8 +16867,8 @@ impl ::serde::ser::Serialize for MembersGetInfoItemBase {
     fn serialize<S: ::serde::ser::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
         // union serializer
         use serde::ser::SerializeStruct;
-        match *self {
-            MembersGetInfoItemBase::IdNotFound(ref x) => {
+        match self {
+            MembersGetInfoItemBase::IdNotFound(x) => {
                 // primitive
                 let mut s = serializer.serialize_struct("MembersGetInfoItemBase", 2)?;
                 s.serialize_field(".tag", "id_not_found")?;
@@ -16938,15 +16938,15 @@ impl ::serde::ser::Serialize for MembersGetInfoItemV2 {
     fn serialize<S: ::serde::ser::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
         // union serializer
         use serde::ser::SerializeStruct;
-        match *self {
-            MembersGetInfoItemV2::IdNotFound(ref x) => {
+        match self {
+            MembersGetInfoItemV2::IdNotFound(x) => {
                 // primitive
                 let mut s = serializer.serialize_struct("MembersGetInfoItemV2", 2)?;
                 s.serialize_field(".tag", "id_not_found")?;
                 s.serialize_field("id_not_found", x)?;
                 s.end()
             }
-            MembersGetInfoItemV2::MemberInfo(ref x) => {
+            MembersGetInfoItemV2::MemberInfo(x) => {
                 // struct
                 let mut s = serializer.serialize_struct("MembersGetInfoItemV2", 3)?;
                 s.serialize_field(".tag", "member_info")?;
@@ -17498,7 +17498,7 @@ impl ::serde::ser::Serialize for MembersListContinueError {
     fn serialize<S: ::serde::ser::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
         // union serializer
         use serde::ser::SerializeStruct;
-        match *self {
+        match self {
             MembersListContinueError::InvalidCursor => {
                 // unit
                 let mut s = serializer.serialize_struct("MembersListContinueError", 1)?;
@@ -17962,7 +17962,7 @@ impl ::serde::ser::Serialize for MembersRecoverError {
     fn serialize<S: ::serde::ser::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
         // union serializer
         use serde::ser::SerializeStruct;
-        match *self {
+        match self {
             MembersRecoverError::UserNotFound => {
                 // unit
                 let mut s = serializer.serialize_struct("MembersRecoverError", 1)?;
@@ -18356,7 +18356,7 @@ impl ::serde::ser::Serialize for MembersRemoveError {
     fn serialize<S: ::serde::ser::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
         // union serializer
         use serde::ser::SerializeStruct;
-        match *self {
+        match self {
             MembersRemoveError::UserNotFound => {
                 // unit
                 let mut s = serializer.serialize_struct("MembersRemoveError", 1)?;
@@ -18592,7 +18592,7 @@ impl ::serde::ser::Serialize for MembersSendWelcomeError {
     fn serialize<S: ::serde::ser::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
         // union serializer
         use serde::ser::SerializeStruct;
-        match *self {
+        match self {
             MembersSendWelcomeError::UserNotFound => {
                 // unit
                 let mut s = serializer.serialize_struct("MembersSendWelcomeError", 1)?;
@@ -18806,7 +18806,7 @@ impl ::serde::ser::Serialize for MembersSetPermissions2Error {
     fn serialize<S: ::serde::ser::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
         // union serializer
         use serde::ser::SerializeStruct;
-        match *self {
+        match self {
             MembersSetPermissions2Error::UserNotFound => {
                 // unit
                 let mut s = serializer.serialize_struct("MembersSetPermissions2Error", 1)?;
@@ -19143,7 +19143,7 @@ impl ::serde::ser::Serialize for MembersSetPermissionsError {
     fn serialize<S: ::serde::ser::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
         // union serializer
         use serde::ser::SerializeStruct;
-        match *self {
+        match self {
             MembersSetPermissionsError::UserNotFound => {
                 // unit
                 let mut s = serializer.serialize_struct("MembersSetPermissionsError", 1)?;
@@ -19610,7 +19610,7 @@ impl ::serde::ser::Serialize for MembersSetProfileError {
     fn serialize<S: ::serde::ser::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
         // union serializer
         use serde::ser::SerializeStruct;
-        match *self {
+        match self {
             MembersSetProfileError::UserNotFound => {
                 // unit
                 let mut s = serializer.serialize_struct("MembersSetProfileError", 1)?;
@@ -19878,7 +19878,7 @@ impl ::serde::ser::Serialize for MembersSetProfilePhotoError {
     fn serialize<S: ::serde::ser::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
         // union serializer
         use serde::ser::SerializeStruct;
-        match *self {
+        match self {
             MembersSetProfilePhotoError::UserNotFound => {
                 // unit
                 let mut s = serializer.serialize_struct("MembersSetProfilePhotoError", 1)?;
@@ -19897,7 +19897,7 @@ impl ::serde::ser::Serialize for MembersSetProfilePhotoError {
                 s.serialize_field(".tag", "set_profile_disallowed")?;
                 s.end()
             }
-            MembersSetProfilePhotoError::PhotoError(ref x) => {
+            MembersSetProfilePhotoError::PhotoError(x) => {
                 // union or polymporphic struct
                 let mut s = serializer.serialize_struct("MembersSetProfilePhotoError", 2)?;
                 s.serialize_field(".tag", "photo_error")?;
@@ -19999,7 +19999,7 @@ impl ::serde::ser::Serialize for MembersSuspendError {
     fn serialize<S: ::serde::ser::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
         // union serializer
         use serde::ser::SerializeStruct;
-        match *self {
+        match self {
             MembersSuspendError::UserNotFound => {
                 // unit
                 let mut s = serializer.serialize_struct("MembersSuspendError", 1)?;
@@ -20145,7 +20145,7 @@ impl ::serde::ser::Serialize for MembersTransferFilesError {
     fn serialize<S: ::serde::ser::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
         // union serializer
         use serde::ser::SerializeStruct;
-        match *self {
+        match self {
             MembersTransferFilesError::UserNotFound => {
                 // unit
                 let mut s = serializer.serialize_struct("MembersTransferFilesError", 1)?;
@@ -20349,7 +20349,7 @@ impl ::serde::ser::Serialize for MembersTransferFormerMembersFilesError {
     fn serialize<S: ::serde::ser::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
         // union serializer
         use serde::ser::SerializeStruct;
-        match *self {
+        match self {
             MembersTransferFormerMembersFilesError::UserNotFound => {
                 // unit
                 let mut s = serializer.serialize_struct("MembersTransferFormerMembersFilesError", 1)?;
@@ -20639,7 +20639,7 @@ impl ::serde::ser::Serialize for MembersUnsuspendError {
     fn serialize<S: ::serde::ser::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
         // union serializer
         use serde::ser::SerializeStruct;
-        match *self {
+        match self {
             MembersUnsuspendError::UserNotFound => {
                 // unit
                 let mut s = serializer.serialize_struct("MembersUnsuspendError", 1)?;
@@ -20753,7 +20753,7 @@ impl ::serde::ser::Serialize for MobileClientPlatform {
     fn serialize<S: ::serde::ser::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
         // union serializer
         use serde::ser::SerializeStruct;
-        match *self {
+        match self {
             MobileClientPlatform::Iphone => {
                 // unit
                 let mut s = serializer.serialize_struct("MobileClientPlatform", 1)?;
@@ -21261,7 +21261,7 @@ impl ::serde::ser::Serialize for NamespaceType {
     fn serialize<S: ::serde::ser::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
         // union serializer
         use serde::ser::SerializeStruct;
-        match *self {
+        match self {
             NamespaceType::AppFolder => {
                 // unit
                 let mut s = serializer.serialize_struct("NamespaceType", 1)?;
@@ -21351,15 +21351,15 @@ impl ::serde::ser::Serialize for RemoveCustomQuotaResult {
     fn serialize<S: ::serde::ser::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
         // union serializer
         use serde::ser::SerializeStruct;
-        match *self {
-            RemoveCustomQuotaResult::Success(ref x) => {
+        match self {
+            RemoveCustomQuotaResult::Success(x) => {
                 // union or polymporphic struct
                 let mut s = serializer.serialize_struct("RemoveCustomQuotaResult", 2)?;
                 s.serialize_field(".tag", "success")?;
                 s.serialize_field("success", x)?;
                 s.end()
             }
-            RemoveCustomQuotaResult::InvalidUser(ref x) => {
+            RemoveCustomQuotaResult::InvalidUser(x) => {
                 // union or polymporphic struct
                 let mut s = serializer.serialize_struct("RemoveCustomQuotaResult", 2)?;
                 s.serialize_field(".tag", "invalid_user")?;
@@ -21547,22 +21547,22 @@ impl ::serde::ser::Serialize for ResendSecondaryEmailResult {
     fn serialize<S: ::serde::ser::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
         // union serializer
         use serde::ser::SerializeStruct;
-        match *self {
-            ResendSecondaryEmailResult::Success(ref x) => {
+        match self {
+            ResendSecondaryEmailResult::Success(x) => {
                 // primitive
                 let mut s = serializer.serialize_struct("ResendSecondaryEmailResult", 2)?;
                 s.serialize_field(".tag", "success")?;
                 s.serialize_field("success", x)?;
                 s.end()
             }
-            ResendSecondaryEmailResult::NotPending(ref x) => {
+            ResendSecondaryEmailResult::NotPending(x) => {
                 // primitive
                 let mut s = serializer.serialize_struct("ResendSecondaryEmailResult", 2)?;
                 s.serialize_field(".tag", "not_pending")?;
                 s.serialize_field("not_pending", x)?;
                 s.end()
             }
-            ResendSecondaryEmailResult::RateLimited(ref x) => {
+            ResendSecondaryEmailResult::RateLimited(x) => {
                 // primitive
                 let mut s = serializer.serialize_struct("ResendSecondaryEmailResult", 2)?;
                 s.serialize_field(".tag", "rate_limited")?;
@@ -21936,22 +21936,22 @@ impl ::serde::ser::Serialize for RevokeDeviceSessionArg {
     fn serialize<S: ::serde::ser::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
         // union serializer
         use serde::ser::SerializeStruct;
-        match *self {
-            RevokeDeviceSessionArg::WebSession(ref x) => {
+        match self {
+            RevokeDeviceSessionArg::WebSession(x) => {
                 // struct
                 let mut s = serializer.serialize_struct("RevokeDeviceSessionArg", 3)?;
                 s.serialize_field(".tag", "web_session")?;
                 x.internal_serialize::<S>(&mut s)?;
                 s.end()
             }
-            RevokeDeviceSessionArg::DesktopClient(ref x) => {
+            RevokeDeviceSessionArg::DesktopClient(x) => {
                 // struct
                 let mut s = serializer.serialize_struct("RevokeDeviceSessionArg", 4)?;
                 s.serialize_field(".tag", "desktop_client")?;
                 x.internal_serialize::<S>(&mut s)?;
                 s.end()
             }
-            RevokeDeviceSessionArg::MobileClient(ref x) => {
+            RevokeDeviceSessionArg::MobileClient(x) => {
                 // struct
                 let mut s = serializer.serialize_struct("RevokeDeviceSessionArg", 3)?;
                 s.serialize_field(".tag", "mobile_client")?;
@@ -22241,7 +22241,7 @@ impl ::serde::ser::Serialize for RevokeDeviceSessionError {
     fn serialize<S: ::serde::ser::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
         // union serializer
         use serde::ser::SerializeStruct;
-        match *self {
+        match self {
             RevokeDeviceSessionError::DeviceSessionNotFound => {
                 // unit
                 let mut s = serializer.serialize_struct("RevokeDeviceSessionError", 1)?;
@@ -22794,7 +22794,7 @@ impl ::serde::ser::Serialize for RevokeLinkedAppError {
     fn serialize<S: ::serde::ser::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
         // union serializer
         use serde::ser::SerializeStruct;
-        match *self {
+        match self {
             RevokeLinkedAppError::AppNotFound => {
                 // unit
                 let mut s = serializer.serialize_struct("RevokeLinkedAppError", 1)?;
@@ -23082,7 +23082,7 @@ impl ::serde::ser::Serialize for SetCustomQuotaError {
     fn serialize<S: ::serde::ser::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
         // union serializer
         use serde::ser::SerializeStruct;
-        match *self {
+        match self {
             SetCustomQuotaError::TooManyUsers => {
                 // unit
                 let mut s = serializer.serialize_struct("SetCustomQuotaError", 1)?;
@@ -23299,8 +23299,8 @@ impl ::serde::ser::Serialize for SharingAllowlistAddError {
     fn serialize<S: ::serde::ser::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
         // union serializer
         use serde::ser::SerializeStruct;
-        match *self {
-            SharingAllowlistAddError::MalformedEntry(ref x) => {
+        match self {
+            SharingAllowlistAddError::MalformedEntry(x) => {
                 // primitive
                 let mut s = serializer.serialize_struct("SharingAllowlistAddError", 2)?;
                 s.serialize_field(".tag", "malformed_entry")?;
@@ -23331,7 +23331,7 @@ impl ::serde::ser::Serialize for SharingAllowlistAddError {
                 s.serialize_field(".tag", "unknown_error")?;
                 s.end()
             }
-            SharingAllowlistAddError::EntriesAlreadyExist(ref x) => {
+            SharingAllowlistAddError::EntriesAlreadyExist(x) => {
                 // primitive
                 let mut s = serializer.serialize_struct("SharingAllowlistAddError", 2)?;
                 s.serialize_field(".tag", "entries_already_exist")?;
@@ -23630,7 +23630,7 @@ impl ::serde::ser::Serialize for SharingAllowlistListContinueError {
     fn serialize<S: ::serde::ser::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
         // union serializer
         use serde::ser::SerializeStruct;
-        match *self {
+        match self {
             SharingAllowlistListContinueError::InvalidCursor => {
                 // unit
                 let mut s = serializer.serialize_struct("SharingAllowlistListContinueError", 1)?;
@@ -24025,15 +24025,15 @@ impl ::serde::ser::Serialize for SharingAllowlistRemoveError {
     fn serialize<S: ::serde::ser::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
         // union serializer
         use serde::ser::SerializeStruct;
-        match *self {
-            SharingAllowlistRemoveError::MalformedEntry(ref x) => {
+        match self {
+            SharingAllowlistRemoveError::MalformedEntry(x) => {
                 // primitive
                 let mut s = serializer.serialize_struct("SharingAllowlistRemoveError", 2)?;
                 s.serialize_field(".tag", "malformed_entry")?;
                 s.serialize_field("malformed_entry", x)?;
                 s.end()
             }
-            SharingAllowlistRemoveError::EntriesDoNotExist(ref x) => {
+            SharingAllowlistRemoveError::EntriesDoNotExist(x) => {
                 // primitive
                 let mut s = serializer.serialize_struct("SharingAllowlistRemoveError", 2)?;
                 s.serialize_field(".tag", "entries_do_not_exist")?;
@@ -24277,7 +24277,7 @@ impl ::serde::ser::Serialize for TeamFolderAccessError {
     fn serialize<S: ::serde::ser::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
         // union serializer
         use serde::ser::SerializeStruct;
-        match *self {
+        match self {
             TeamFolderAccessError::InvalidTeamFolderId => {
                 // unit
                 let mut s = serializer.serialize_struct("TeamFolderAccessError", 1)?;
@@ -24375,22 +24375,22 @@ impl ::serde::ser::Serialize for TeamFolderActivateError {
     fn serialize<S: ::serde::ser::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
         // union serializer
         use serde::ser::SerializeStruct;
-        match *self {
-            TeamFolderActivateError::AccessError(ref x) => {
+        match self {
+            TeamFolderActivateError::AccessError(x) => {
                 // union or polymporphic struct
                 let mut s = serializer.serialize_struct("TeamFolderActivateError", 2)?;
                 s.serialize_field(".tag", "access_error")?;
                 s.serialize_field("access_error", x)?;
                 s.end()
             }
-            TeamFolderActivateError::StatusError(ref x) => {
+            TeamFolderActivateError::StatusError(x) => {
                 // union or polymporphic struct
                 let mut s = serializer.serialize_struct("TeamFolderActivateError", 2)?;
                 s.serialize_field(".tag", "status_error")?;
                 s.serialize_field("status_error", x)?;
                 s.end()
             }
-            TeamFolderActivateError::TeamSharedDropboxError(ref x) => {
+            TeamFolderActivateError::TeamSharedDropboxError(x) => {
                 // union or polymporphic struct
                 let mut s = serializer.serialize_struct("TeamFolderActivateError", 2)?;
                 s.serialize_field(".tag", "team_shared_dropbox_error")?;
@@ -24621,22 +24621,22 @@ impl ::serde::ser::Serialize for TeamFolderArchiveError {
     fn serialize<S: ::serde::ser::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
         // union serializer
         use serde::ser::SerializeStruct;
-        match *self {
-            TeamFolderArchiveError::AccessError(ref x) => {
+        match self {
+            TeamFolderArchiveError::AccessError(x) => {
                 // union or polymporphic struct
                 let mut s = serializer.serialize_struct("TeamFolderArchiveError", 2)?;
                 s.serialize_field(".tag", "access_error")?;
                 s.serialize_field("access_error", x)?;
                 s.end()
             }
-            TeamFolderArchiveError::StatusError(ref x) => {
+            TeamFolderArchiveError::StatusError(x) => {
                 // union or polymporphic struct
                 let mut s = serializer.serialize_struct("TeamFolderArchiveError", 2)?;
                 s.serialize_field(".tag", "status_error")?;
                 s.serialize_field("status_error", x)?;
                 s.end()
             }
-            TeamFolderArchiveError::TeamSharedDropboxError(ref x) => {
+            TeamFolderArchiveError::TeamSharedDropboxError(x) => {
                 // union or polymporphic struct
                 let mut s = serializer.serialize_struct("TeamFolderArchiveError", 2)?;
                 s.serialize_field(".tag", "team_shared_dropbox_error")?;
@@ -24734,21 +24734,21 @@ impl ::serde::ser::Serialize for TeamFolderArchiveJobStatus {
     fn serialize<S: ::serde::ser::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
         // union serializer
         use serde::ser::SerializeStruct;
-        match *self {
+        match self {
             TeamFolderArchiveJobStatus::InProgress => {
                 // unit
                 let mut s = serializer.serialize_struct("TeamFolderArchiveJobStatus", 1)?;
                 s.serialize_field(".tag", "in_progress")?;
                 s.end()
             }
-            TeamFolderArchiveJobStatus::Complete(ref x) => {
+            TeamFolderArchiveJobStatus::Complete(x) => {
                 // struct
                 let mut s = serializer.serialize_struct("TeamFolderArchiveJobStatus", 7)?;
                 s.serialize_field(".tag", "complete")?;
                 x.internal_serialize::<S>(&mut s)?;
                 s.end()
             }
-            TeamFolderArchiveJobStatus::Failed(ref x) => {
+            TeamFolderArchiveJobStatus::Failed(x) => {
                 // union or polymporphic struct
                 let mut s = serializer.serialize_struct("TeamFolderArchiveJobStatus", 2)?;
                 s.serialize_field(".tag", "failed")?;
@@ -24815,15 +24815,15 @@ impl ::serde::ser::Serialize for TeamFolderArchiveLaunch {
     fn serialize<S: ::serde::ser::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
         // union serializer
         use serde::ser::SerializeStruct;
-        match *self {
-            TeamFolderArchiveLaunch::AsyncJobId(ref x) => {
+        match self {
+            TeamFolderArchiveLaunch::AsyncJobId(x) => {
                 // primitive
                 let mut s = serializer.serialize_struct("TeamFolderArchiveLaunch", 2)?;
                 s.serialize_field(".tag", "async_job_id")?;
                 s.serialize_field("async_job_id", x)?;
                 s.end()
             }
-            TeamFolderArchiveLaunch::Complete(ref x) => {
+            TeamFolderArchiveLaunch::Complete(x) => {
                 // struct
                 let mut s = serializer.serialize_struct("TeamFolderArchiveLaunch", 7)?;
                 s.serialize_field(".tag", "complete")?;
@@ -25015,7 +25015,7 @@ impl ::serde::ser::Serialize for TeamFolderCreateError {
     fn serialize<S: ::serde::ser::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
         // union serializer
         use serde::ser::SerializeStruct;
-        match *self {
+        match self {
             TeamFolderCreateError::InvalidFolderName => {
                 // unit
                 let mut s = serializer.serialize_struct("TeamFolderCreateError", 1)?;
@@ -25034,7 +25034,7 @@ impl ::serde::ser::Serialize for TeamFolderCreateError {
                 s.serialize_field(".tag", "folder_name_reserved")?;
                 s.end()
             }
-            TeamFolderCreateError::SyncSettingsError(ref x) => {
+            TeamFolderCreateError::SyncSettingsError(x) => {
                 // union or polymporphic struct
                 let mut s = serializer.serialize_struct("TeamFolderCreateError", 2)?;
                 s.serialize_field(".tag", "sync_settings_error")?;
@@ -25117,15 +25117,15 @@ impl ::serde::ser::Serialize for TeamFolderGetInfoItem {
     fn serialize<S: ::serde::ser::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
         // union serializer
         use serde::ser::SerializeStruct;
-        match *self {
-            TeamFolderGetInfoItem::IdNotFound(ref x) => {
+        match self {
+            TeamFolderGetInfoItem::IdNotFound(x) => {
                 // primitive
                 let mut s = serializer.serialize_struct("TeamFolderGetInfoItem", 2)?;
                 s.serialize_field(".tag", "id_not_found")?;
                 s.serialize_field("id_not_found", x)?;
                 s.end()
             }
-            TeamFolderGetInfoItem::TeamFolderMetadata(ref x) => {
+            TeamFolderGetInfoItem::TeamFolderMetadata(x) => {
                 // struct
                 let mut s = serializer.serialize_struct("TeamFolderGetInfoItem", 7)?;
                 s.serialize_field(".tag", "team_folder_metadata")?;
@@ -25369,7 +25369,7 @@ impl ::serde::ser::Serialize for TeamFolderInvalidStatusError {
     fn serialize<S: ::serde::ser::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
         // union serializer
         use serde::ser::SerializeStruct;
-        match *self {
+        match self {
             TeamFolderInvalidStatusError::Active => {
                 // unit
                 let mut s = serializer.serialize_struct("TeamFolderInvalidStatusError", 1)?;
@@ -25630,7 +25630,7 @@ impl ::serde::ser::Serialize for TeamFolderListContinueError {
     fn serialize<S: ::serde::ser::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
         // union serializer
         use serde::ser::SerializeStruct;
-        match *self {
+        match self {
             TeamFolderListContinueError::InvalidCursor => {
                 // unit
                 let mut s = serializer.serialize_struct("TeamFolderListContinueError", 1)?;
@@ -26106,22 +26106,22 @@ impl ::serde::ser::Serialize for TeamFolderPermanentlyDeleteError {
     fn serialize<S: ::serde::ser::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
         // union serializer
         use serde::ser::SerializeStruct;
-        match *self {
-            TeamFolderPermanentlyDeleteError::AccessError(ref x) => {
+        match self {
+            TeamFolderPermanentlyDeleteError::AccessError(x) => {
                 // union or polymporphic struct
                 let mut s = serializer.serialize_struct("TeamFolderPermanentlyDeleteError", 2)?;
                 s.serialize_field(".tag", "access_error")?;
                 s.serialize_field("access_error", x)?;
                 s.end()
             }
-            TeamFolderPermanentlyDeleteError::StatusError(ref x) => {
+            TeamFolderPermanentlyDeleteError::StatusError(x) => {
                 // union or polymporphic struct
                 let mut s = serializer.serialize_struct("TeamFolderPermanentlyDeleteError", 2)?;
                 s.serialize_field(".tag", "status_error")?;
                 s.serialize_field("status_error", x)?;
                 s.end()
             }
-            TeamFolderPermanentlyDeleteError::TeamSharedDropboxError(ref x) => {
+            TeamFolderPermanentlyDeleteError::TeamSharedDropboxError(x) => {
                 // union or polymporphic struct
                 let mut s = serializer.serialize_struct("TeamFolderPermanentlyDeleteError", 2)?;
                 s.serialize_field(".tag", "team_shared_dropbox_error")?;
@@ -26356,22 +26356,22 @@ impl ::serde::ser::Serialize for TeamFolderRenameError {
     fn serialize<S: ::serde::ser::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
         // union serializer
         use serde::ser::SerializeStruct;
-        match *self {
-            TeamFolderRenameError::AccessError(ref x) => {
+        match self {
+            TeamFolderRenameError::AccessError(x) => {
                 // union or polymporphic struct
                 let mut s = serializer.serialize_struct("TeamFolderRenameError", 2)?;
                 s.serialize_field(".tag", "access_error")?;
                 s.serialize_field("access_error", x)?;
                 s.end()
             }
-            TeamFolderRenameError::StatusError(ref x) => {
+            TeamFolderRenameError::StatusError(x) => {
                 // union or polymporphic struct
                 let mut s = serializer.serialize_struct("TeamFolderRenameError", 2)?;
                 s.serialize_field(".tag", "status_error")?;
                 s.serialize_field("status_error", x)?;
                 s.end()
             }
-            TeamFolderRenameError::TeamSharedDropboxError(ref x) => {
+            TeamFolderRenameError::TeamSharedDropboxError(x) => {
                 // union or polymporphic struct
                 let mut s = serializer.serialize_struct("TeamFolderRenameError", 2)?;
                 s.serialize_field(".tag", "team_shared_dropbox_error")?;
@@ -26488,7 +26488,7 @@ impl ::serde::ser::Serialize for TeamFolderStatus {
     fn serialize<S: ::serde::ser::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
         // union serializer
         use serde::ser::SerializeStruct;
-        match *self {
+        match self {
             TeamFolderStatus::Active => {
                 // unit
                 let mut s = serializer.serialize_struct("TeamFolderStatus", 1)?;
@@ -26555,7 +26555,7 @@ impl ::serde::ser::Serialize for TeamFolderTeamSharedDropboxError {
     fn serialize<S: ::serde::ser::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
         // union serializer
         use serde::ser::SerializeStruct;
-        match *self {
+        match self {
             TeamFolderTeamSharedDropboxError::Disallowed => {
                 // unit
                 let mut s = serializer.serialize_struct("TeamFolderTeamSharedDropboxError", 1)?;
@@ -26798,29 +26798,29 @@ impl ::serde::ser::Serialize for TeamFolderUpdateSyncSettingsError {
     fn serialize<S: ::serde::ser::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
         // union serializer
         use serde::ser::SerializeStruct;
-        match *self {
-            TeamFolderUpdateSyncSettingsError::AccessError(ref x) => {
+        match self {
+            TeamFolderUpdateSyncSettingsError::AccessError(x) => {
                 // union or polymporphic struct
                 let mut s = serializer.serialize_struct("TeamFolderUpdateSyncSettingsError", 2)?;
                 s.serialize_field(".tag", "access_error")?;
                 s.serialize_field("access_error", x)?;
                 s.end()
             }
-            TeamFolderUpdateSyncSettingsError::StatusError(ref x) => {
+            TeamFolderUpdateSyncSettingsError::StatusError(x) => {
                 // union or polymporphic struct
                 let mut s = serializer.serialize_struct("TeamFolderUpdateSyncSettingsError", 2)?;
                 s.serialize_field(".tag", "status_error")?;
                 s.serialize_field("status_error", x)?;
                 s.end()
             }
-            TeamFolderUpdateSyncSettingsError::TeamSharedDropboxError(ref x) => {
+            TeamFolderUpdateSyncSettingsError::TeamSharedDropboxError(x) => {
                 // union or polymporphic struct
                 let mut s = serializer.serialize_struct("TeamFolderUpdateSyncSettingsError", 2)?;
                 s.serialize_field(".tag", "team_shared_dropbox_error")?;
                 s.serialize_field("team_shared_dropbox_error", x)?;
                 s.end()
             }
-            TeamFolderUpdateSyncSettingsError::SyncSettingsError(ref x) => {
+            TeamFolderUpdateSyncSettingsError::SyncSettingsError(x) => {
                 // union or polymporphic struct
                 let mut s = serializer.serialize_struct("TeamFolderUpdateSyncSettingsError", 2)?;
                 s.serialize_field(".tag", "sync_settings_error")?;
@@ -27920,7 +27920,7 @@ impl ::serde::ser::Serialize for TeamMemberStatus {
     fn serialize<S: ::serde::ser::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
         // union serializer
         use serde::ser::SerializeStruct;
-        match *self {
+        match self {
             TeamMemberStatus::Active => {
                 // unit
                 let mut s = serializer.serialize_struct("TeamMemberStatus", 1)?;
@@ -27939,7 +27939,7 @@ impl ::serde::ser::Serialize for TeamMemberStatus {
                 s.serialize_field(".tag", "suspended")?;
                 s.end()
             }
-            TeamMemberStatus::Removed(ref x) => {
+            TeamMemberStatus::Removed(x) => {
                 // struct
                 let mut s = serializer.serialize_struct("TeamMemberStatus", 3)?;
                 s.serialize_field(".tag", "removed")?;
@@ -27993,7 +27993,7 @@ impl ::serde::ser::Serialize for TeamMembershipType {
     fn serialize<S: ::serde::ser::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
         // union serializer
         use serde::ser::SerializeStruct;
-        match *self {
+        match self {
             TeamMembershipType::Full => {
                 // unit
                 let mut s = serializer.serialize_struct("TeamMembershipType", 1)?;
@@ -28237,7 +28237,7 @@ impl ::serde::ser::Serialize for TeamNamespacesListContinueError {
     fn serialize<S: ::serde::ser::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
         // union serializer
         use serde::ser::SerializeStruct;
-        match *self {
+        match self {
             TeamNamespacesListContinueError::InvalidArg => {
                 // unit
                 let mut s = serializer.serialize_struct("TeamNamespacesListContinueError", 1)?;
@@ -28320,7 +28320,7 @@ impl ::serde::ser::Serialize for TeamNamespacesListError {
     fn serialize<S: ::serde::ser::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
         // union serializer
         use serde::ser::SerializeStruct;
-        match *self {
+        match self {
             TeamNamespacesListError::InvalidArg => {
                 // unit
                 let mut s = serializer.serialize_struct("TeamNamespacesListError", 1)?;
@@ -28516,7 +28516,7 @@ impl ::serde::ser::Serialize for TeamReportFailureReason {
     fn serialize<S: ::serde::ser::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
         // union serializer
         use serde::ser::SerializeStruct;
-        match *self {
+        match self {
             TeamReportFailureReason::TemporaryError => {
                 // unit
                 let mut s = serializer.serialize_struct("TeamReportFailureReason", 1)?;
@@ -28592,7 +28592,7 @@ impl ::serde::ser::Serialize for TokenGetAuthenticatedAdminError {
     fn serialize<S: ::serde::ser::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
         // union serializer
         use serde::ser::SerializeStruct;
-        match *self {
+        match self {
             TokenGetAuthenticatedAdminError::MappingNotFound => {
                 // unit
                 let mut s = serializer.serialize_struct("TokenGetAuthenticatedAdminError", 1)?;
@@ -28770,14 +28770,14 @@ impl ::serde::ser::Serialize for UploadApiRateLimitValue {
     fn serialize<S: ::serde::ser::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
         // union serializer
         use serde::ser::SerializeStruct;
-        match *self {
+        match self {
             UploadApiRateLimitValue::Unlimited => {
                 // unit
                 let mut s = serializer.serialize_struct("UploadApiRateLimitValue", 1)?;
                 s.serialize_field(".tag", "unlimited")?;
                 s.end()
             }
-            UploadApiRateLimitValue::Limit(ref x) => {
+            UploadApiRateLimitValue::Limit(x) => {
                 // primitive
                 let mut s = serializer.serialize_struct("UploadApiRateLimitValue", 2)?;
                 s.serialize_field(".tag", "limit")?;
@@ -28865,29 +28865,29 @@ impl ::serde::ser::Serialize for UserAddResult {
     fn serialize<S: ::serde::ser::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
         // union serializer
         use serde::ser::SerializeStruct;
-        match *self {
-            UserAddResult::Success(ref x) => {
+        match self {
+            UserAddResult::Success(x) => {
                 // struct
                 let mut s = serializer.serialize_struct("UserAddResult", 3)?;
                 s.serialize_field(".tag", "success")?;
                 x.internal_serialize::<S>(&mut s)?;
                 s.end()
             }
-            UserAddResult::InvalidUser(ref x) => {
+            UserAddResult::InvalidUser(x) => {
                 // union or polymporphic struct
                 let mut s = serializer.serialize_struct("UserAddResult", 2)?;
                 s.serialize_field(".tag", "invalid_user")?;
                 s.serialize_field("invalid_user", x)?;
                 s.end()
             }
-            UserAddResult::Unverified(ref x) => {
+            UserAddResult::Unverified(x) => {
                 // union or polymporphic struct
                 let mut s = serializer.serialize_struct("UserAddResult", 2)?;
                 s.serialize_field(".tag", "unverified")?;
                 s.serialize_field("unverified", x)?;
                 s.end()
             }
-            UserAddResult::PlaceholderUser(ref x) => {
+            UserAddResult::PlaceholderUser(x) => {
                 // union or polymporphic struct
                 let mut s = serializer.serialize_struct("UserAddResult", 2)?;
                 s.serialize_field(".tag", "placeholder_user")?;
@@ -29271,15 +29271,15 @@ impl ::serde::ser::Serialize for UserDeleteResult {
     fn serialize<S: ::serde::ser::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
         // union serializer
         use serde::ser::SerializeStruct;
-        match *self {
-            UserDeleteResult::Success(ref x) => {
+        match self {
+            UserDeleteResult::Success(x) => {
                 // struct
                 let mut s = serializer.serialize_struct("UserDeleteResult", 3)?;
                 s.serialize_field(".tag", "success")?;
                 x.internal_serialize::<S>(&mut s)?;
                 s.end()
             }
-            UserDeleteResult::InvalidUser(ref x) => {
+            UserDeleteResult::InvalidUser(x) => {
                 // union or polymporphic struct
                 let mut s = serializer.serialize_struct("UserDeleteResult", 2)?;
                 s.serialize_field(".tag", "invalid_user")?;
@@ -29449,15 +29449,15 @@ impl ::serde::ser::Serialize for UserResendResult {
     fn serialize<S: ::serde::ser::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
         // union serializer
         use serde::ser::SerializeStruct;
-        match *self {
-            UserResendResult::Success(ref x) => {
+        match self {
+            UserResendResult::Success(x) => {
                 // struct
                 let mut s = serializer.serialize_struct("UserResendResult", 3)?;
                 s.serialize_field(".tag", "success")?;
                 x.internal_serialize::<S>(&mut s)?;
                 s.end()
             }
-            UserResendResult::InvalidUser(ref x) => {
+            UserResendResult::InvalidUser(x) => {
                 // union or polymporphic struct
                 let mut s = serializer.serialize_struct("UserResendResult", 2)?;
                 s.serialize_field(".tag", "invalid_user")?;
@@ -29739,22 +29739,22 @@ impl ::serde::ser::Serialize for UserSelectorArg {
     fn serialize<S: ::serde::ser::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
         // union serializer
         use serde::ser::SerializeStruct;
-        match *self {
-            UserSelectorArg::TeamMemberId(ref x) => {
+        match self {
+            UserSelectorArg::TeamMemberId(x) => {
                 // primitive
                 let mut s = serializer.serialize_struct("UserSelectorArg", 2)?;
                 s.serialize_field(".tag", "team_member_id")?;
                 s.serialize_field("team_member_id", x)?;
                 s.end()
             }
-            UserSelectorArg::ExternalId(ref x) => {
+            UserSelectorArg::ExternalId(x) => {
                 // primitive
                 let mut s = serializer.serialize_struct("UserSelectorArg", 2)?;
                 s.serialize_field(".tag", "external_id")?;
                 s.serialize_field("external_id", x)?;
                 s.end()
             }
-            UserSelectorArg::Email(ref x) => {
+            UserSelectorArg::Email(x) => {
                 // primitive
                 let mut s = serializer.serialize_struct("UserSelectorArg", 2)?;
                 s.serialize_field(".tag", "email")?;
@@ -29805,7 +29805,7 @@ impl ::serde::ser::Serialize for UserSelectorError {
     fn serialize<S: ::serde::ser::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
         // union serializer
         use serde::ser::SerializeStruct;
-        match *self {
+        match self {
             UserSelectorError::UserNotFound => {
                 // unit
                 let mut s = serializer.serialize_struct("UserSelectorError", 1)?;
@@ -29892,22 +29892,22 @@ impl ::serde::ser::Serialize for UsersSelectorArg {
     fn serialize<S: ::serde::ser::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
         // union serializer
         use serde::ser::SerializeStruct;
-        match *self {
-            UsersSelectorArg::TeamMemberIds(ref x) => {
+        match self {
+            UsersSelectorArg::TeamMemberIds(x) => {
                 // primitive
                 let mut s = serializer.serialize_struct("UsersSelectorArg", 2)?;
                 s.serialize_field(".tag", "team_member_ids")?;
                 s.serialize_field("team_member_ids", x)?;
                 s.end()
             }
-            UsersSelectorArg::ExternalIds(ref x) => {
+            UsersSelectorArg::ExternalIds(x) => {
                 // primitive
                 let mut s = serializer.serialize_struct("UsersSelectorArg", 2)?;
                 s.serialize_field(".tag", "external_ids")?;
                 s.serialize_field("external_ids", x)?;
                 s.end()
             }
-            UsersSelectorArg::Emails(ref x) => {
+            UsersSelectorArg::Emails(x) => {
                 // primitive
                 let mut s = serializer.serialize_struct("UsersSelectorArg", 2)?;
                 s.serialize_field(".tag", "emails")?;

--- a/src/generated/types/team_common.rs
+++ b/src/generated/types/team_common.rs
@@ -67,7 +67,7 @@ impl ::serde::ser::Serialize for GroupManagementType {
     fn serialize<S: ::serde::ser::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
         // union serializer
         use serde::ser::SerializeStruct;
-        match *self {
+        match self {
             GroupManagementType::UserManaged => {
                 // unit
                 let mut s = serializer.serialize_struct("GroupManagementType", 1)?;
@@ -300,7 +300,7 @@ impl ::serde::ser::Serialize for GroupType {
     fn serialize<S: ::serde::ser::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
         // union serializer
         use serde::ser::SerializeStruct;
-        match *self {
+        match self {
             GroupType::Team => {
                 // unit
                 let mut s = serializer.serialize_struct("GroupType", 1)?;
@@ -372,7 +372,7 @@ impl ::serde::ser::Serialize for MemberSpaceLimitType {
     fn serialize<S: ::serde::ser::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
         // union serializer
         use serde::ser::SerializeStruct;
-        match *self {
+        match self {
             MemberSpaceLimitType::Off => {
                 // unit
                 let mut s = serializer.serialize_struct("MemberSpaceLimitType", 1)?;

--- a/src/generated/types/team_policies.rs
+++ b/src/generated/types/team_policies.rs
@@ -55,7 +55,7 @@ impl ::serde::ser::Serialize for CameraUploadsPolicyState {
     fn serialize<S: ::serde::ser::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
         // union serializer
         use serde::ser::SerializeStruct;
-        match *self {
+        match self {
             CameraUploadsPolicyState::Disabled => {
                 // unit
                 let mut s = serializer.serialize_struct("CameraUploadsPolicyState", 1)?;
@@ -124,7 +124,7 @@ impl ::serde::ser::Serialize for ComputerBackupPolicyState {
     fn serialize<S: ::serde::ser::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
         // union serializer
         use serde::ser::SerializeStruct;
-        match *self {
+        match self {
             ComputerBackupPolicyState::Disabled => {
                 // unit
                 let mut s = serializer.serialize_struct("ComputerBackupPolicyState", 1)?;
@@ -199,7 +199,7 @@ impl ::serde::ser::Serialize for EmmState {
     fn serialize<S: ::serde::ser::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
         // union serializer
         use serde::ser::SerializeStruct;
-        match *self {
+        match self {
             EmmState::Disabled => {
                 // unit
                 let mut s = serializer.serialize_struct("EmmState", 1)?;
@@ -274,7 +274,7 @@ impl ::serde::ser::Serialize for ExternalDriveBackupPolicyState {
     fn serialize<S: ::serde::ser::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
         // union serializer
         use serde::ser::SerializeStruct;
-        match *self {
+        match self {
             ExternalDriveBackupPolicyState::Disabled => {
                 // unit
                 let mut s = serializer.serialize_struct("ExternalDriveBackupPolicyState", 1)?;
@@ -345,7 +345,7 @@ impl ::serde::ser::Serialize for FileLockingPolicyState {
     fn serialize<S: ::serde::ser::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
         // union serializer
         use serde::ser::SerializeStruct;
-        match *self {
+        match self {
             FileLockingPolicyState::Disabled => {
                 // unit
                 let mut s = serializer.serialize_struct("FileLockingPolicyState", 1)?;
@@ -414,7 +414,7 @@ impl ::serde::ser::Serialize for FileProviderMigrationPolicyState {
     fn serialize<S: ::serde::ser::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
         // union serializer
         use serde::ser::SerializeStruct;
-        match *self {
+        match self {
             FileProviderMigrationPolicyState::Disabled => {
                 // unit
                 let mut s = serializer.serialize_struct("FileProviderMigrationPolicyState", 1)?;
@@ -480,7 +480,7 @@ impl ::serde::ser::Serialize for GroupCreation {
     fn serialize<S: ::serde::ser::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
         // union serializer
         use serde::ser::SerializeStruct;
-        match *self {
+        match self {
             GroupCreation::AdminsAndMembers => {
                 // unit
                 let mut s = serializer.serialize_struct("GroupCreation", 1)?;
@@ -544,7 +544,7 @@ impl ::serde::ser::Serialize for OfficeAddInPolicy {
     fn serialize<S: ::serde::ser::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
         // union serializer
         use serde::ser::SerializeStruct;
-        match *self {
+        match self {
             OfficeAddInPolicy::Disabled => {
                 // unit
                 let mut s = serializer.serialize_struct("OfficeAddInPolicy", 1)?;
@@ -609,7 +609,7 @@ impl ::serde::ser::Serialize for PaperDefaultFolderPolicy {
     fn serialize<S: ::serde::ser::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
         // union serializer
         use serde::ser::SerializeStruct;
-        match *self {
+        match self {
             PaperDefaultFolderPolicy::EveryoneInTeam => {
                 // unit
                 let mut s = serializer.serialize_struct("PaperDefaultFolderPolicy", 1)?;
@@ -675,7 +675,7 @@ impl ::serde::ser::Serialize for PaperDeploymentPolicy {
     fn serialize<S: ::serde::ser::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
         // union serializer
         use serde::ser::SerializeStruct;
-        match *self {
+        match self {
             PaperDeploymentPolicy::Full => {
                 // unit
                 let mut s = serializer.serialize_struct("PaperDeploymentPolicy", 1)?;
@@ -740,7 +740,7 @@ impl ::serde::ser::Serialize for PaperDesktopPolicy {
     fn serialize<S: ::serde::ser::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
         // union serializer
         use serde::ser::SerializeStruct;
-        match *self {
+        match self {
             PaperDesktopPolicy::Disabled => {
                 // unit
                 let mut s = serializer.serialize_struct("PaperDesktopPolicy", 1)?;
@@ -809,7 +809,7 @@ impl ::serde::ser::Serialize for PaperEnabledPolicy {
     fn serialize<S: ::serde::ser::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
         // union serializer
         use serde::ser::SerializeStruct;
-        match *self {
+        match self {
             PaperEnabledPolicy::Disabled => {
                 // unit
                 let mut s = serializer.serialize_struct("PaperEnabledPolicy", 1)?;
@@ -880,7 +880,7 @@ impl ::serde::ser::Serialize for PasswordControlMode {
     fn serialize<S: ::serde::ser::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
         // union serializer
         use serde::ser::SerializeStruct;
-        match *self {
+        match self {
             PasswordControlMode::Disabled => {
                 // unit
                 let mut s = serializer.serialize_struct("PasswordControlMode", 1)?;
@@ -949,7 +949,7 @@ impl ::serde::ser::Serialize for PasswordStrengthPolicy {
     fn serialize<S: ::serde::ser::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
         // union serializer
         use serde::ser::SerializeStruct;
-        match *self {
+        match self {
             PasswordStrengthPolicy::MinimalRequirements => {
                 // unit
                 let mut s = serializer.serialize_struct("PasswordStrengthPolicy", 1)?;
@@ -1019,7 +1019,7 @@ impl ::serde::ser::Serialize for RolloutMethod {
     fn serialize<S: ::serde::ser::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
         // union serializer
         use serde::ser::SerializeStruct;
-        match *self {
+        match self {
             RolloutMethod::UnlinkAll => {
                 // unit
                 let mut s = serializer.serialize_struct("RolloutMethod", 1)?;
@@ -1090,7 +1090,7 @@ impl ::serde::ser::Serialize for SharedFolderBlanketLinkRestrictionPolicy {
     fn serialize<S: ::serde::ser::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
         // union serializer
         use serde::ser::SerializeStruct;
-        match *self {
+        match self {
             SharedFolderBlanketLinkRestrictionPolicy::Members => {
                 // unit
                 let mut s = serializer.serialize_struct("SharedFolderBlanketLinkRestrictionPolicy", 1)?;
@@ -1156,7 +1156,7 @@ impl ::serde::ser::Serialize for SharedFolderJoinPolicy {
     fn serialize<S: ::serde::ser::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
         // union serializer
         use serde::ser::SerializeStruct;
-        match *self {
+        match self {
             SharedFolderJoinPolicy::FromTeamOnly => {
                 // unit
                 let mut s = serializer.serialize_struct("SharedFolderJoinPolicy", 1)?;
@@ -1222,7 +1222,7 @@ impl ::serde::ser::Serialize for SharedFolderMemberPolicy {
     fn serialize<S: ::serde::ser::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
         // union serializer
         use serde::ser::SerializeStruct;
-        match *self {
+        match self {
             SharedFolderMemberPolicy::Team => {
                 // unit
                 let mut s = serializer.serialize_struct("SharedFolderMemberPolicy", 1)?;
@@ -1301,7 +1301,7 @@ impl ::serde::ser::Serialize for SharedLinkCreatePolicy {
     fn serialize<S: ::serde::ser::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
         // union serializer
         use serde::ser::SerializeStruct;
-        match *self {
+        match self {
             SharedLinkCreatePolicy::DefaultPublic => {
                 // unit
                 let mut s = serializer.serialize_struct("SharedLinkCreatePolicy", 1)?;
@@ -1378,7 +1378,7 @@ impl ::serde::ser::Serialize for ShowcaseDownloadPolicy {
     fn serialize<S: ::serde::ser::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
         // union serializer
         use serde::ser::SerializeStruct;
-        match *self {
+        match self {
             ShowcaseDownloadPolicy::Disabled => {
                 // unit
                 let mut s = serializer.serialize_struct("ShowcaseDownloadPolicy", 1)?;
@@ -1443,7 +1443,7 @@ impl ::serde::ser::Serialize for ShowcaseEnabledPolicy {
     fn serialize<S: ::serde::ser::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
         // union serializer
         use serde::ser::SerializeStruct;
-        match *self {
+        match self {
             ShowcaseEnabledPolicy::Disabled => {
                 // unit
                 let mut s = serializer.serialize_struct("ShowcaseEnabledPolicy", 1)?;
@@ -1508,7 +1508,7 @@ impl ::serde::ser::Serialize for ShowcaseExternalSharingPolicy {
     fn serialize<S: ::serde::ser::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
         // union serializer
         use serde::ser::SerializeStruct;
-        match *self {
+        match self {
             ShowcaseExternalSharingPolicy::Disabled => {
                 // unit
                 let mut s = serializer.serialize_struct("ShowcaseExternalSharingPolicy", 1)?;
@@ -1573,7 +1573,7 @@ impl ::serde::ser::Serialize for SmartSyncPolicy {
     fn serialize<S: ::serde::ser::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
         // union serializer
         use serde::ser::SerializeStruct;
-        match *self {
+        match self {
             SmartSyncPolicy::Local => {
                 // unit
                 let mut s = serializer.serialize_struct("SmartSyncPolicy", 1)?;
@@ -1638,7 +1638,7 @@ impl ::serde::ser::Serialize for SmarterSmartSyncPolicyState {
     fn serialize<S: ::serde::ser::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
         // union serializer
         use serde::ser::SerializeStruct;
-        match *self {
+        match self {
             SmarterSmartSyncPolicyState::Disabled => {
                 // unit
                 let mut s = serializer.serialize_struct("SmarterSmartSyncPolicyState", 1)?;
@@ -1707,7 +1707,7 @@ impl ::serde::ser::Serialize for SsoPolicy {
     fn serialize<S: ::serde::ser::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
         // union serializer
         use serde::ser::SerializeStruct;
-        match *self {
+        match self {
             SsoPolicy::Disabled => {
                 // unit
                 let mut s = serializer.serialize_struct("SsoPolicy", 1)?;
@@ -1778,7 +1778,7 @@ impl ::serde::ser::Serialize for SuggestMembersPolicy {
     fn serialize<S: ::serde::ser::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
         // union serializer
         use serde::ser::SerializeStruct;
-        match *self {
+        match self {
             SuggestMembersPolicy::Disabled => {
                 // unit
                 let mut s = serializer.serialize_struct("SuggestMembersPolicy", 1)?;
@@ -2134,7 +2134,7 @@ impl ::serde::ser::Serialize for TwoStepVerificationPolicy {
     fn serialize<S: ::serde::ser::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
         // union serializer
         use serde::ser::SerializeStruct;
-        match *self {
+        match self {
             TwoStepVerificationPolicy::RequireTfaEnable => {
                 // unit
                 let mut s = serializer.serialize_struct("TwoStepVerificationPolicy", 1)?;
@@ -2203,7 +2203,7 @@ impl ::serde::ser::Serialize for TwoStepVerificationState {
     fn serialize<S: ::serde::ser::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
         // union serializer
         use serde::ser::SerializeStruct;
-        match *self {
+        match self {
             TwoStepVerificationState::Required => {
                 // unit
                 let mut s = serializer.serialize_struct("TwoStepVerificationState", 1)?;

--- a/src/generated/types/users.rs
+++ b/src/generated/types/users.rs
@@ -456,8 +456,8 @@ impl ::serde::ser::Serialize for FileLockingValue {
     fn serialize<S: ::serde::ser::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
         // union serializer
         use serde::ser::SerializeStruct;
-        match *self {
-            FileLockingValue::Enabled(ref x) => {
+        match self {
+            FileLockingValue::Enabled(x) => {
                 // primitive
                 let mut s = serializer.serialize_struct("FileLockingValue", 2)?;
                 s.serialize_field(".tag", "enabled")?;
@@ -1163,8 +1163,8 @@ impl ::serde::ser::Serialize for GetAccountBatchError {
     fn serialize<S: ::serde::ser::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
         // union serializer
         use serde::ser::SerializeStruct;
-        match *self {
-            GetAccountBatchError::NoAccount(ref x) => {
+        match self {
+            GetAccountBatchError::NoAccount(x) => {
                 // primitive
                 let mut s = serializer.serialize_struct("GetAccountBatchError", 2)?;
                 s.serialize_field(".tag", "no_account")?;
@@ -1231,7 +1231,7 @@ impl ::serde::ser::Serialize for GetAccountError {
     fn serialize<S: ::serde::ser::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
         // union serializer
         use serde::ser::SerializeStruct;
-        match *self {
+        match self {
             GetAccountError::NoAccount => {
                 // unit
                 let mut s = serializer.serialize_struct("GetAccountError", 1)?;
@@ -1547,8 +1547,8 @@ impl ::serde::ser::Serialize for PaperAsFilesValue {
     fn serialize<S: ::serde::ser::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
         // union serializer
         use serde::ser::SerializeStruct;
-        match *self {
-            PaperAsFilesValue::Enabled(ref x) => {
+        match self {
+            PaperAsFilesValue::Enabled(x) => {
                 // primitive
                 let mut s = serializer.serialize_struct("PaperAsFilesValue", 2)?;
                 s.serialize_field(".tag", "enabled")?;
@@ -1608,15 +1608,15 @@ impl ::serde::ser::Serialize for SpaceAllocation {
     fn serialize<S: ::serde::ser::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
         // union serializer
         use serde::ser::SerializeStruct;
-        match *self {
-            SpaceAllocation::Individual(ref x) => {
+        match self {
+            SpaceAllocation::Individual(x) => {
                 // struct
                 let mut s = serializer.serialize_struct("SpaceAllocation", 2)?;
                 s.serialize_field(".tag", "individual")?;
                 x.internal_serialize::<S>(&mut s)?;
                 s.end()
             }
-            SpaceAllocation::Team(ref x) => {
+            SpaceAllocation::Team(x) => {
                 // struct
                 let mut s = serializer.serialize_struct("SpaceAllocation", 6)?;
                 s.serialize_field(".tag", "team")?;
@@ -2036,7 +2036,7 @@ impl ::serde::ser::Serialize for UserFeature {
     fn serialize<S: ::serde::ser::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
         // union serializer
         use serde::ser::SerializeStruct;
-        match *self {
+        match self {
             UserFeature::PaperAsFiles => {
                 // unit
                 let mut s = serializer.serialize_struct("UserFeature", 1)?;
@@ -2112,15 +2112,15 @@ impl ::serde::ser::Serialize for UserFeatureValue {
     fn serialize<S: ::serde::ser::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
         // union serializer
         use serde::ser::SerializeStruct;
-        match *self {
-            UserFeatureValue::PaperAsFiles(ref x) => {
+        match self {
+            UserFeatureValue::PaperAsFiles(x) => {
                 // union or polymporphic struct
                 let mut s = serializer.serialize_struct("UserFeatureValue", 2)?;
                 s.serialize_field(".tag", "paper_as_files")?;
                 s.serialize_field("paper_as_files", x)?;
                 s.end()
             }
-            UserFeatureValue::FileLocking(ref x) => {
+            UserFeatureValue::FileLocking(x) => {
                 // union or polymporphic struct
                 let mut s = serializer.serialize_struct("UserFeatureValue", 2)?;
                 s.serialize_field(".tag", "file_locking")?;
@@ -2268,7 +2268,7 @@ impl ::serde::ser::Serialize for UserFeaturesGetValuesBatchError {
     fn serialize<S: ::serde::ser::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
         // union serializer
         use serde::ser::SerializeStruct;
-        match *self {
+        match self {
             UserFeaturesGetValuesBatchError::EmptyFeaturesList => {
                 // unit
                 let mut s = serializer.serialize_struct("UserFeaturesGetValuesBatchError", 1)?;

--- a/src/generated/types/users_common.rs
+++ b/src/generated/types/users_common.rs
@@ -59,7 +59,7 @@ impl ::serde::ser::Serialize for AccountType {
     fn serialize<S: ::serde::ser::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
         // union serializer
         use serde::ser::SerializeStruct;
-        match *self {
+        match self {
             AccountType::Basic => {
                 // unit
                 let mut s = serializer.serialize_struct("AccountType", 1)?;


### PR DESCRIPTION
Testing out the Rust 2024 edition revealed some cases where the generated serialization code is inconsistent in its binding modes. We start as ref (`&self`), switch to move (using `*` deref operator), then back to ref (using `ref`). The 2024 edition doesn't let you do this, and we don't need to anyway (just stay in ref mode), so let's fix that.

<!--
Thank you for your pull request. Please provide a description below.
-->

## **Checklist**

**General Contributing**
<!-- Change [ ] to [x] if you have: -->
- [x] I have read the Code of Conduct and signed the [CLA](https://opensource.dropbox.com/cla/).
- [x] I have added an entry to the `RELEASE_NOTES.md` file, or believe it's not necessary for this change.

**Validation**
<!-- Describe which tests cover the changes you've made, and any additional manual validation you
     did to ensure the correctness of this change. Does this change warrant addition of new tests?
     Does this change have performance implications? Etc. -->
Everything compiles.