### PR TITLE
use type name in Display impl for errors with no other message set

### DIFF
--- a/.github/workflows/cargo-test.yml
+++ b/.github/workflows/cargo-test.yml
@@ -41,6 +41,12 @@ jobs:
       - name: Install MSRV toolchain
         run: rustup install 1.75.0 --profile minimal
 
+      # remove this once our MSRV is >= 1.84, which has the MSRV-aware resolver
+      - name: fix deps for old rustc
+        run: |
+          rustup run 1.75.0 cargo update litemap --precise 0.7.4
+          rustup run 1.75.0 cargo update zerofrom --precise 0.1.5
+
       - name: Run cargo test
         run: rustup run 1.75.0 cargo test --all-features
 

--- a/generator/rust.stoneg.py
+++ b/generator/rust.stoneg.py
@@ -1144,6 +1144,9 @@ class RustBackend(RustHelperBackend):
                             msg = msg[:-1]
                         if msg:
                             msg += ': '
+                        else:
+                            # if there's no message for the variant, use the type name
+                            msg = f"{type_name}: "
                         msg += inner_fmt
                         args = 'inner'
 

--- a/src/default_async_client.rs
+++ b/src/default_async_client.rs
@@ -327,7 +327,7 @@ impl HttpClient for ReqwestClient {
 
                     let body = resp
                         .bytes_stream()
-                        .map_err(|e| futures::io::Error::new(futures::io::ErrorKind::Other, e))
+                        .map_err(futures::io::Error::other)
                         .into_async_read();
 
                     Ok(HttpRequestResultRaw {

--- a/src/generated/types/file_properties.rs
+++ b/src/generated/types/file_properties.rs
@@ -301,7 +301,7 @@ impl ::std::fmt::Display for AddPropertiesError {
         match self {
             AddPropertiesError::TemplateNotFound(inner) => write!(f, "Template does not exist for the given identifier: {:?}", inner),
             AddPropertiesError::RestrictedContent => f.write_str("You do not have permission to modify this template."),
-            AddPropertiesError::Path(inner) => write!(f, "{}", inner),
+            AddPropertiesError::Path(inner) => write!(f, "AddPropertiesError: {}", inner),
             AddPropertiesError::UnsupportedFolder => f.write_str("This folder cannot be tagged. Tagging folders is not supported for team-owned templates."),
             AddPropertiesError::PropertyFieldTooLarge => f.write_str("One or more of the supplied property field values is too large."),
             AddPropertiesError::DoesNotFitTemplate => f.write_str("One or more of the supplied property fields does not conform to the template specifications."),
@@ -911,7 +911,7 @@ impl ::std::fmt::Display for InvalidPropertyGroupError {
         match self {
             InvalidPropertyGroupError::TemplateNotFound(inner) => write!(f, "Template does not exist for the given identifier: {:?}", inner),
             InvalidPropertyGroupError::RestrictedContent => f.write_str("You do not have permission to modify this template."),
-            InvalidPropertyGroupError::Path(inner) => write!(f, "{}", inner),
+            InvalidPropertyGroupError::Path(inner) => write!(f, "InvalidPropertyGroupError: {}", inner),
             InvalidPropertyGroupError::UnsupportedFolder => f.write_str("This folder cannot be tagged. Tagging folders is not supported for team-owned templates."),
             InvalidPropertyGroupError::PropertyFieldTooLarge => f.write_str("One or more of the supplied property field values is too large."),
             InvalidPropertyGroupError::DoesNotFitTemplate => f.write_str("One or more of the supplied property fields does not conform to the template specifications."),
@@ -1624,7 +1624,7 @@ impl ::std::fmt::Display for PropertiesError {
         match self {
             PropertiesError::TemplateNotFound(inner) => write!(f, "Template does not exist for the given identifier: {:?}", inner),
             PropertiesError::RestrictedContent => f.write_str("You do not have permission to modify this template."),
-            PropertiesError::Path(inner) => write!(f, "{}", inner),
+            PropertiesError::Path(inner) => write!(f, "PropertiesError: {}", inner),
             PropertiesError::UnsupportedFolder => f.write_str("This folder cannot be tagged. Tagging folders is not supported for team-owned templates."),
             _ => write!(f, "{:?}", *self),
         }
@@ -1983,7 +1983,7 @@ impl ::std::error::Error for PropertiesSearchError {
 impl ::std::fmt::Display for PropertiesSearchError {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match self {
-            PropertiesSearchError::PropertyGroupLookup(inner) => write!(f, "{}", inner),
+            PropertiesSearchError::PropertyGroupLookup(inner) => write!(f, "PropertiesSearchError: {}", inner),
             _ => write!(f, "{:?}", *self),
         }
     }
@@ -3300,9 +3300,9 @@ impl ::std::fmt::Display for RemovePropertiesError {
         match self {
             RemovePropertiesError::TemplateNotFound(inner) => write!(f, "Template does not exist for the given identifier: {:?}", inner),
             RemovePropertiesError::RestrictedContent => f.write_str("You do not have permission to modify this template."),
-            RemovePropertiesError::Path(inner) => write!(f, "{}", inner),
+            RemovePropertiesError::Path(inner) => write!(f, "RemovePropertiesError: {}", inner),
             RemovePropertiesError::UnsupportedFolder => f.write_str("This folder cannot be tagged. Tagging folders is not supported for team-owned templates."),
-            RemovePropertiesError::PropertyGroupLookup(inner) => write!(f, "{}", inner),
+            RemovePropertiesError::PropertyGroupLookup(inner) => write!(f, "RemovePropertiesError: {}", inner),
             _ => write!(f, "{:?}", *self),
         }
     }
@@ -3971,12 +3971,12 @@ impl ::std::fmt::Display for UpdatePropertiesError {
         match self {
             UpdatePropertiesError::TemplateNotFound(inner) => write!(f, "Template does not exist for the given identifier: {:?}", inner),
             UpdatePropertiesError::RestrictedContent => f.write_str("You do not have permission to modify this template."),
-            UpdatePropertiesError::Path(inner) => write!(f, "{}", inner),
+            UpdatePropertiesError::Path(inner) => write!(f, "UpdatePropertiesError: {}", inner),
             UpdatePropertiesError::UnsupportedFolder => f.write_str("This folder cannot be tagged. Tagging folders is not supported for team-owned templates."),
             UpdatePropertiesError::PropertyFieldTooLarge => f.write_str("One or more of the supplied property field values is too large."),
             UpdatePropertiesError::DoesNotFitTemplate => f.write_str("One or more of the supplied property fields does not conform to the template specifications."),
             UpdatePropertiesError::DuplicatePropertyGroups => f.write_str("There are 2 or more property groups referring to the same templates in the input."),
-            UpdatePropertiesError::PropertyGroupLookup(inner) => write!(f, "{}", inner),
+            UpdatePropertiesError::PropertyGroupLookup(inner) => write!(f, "UpdatePropertiesError: {}", inner),
             _ => write!(f, "{:?}", *self),
         }
     }

--- a/src/generated/types/files.rs
+++ b/src/generated/types/files.rs
@@ -215,7 +215,7 @@ impl ::std::error::Error for AddTagError {
 impl ::std::fmt::Display for AddTagError {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match self {
-            AddTagError::Path(inner) => write!(f, "{}", inner),
+            AddTagError::Path(inner) => write!(f, "AddTagError: {}", inner),
             AddTagError::TooManyTags => f.write_str("The item already has the maximum supported number of tags."),
             _ => write!(f, "{:?}", *self),
         }
@@ -527,8 +527,8 @@ impl ::std::error::Error for AlphaGetMetadataError {
 impl ::std::fmt::Display for AlphaGetMetadataError {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match self {
-            AlphaGetMetadataError::Path(inner) => write!(f, "{}", inner),
-            AlphaGetMetadataError::PropertiesError(inner) => write!(f, "{}", inner),
+            AlphaGetMetadataError::Path(inner) => write!(f, "AlphaGetMetadataError: {}", inner),
+            AlphaGetMetadataError::PropertiesError(inner) => write!(f, "AlphaGetMetadataError: {}", inner),
         }
     }
 }
@@ -614,7 +614,7 @@ impl ::std::error::Error for BaseTagError {
 impl ::std::fmt::Display for BaseTagError {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match self {
-            BaseTagError::Path(inner) => write!(f, "{}", inner),
+            BaseTagError::Path(inner) => write!(f, "BaseTagError: {}", inner),
             _ => write!(f, "{:?}", *self),
         }
     }
@@ -1773,7 +1773,7 @@ impl ::std::error::Error for CreateFolderEntryError {
 impl ::std::fmt::Display for CreateFolderEntryError {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match self {
-            CreateFolderEntryError::Path(inner) => write!(f, "{}", inner),
+            CreateFolderEntryError::Path(inner) => write!(f, "CreateFolderEntryError: {}", inner),
             _ => write!(f, "{:?}", *self),
         }
     }
@@ -1936,7 +1936,7 @@ impl ::std::error::Error for CreateFolderError {
 impl ::std::fmt::Display for CreateFolderError {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match self {
-            CreateFolderError::Path(inner) => write!(f, "{}", inner),
+            CreateFolderError::Path(inner) => write!(f, "CreateFolderError: {}", inner),
         }
     }
 }
@@ -2843,8 +2843,8 @@ impl ::std::error::Error for DeleteError {
 impl ::std::fmt::Display for DeleteError {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match self {
-            DeleteError::PathLookup(inner) => write!(f, "{}", inner),
-            DeleteError::PathWrite(inner) => write!(f, "{}", inner),
+            DeleteError::PathLookup(inner) => write!(f, "DeleteError: {}", inner),
+            DeleteError::PathWrite(inner) => write!(f, "DeleteError: {}", inner),
             DeleteError::TooManyWriteOperations => f.write_str("There are too many write operations in user's Dropbox. Please retry this request."),
             DeleteError::TooManyFiles => f.write_str("There are too many files in one request. Please retry with fewer files."),
             _ => write!(f, "{:?}", *self),
@@ -3437,7 +3437,7 @@ impl ::std::error::Error for DownloadError {
 impl ::std::fmt::Display for DownloadError {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match self {
-            DownloadError::Path(inner) => write!(f, "{}", inner),
+            DownloadError::Path(inner) => write!(f, "DownloadError: {}", inner),
             _ => write!(f, "{:?}", *self),
         }
     }
@@ -3627,7 +3627,7 @@ impl ::std::error::Error for DownloadZipError {
 impl ::std::fmt::Display for DownloadZipError {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match self {
-            DownloadZipError::Path(inner) => write!(f, "{}", inner),
+            DownloadZipError::Path(inner) => write!(f, "DownloadZipError: {}", inner),
             DownloadZipError::TooLarge => f.write_str("The folder or a file is too large to download."),
             DownloadZipError::TooManyFiles => f.write_str("The folder has too many files to download."),
             _ => write!(f, "{:?}", *self),
@@ -3942,7 +3942,7 @@ impl ::std::error::Error for ExportError {
 impl ::std::fmt::Display for ExportError {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match self {
-            ExportError::Path(inner) => write!(f, "{}", inner),
+            ExportError::Path(inner) => write!(f, "ExportError: {}", inner),
             ExportError::InvalidExportFormat => f.write_str("The specified export format is not a valid option for this file type."),
             ExportError::RetryError => f.write_str("The exportable content is not yet available. Please retry later."),
             _ => write!(f, "{:?}", *self),
@@ -6063,7 +6063,7 @@ impl ::std::error::Error for GetCopyReferenceError {
 impl ::std::fmt::Display for GetCopyReferenceError {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match self {
-            GetCopyReferenceError::Path(inner) => write!(f, "{}", inner),
+            GetCopyReferenceError::Path(inner) => write!(f, "GetCopyReferenceError: {}", inner),
             _ => write!(f, "{:?}", *self),
         }
     }
@@ -6434,7 +6434,7 @@ impl ::std::error::Error for GetMetadataError {
 impl ::std::fmt::Display for GetMetadataError {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match self {
-            GetMetadataError::Path(inner) => write!(f, "{}", inner),
+            GetMetadataError::Path(inner) => write!(f, "GetMetadataError: {}", inner),
         }
     }
 }
@@ -6819,7 +6819,7 @@ impl ::std::error::Error for GetTemporaryLinkError {
 impl ::std::fmt::Display for GetTemporaryLinkError {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match self {
-            GetTemporaryLinkError::Path(inner) => write!(f, "{}", inner),
+            GetTemporaryLinkError::Path(inner) => write!(f, "GetTemporaryLinkError: {}", inner),
             _ => write!(f, "{:?}", *self),
         }
     }
@@ -8302,7 +8302,7 @@ impl ::std::error::Error for ListFolderContinueError {
 impl ::std::fmt::Display for ListFolderContinueError {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match self {
-            ListFolderContinueError::Path(inner) => write!(f, "{}", inner),
+            ListFolderContinueError::Path(inner) => write!(f, "ListFolderContinueError: {}", inner),
             _ => write!(f, "{:?}", *self),
         }
     }
@@ -8398,8 +8398,8 @@ impl ::std::error::Error for ListFolderError {
 impl ::std::fmt::Display for ListFolderError {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match self {
-            ListFolderError::Path(inner) => write!(f, "{}", inner),
-            ListFolderError::TemplateError(inner) => write!(f, "{}", inner),
+            ListFolderError::Path(inner) => write!(f, "ListFolderError: {}", inner),
+            ListFolderError::TemplateError(inner) => write!(f, "ListFolderError: {}", inner),
             _ => write!(f, "{:?}", *self),
         }
     }
@@ -9113,7 +9113,7 @@ impl ::std::error::Error for ListRevisionsError {
 impl ::std::fmt::Display for ListRevisionsError {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match self {
-            ListRevisionsError::Path(inner) => write!(f, "{}", inner),
+            ListRevisionsError::Path(inner) => write!(f, "ListRevisionsError: {}", inner),
             _ => write!(f, "{:?}", *self),
         }
     }
@@ -11697,7 +11697,7 @@ impl ::std::fmt::Display for PaperUpdateError {
             PaperUpdateError::ContentMalformed => f.write_str("The provided content was malformed and cannot be imported to Paper."),
             PaperUpdateError::DocLengthExceeded => f.write_str("The Paper doc would be too large, split the content into multiple docs."),
             PaperUpdateError::ImageSizeExceeded => f.write_str("The imported document contains an image that is too large. The current limit is 1MB. This only applies to HTML with data URI."),
-            PaperUpdateError::Path(inner) => write!(f, "{}", inner),
+            PaperUpdateError::Path(inner) => write!(f, "PaperUpdateError: {}", inner),
             PaperUpdateError::RevisionMismatch => f.write_str("The provided revision does not match the document head."),
             PaperUpdateError::DocArchived => f.write_str("This operation is not allowed on archived Paper docs."),
             PaperUpdateError::DocDeleted => f.write_str("This operation is not allowed on deleted Paper docs."),
@@ -13125,9 +13125,9 @@ impl ::std::error::Error for RelocationBatchError {
 impl ::std::fmt::Display for RelocationBatchError {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match self {
-            RelocationBatchError::FromLookup(inner) => write!(f, "{}", inner),
-            RelocationBatchError::FromWrite(inner) => write!(f, "{}", inner),
-            RelocationBatchError::To(inner) => write!(f, "{}", inner),
+            RelocationBatchError::FromLookup(inner) => write!(f, "RelocationBatchError: {}", inner),
+            RelocationBatchError::FromWrite(inner) => write!(f, "RelocationBatchError: {}", inner),
+            RelocationBatchError::To(inner) => write!(f, "RelocationBatchError: {}", inner),
             RelocationBatchError::CantCopySharedFolder => f.write_str("Shared folders can't be copied."),
             RelocationBatchError::CantNestSharedFolder => f.write_str("Your move operation would result in nested shared folders.  This is not allowed."),
             RelocationBatchError::CantMoveFolderIntoItself => f.write_str("You cannot move a folder into itself."),
@@ -14165,9 +14165,9 @@ impl ::std::error::Error for RelocationError {
 impl ::std::fmt::Display for RelocationError {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match self {
-            RelocationError::FromLookup(inner) => write!(f, "{}", inner),
-            RelocationError::FromWrite(inner) => write!(f, "{}", inner),
-            RelocationError::To(inner) => write!(f, "{}", inner),
+            RelocationError::FromLookup(inner) => write!(f, "RelocationError: {}", inner),
+            RelocationError::FromWrite(inner) => write!(f, "RelocationError: {}", inner),
+            RelocationError::To(inner) => write!(f, "RelocationError: {}", inner),
             RelocationError::CantCopySharedFolder => f.write_str("Shared folders can't be copied."),
             RelocationError::CantNestSharedFolder => f.write_str("Your move operation would result in nested shared folders.  This is not allowed."),
             RelocationError::CantMoveFolderIntoItself => f.write_str("You cannot move a folder into itself."),
@@ -14570,7 +14570,7 @@ impl ::std::error::Error for RemoveTagError {
 impl ::std::fmt::Display for RemoveTagError {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match self {
-            RemoveTagError::Path(inner) => write!(f, "{}", inner),
+            RemoveTagError::Path(inner) => write!(f, "RemoveTagError: {}", inner),
             RemoveTagError::TagNotPresent => f.write_str("That tag doesn't exist at this path."),
             _ => write!(f, "{:?}", *self),
         }
@@ -15029,7 +15029,7 @@ impl ::std::error::Error for SaveCopyReferenceError {
 impl ::std::fmt::Display for SaveCopyReferenceError {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match self {
-            SaveCopyReferenceError::Path(inner) => write!(f, "{}", inner),
+            SaveCopyReferenceError::Path(inner) => write!(f, "SaveCopyReferenceError: {}", inner),
             SaveCopyReferenceError::InvalidCopyReference => f.write_str("The copy reference is invalid."),
             SaveCopyReferenceError::NoPermission => f.write_str("You don't have permission to save the given copy reference. Please make sure this app is same app which created the copy reference and the source user is still linked to the app."),
             SaveCopyReferenceError::NotFound => f.write_str("The file referenced by the copy reference cannot be found."),
@@ -15338,7 +15338,7 @@ impl ::std::error::Error for SaveUrlError {
 impl ::std::fmt::Display for SaveUrlError {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match self {
-            SaveUrlError::Path(inner) => write!(f, "{}", inner),
+            SaveUrlError::Path(inner) => write!(f, "SaveUrlError: {}", inner),
             SaveUrlError::DownloadFailed => f.write_str("Failed downloading the given URL. The URL may be  password-protected and the password provided was incorrect,  or the link may be disabled."),
             SaveUrlError::InvalidUrl => f.write_str("The given URL is invalid."),
             SaveUrlError::NotFound => f.write_str("The file where the URL is saved to no longer exists."),
@@ -15776,7 +15776,7 @@ impl ::std::error::Error for SearchError {
 impl ::std::fmt::Display for SearchError {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match self {
-            SearchError::Path(inner) => write!(f, "{}", inner),
+            SearchError::Path(inner) => write!(f, "SearchError: {}", inner),
             SearchError::InvalidArgument(None) => f.write_str("invalid_argument"),
             SearchError::InvalidArgument(Some(inner)) => write!(f, "invalid_argument: {:?}", inner),
             SearchError::InternalError => f.write_str("Something went wrong, please try again."),
@@ -17904,7 +17904,7 @@ impl ::std::error::Error for SyncSettingsError {
 impl ::std::fmt::Display for SyncSettingsError {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match self {
-            SyncSettingsError::Path(inner) => write!(f, "{}", inner),
+            SyncSettingsError::Path(inner) => write!(f, "SyncSettingsError: {}", inner),
             SyncSettingsError::UnsupportedCombination => f.write_str("Setting this combination of sync settings simultaneously is not supported."),
             SyncSettingsError::UnsupportedConfiguration => f.write_str("The specified configuration is not supported."),
             _ => write!(f, "{:?}", *self),

--- a/src/generated/types/openid.rs
+++ b/src/generated/types/openid.rs
@@ -192,7 +192,7 @@ impl ::std::error::Error for UserInfoError {
 impl ::std::fmt::Display for UserInfoError {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match self {
-            UserInfoError::OpenidError(inner) => write!(f, "{}", inner),
+            UserInfoError::OpenidError(inner) => write!(f, "UserInfoError: {}", inner),
             _ => write!(f, "{:?}", *self),
         }
     }

--- a/src/generated/types/paper.rs
+++ b/src/generated/types/paper.rs
@@ -1464,7 +1464,7 @@ impl ::std::error::Error for ListDocsCursorError {
 impl ::std::fmt::Display for ListDocsCursorError {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match self {
-            ListDocsCursorError::CursorError(inner) => write!(f, "{}", inner),
+            ListDocsCursorError::CursorError(inner) => write!(f, "ListDocsCursorError: {}", inner),
             _ => write!(f, "{:?}", *self),
         }
     }
@@ -2138,7 +2138,7 @@ impl ::std::fmt::Display for ListUsersCursorError {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match self {
             ListUsersCursorError::DocNotFound => f.write_str("The required doc was not found."),
-            ListUsersCursorError::CursorError(inner) => write!(f, "{}", inner),
+            ListUsersCursorError::CursorError(inner) => write!(f, "ListUsersCursorError: {}", inner),
             _ => write!(f, "{:?}", *self),
         }
     }

--- a/src/generated/types/sharing.rs
+++ b/src/generated/types/sharing.rs
@@ -561,8 +561,8 @@ impl ::std::error::Error for AddFileMemberError {
 impl ::std::fmt::Display for AddFileMemberError {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match self {
-            AddFileMemberError::UserError(inner) => write!(f, "{}", inner),
-            AddFileMemberError::AccessError(inner) => write!(f, "{}", inner),
+            AddFileMemberError::UserError(inner) => write!(f, "AddFileMemberError: {}", inner),
+            AddFileMemberError::AccessError(inner) => write!(f, "AddFileMemberError: {}", inner),
             AddFileMemberError::RateLimit => f.write_str("The user has reached the rate limit for invitations."),
             AddFileMemberError::InvalidComment => f.write_str("The custom message did not pass comment permissions checks."),
             _ => write!(f, "{:?}", *self),
@@ -940,7 +940,7 @@ impl ::std::fmt::Display for AddFolderMemberError {
         match self {
             AddFolderMemberError::AccessError(inner) => write!(f, "Unable to access shared folder: {}", inner),
             AddFolderMemberError::BannedMember => f.write_str("The current user has been banned."),
-            AddFolderMemberError::BadMember(inner) => write!(f, "{}", inner),
+            AddFolderMemberError::BadMember(inner) => write!(f, "AddFolderMemberError: {}", inner),
             AddFolderMemberError::CantShareOutsideTeam => f.write_str("Your team policy does not allow sharing outside of the team."),
             AddFolderMemberError::TooManyMembers(inner) => write!(f, "The value is the member limit that was reached: {:?}", inner),
             AddFolderMemberError::TooManyPendingInvites(inner) => write!(f, "The value is the pending invite limit that was reached: {:?}", inner),
@@ -2005,7 +2005,7 @@ impl ::std::error::Error for CreateSharedLinkError {
 impl ::std::fmt::Display for CreateSharedLinkError {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match self {
-            CreateSharedLinkError::Path(inner) => write!(f, "{}", inner),
+            CreateSharedLinkError::Path(inner) => write!(f, "CreateSharedLinkError: {}", inner),
             _ => write!(f, "{:?}", *self),
         }
     }
@@ -2250,7 +2250,7 @@ impl ::std::error::Error for CreateSharedLinkWithSettingsError {
 impl ::std::fmt::Display for CreateSharedLinkWithSettingsError {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match self {
-            CreateSharedLinkWithSettingsError::Path(inner) => write!(f, "{}", inner),
+            CreateSharedLinkWithSettingsError::Path(inner) => write!(f, "CreateSharedLinkWithSettingsError: {}", inner),
             CreateSharedLinkWithSettingsError::SharedLinkAlreadyExists(None) => f.write_str("shared_link_already_exists"),
             CreateSharedLinkWithSettingsError::SharedLinkAlreadyExists(Some(inner)) => write!(f, "shared_link_already_exists: {:?}", inner),
             CreateSharedLinkWithSettingsError::SettingsError(inner) => write!(f, "There is an error with the given settings: {}", inner),
@@ -4701,8 +4701,8 @@ impl ::std::error::Error for GetFileMetadataError {
 impl ::std::fmt::Display for GetFileMetadataError {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match self {
-            GetFileMetadataError::UserError(inner) => write!(f, "{}", inner),
-            GetFileMetadataError::AccessError(inner) => write!(f, "{}", inner),
+            GetFileMetadataError::UserError(inner) => write!(f, "GetFileMetadataError: {}", inner),
+            GetFileMetadataError::AccessError(inner) => write!(f, "GetFileMetadataError: {}", inner),
             _ => write!(f, "{:?}", *self),
         }
     }
@@ -6399,9 +6399,9 @@ impl ::std::error::Error for JobError {
 impl ::std::fmt::Display for JobError {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match self {
-            JobError::UnshareFolderError(inner) => write!(f, "{}", inner),
-            JobError::RemoveFolderMemberError(inner) => write!(f, "{}", inner),
-            JobError::RelinquishFolderMembershipError(inner) => write!(f, "{}", inner),
+            JobError::UnshareFolderError(inner) => write!(f, "JobError: {}", inner),
+            JobError::RemoveFolderMemberError(inner) => write!(f, "JobError: {}", inner),
+            JobError::RelinquishFolderMembershipError(inner) => write!(f, "JobError: {}", inner),
             _ => write!(f, "{:?}", *self),
         }
     }
@@ -8465,8 +8465,8 @@ impl ::std::error::Error for ListFileMembersContinueError {
 impl ::std::fmt::Display for ListFileMembersContinueError {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match self {
-            ListFileMembersContinueError::UserError(inner) => write!(f, "{}", inner),
-            ListFileMembersContinueError::AccessError(inner) => write!(f, "{}", inner),
+            ListFileMembersContinueError::UserError(inner) => write!(f, "ListFileMembersContinueError: {}", inner),
+            ListFileMembersContinueError::AccessError(inner) => write!(f, "ListFileMembersContinueError: {}", inner),
             _ => write!(f, "{:?}", *self),
         }
     }
@@ -8667,8 +8667,8 @@ impl ::std::error::Error for ListFileMembersError {
 impl ::std::fmt::Display for ListFileMembersError {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match self {
-            ListFileMembersError::UserError(inner) => write!(f, "{}", inner),
-            ListFileMembersError::AccessError(inner) => write!(f, "{}", inner),
+            ListFileMembersError::UserError(inner) => write!(f, "ListFileMembersError: {}", inner),
+            ListFileMembersError::AccessError(inner) => write!(f, "ListFileMembersError: {}", inner),
             _ => write!(f, "{:?}", *self),
         }
     }
@@ -9474,7 +9474,7 @@ impl ::std::error::Error for ListFolderMembersContinueError {
 impl ::std::fmt::Display for ListFolderMembersContinueError {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match self {
-            ListFolderMembersContinueError::AccessError(inner) => write!(f, "{}", inner),
+            ListFolderMembersContinueError::AccessError(inner) => write!(f, "ListFolderMembersContinueError: {}", inner),
             _ => write!(f, "{:?}", *self),
         }
     }
@@ -10181,7 +10181,7 @@ impl ::std::error::Error for ListSharedLinksError {
 impl ::std::fmt::Display for ListSharedLinksError {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match self {
-            ListSharedLinksError::Path(inner) => write!(f, "{}", inner),
+            ListSharedLinksError::Path(inner) => write!(f, "ListSharedLinksError: {}", inner),
             _ => write!(f, "{:?}", *self),
         }
     }
@@ -11442,7 +11442,7 @@ impl ::std::error::Error for MountFolderError {
 impl ::std::fmt::Display for MountFolderError {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match self {
-            MountFolderError::AccessError(inner) => write!(f, "{}", inner),
+            MountFolderError::AccessError(inner) => write!(f, "MountFolderError: {}", inner),
             MountFolderError::InsideSharedFolder => f.write_str("Mounting would cause a shared folder to be inside another, which is disallowed."),
             MountFolderError::InsufficientQuota(inner) => write!(f, "The current user does not have enough space to mount the shared folder: {:?}", inner),
             MountFolderError::AlreadyMounted => f.write_str("The shared folder is already mounted."),
@@ -12174,7 +12174,7 @@ impl ::std::error::Error for RelinquishFileMembershipError {
 impl ::std::fmt::Display for RelinquishFileMembershipError {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match self {
-            RelinquishFileMembershipError::AccessError(inner) => write!(f, "{}", inner),
+            RelinquishFileMembershipError::AccessError(inner) => write!(f, "RelinquishFileMembershipError: {}", inner),
             RelinquishFileMembershipError::GroupAccess => f.write_str("The current user has access to the shared file via a group.  You can't relinquish membership to a file shared via groups."),
             RelinquishFileMembershipError::NoPermission => f.write_str("The current user does not have permission to perform this action."),
             _ => write!(f, "{:?}", *self),
@@ -12431,7 +12431,7 @@ impl ::std::error::Error for RelinquishFolderMembershipError {
 impl ::std::fmt::Display for RelinquishFolderMembershipError {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match self {
-            RelinquishFolderMembershipError::AccessError(inner) => write!(f, "{}", inner),
+            RelinquishFolderMembershipError::AccessError(inner) => write!(f, "RelinquishFolderMembershipError: {}", inner),
             RelinquishFolderMembershipError::FolderOwner => f.write_str("The current user is the owner of the shared folder. Owners cannot relinquish membership to their own folders. Try unsharing or transferring ownership first."),
             RelinquishFolderMembershipError::Mounted => f.write_str("The shared folder is currently mounted.  Unmount the shared folder before relinquishing membership."),
             RelinquishFolderMembershipError::GroupAccess => f.write_str("The current user has access to the shared folder via a group.  You can't relinquish membership to folders shared via groups."),
@@ -12653,8 +12653,8 @@ impl ::std::error::Error for RemoveFileMemberError {
 impl ::std::fmt::Display for RemoveFileMemberError {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match self {
-            RemoveFileMemberError::UserError(inner) => write!(f, "{}", inner),
-            RemoveFileMemberError::AccessError(inner) => write!(f, "{}", inner),
+            RemoveFileMemberError::UserError(inner) => write!(f, "RemoveFileMemberError: {}", inner),
+            RemoveFileMemberError::AccessError(inner) => write!(f, "RemoveFileMemberError: {}", inner),
             RemoveFileMemberError::NoExplicitAccess(inner) => write!(f, "This member does not have explicit access to the file and therefore cannot be removed. The return value is the access that a user might have to the file from a parent folder: {:?}", inner),
             _ => write!(f, "{:?}", *self),
         }
@@ -12926,8 +12926,8 @@ impl ::std::error::Error for RemoveFolderMemberError {
 impl ::std::fmt::Display for RemoveFolderMemberError {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match self {
-            RemoveFolderMemberError::AccessError(inner) => write!(f, "{}", inner),
-            RemoveFolderMemberError::MemberError(inner) => write!(f, "{}", inner),
+            RemoveFolderMemberError::AccessError(inner) => write!(f, "RemoveFolderMemberError: {}", inner),
+            RemoveFolderMemberError::MemberError(inner) => write!(f, "RemoveFolderMemberError: {}", inner),
             RemoveFolderMemberError::FolderOwner => f.write_str("The target user is the owner of the shared folder. You can't remove this user until ownership has been transferred to another member."),
             RemoveFolderMemberError::GroupAccess => f.write_str("The target user has access to the shared folder via a group."),
             RemoveFolderMemberError::TeamFolder => f.write_str("This action cannot be performed on a team shared folder."),
@@ -14316,7 +14316,7 @@ impl ::std::error::Error for ShareFolderError {
 impl ::std::fmt::Display for ShareFolderError {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match self {
-            ShareFolderError::BadPath(inner) => write!(f, "{}", inner),
+            ShareFolderError::BadPath(inner) => write!(f, "ShareFolderError: {}", inner),
             ShareFolderError::NoPermission => f.write_str("The current user does not have permission to perform this action."),
             _ => write!(f, "{:?}", *self),
         }
@@ -17977,7 +17977,7 @@ impl ::std::error::Error for TransferFolderError {
 impl ::std::fmt::Display for TransferFolderError {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match self {
-            TransferFolderError::AccessError(inner) => write!(f, "{}", inner),
+            TransferFolderError::AccessError(inner) => write!(f, "TransferFolderError: {}", inner),
             TransferFolderError::NewOwnerNotAMember => f.write_str("The new designated owner is not currently a member of the shared folder."),
             TransferFolderError::NewOwnerUnmounted => f.write_str("The new designated owner has not added the folder to their Dropbox."),
             TransferFolderError::TeamFolder => f.write_str("This action cannot be performed on a team shared folder."),
@@ -18172,7 +18172,7 @@ impl ::std::error::Error for UnmountFolderError {
 impl ::std::fmt::Display for UnmountFolderError {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match self {
-            UnmountFolderError::AccessError(inner) => write!(f, "{}", inner),
+            UnmountFolderError::AccessError(inner) => write!(f, "UnmountFolderError: {}", inner),
             UnmountFolderError::NoPermission => f.write_str("The current user does not have permission to perform this action."),
             UnmountFolderError::NotUnmountable => f.write_str("The shared folder can't be unmounted. One example where this can occur is when the shared folder's parent folder is also a shared folder that resides in the current user's Dropbox."),
             _ => write!(f, "{:?}", *self),
@@ -18363,8 +18363,8 @@ impl ::std::error::Error for UnshareFileError {
 impl ::std::fmt::Display for UnshareFileError {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match self {
-            UnshareFileError::UserError(inner) => write!(f, "{}", inner),
-            UnshareFileError::AccessError(inner) => write!(f, "{}", inner),
+            UnshareFileError::UserError(inner) => write!(f, "UnshareFileError: {}", inner),
+            UnshareFileError::AccessError(inner) => write!(f, "UnshareFileError: {}", inner),
             _ => write!(f, "{:?}", *self),
         }
     }
@@ -18586,7 +18586,7 @@ impl ::std::error::Error for UnshareFolderError {
 impl ::std::fmt::Display for UnshareFolderError {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match self {
-            UnshareFolderError::AccessError(inner) => write!(f, "{}", inner),
+            UnshareFolderError::AccessError(inner) => write!(f, "UnshareFolderError: {}", inner),
             UnshareFolderError::TeamFolder => f.write_str("This action cannot be performed on a team shared folder."),
             UnshareFolderError::NoPermission => f.write_str("The current user does not have permission to perform this action."),
             UnshareFolderError::TooManyFiles => f.write_str("This shared folder has too many files to be unshared."),
@@ -18966,8 +18966,8 @@ impl ::std::error::Error for UpdateFolderMemberError {
 impl ::std::fmt::Display for UpdateFolderMemberError {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match self {
-            UpdateFolderMemberError::AccessError(inner) => write!(f, "{}", inner),
-            UpdateFolderMemberError::MemberError(inner) => write!(f, "{}", inner),
+            UpdateFolderMemberError::AccessError(inner) => write!(f, "UpdateFolderMemberError: {}", inner),
+            UpdateFolderMemberError::MemberError(inner) => write!(f, "UpdateFolderMemberError: {}", inner),
             UpdateFolderMemberError::NoExplicitAccess(inner) => write!(f, "If updating the access type required the member to be added to the shared folder and there was an error when adding the member: {}", inner),
             UpdateFolderMemberError::InsufficientPlan => f.write_str("The current user's account doesn't support this action. An example of this is when downgrading a member from editor to viewer. This action can only be performed by users that have upgraded to a Pro or Business plan."),
             UpdateFolderMemberError::NoPermission => f.write_str("The current user does not have permission to perform this action."),
@@ -19316,7 +19316,7 @@ impl ::std::error::Error for UpdateFolderPolicyError {
 impl ::std::fmt::Display for UpdateFolderPolicyError {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match self {
-            UpdateFolderPolicyError::AccessError(inner) => write!(f, "{}", inner),
+            UpdateFolderPolicyError::AccessError(inner) => write!(f, "UpdateFolderPolicyError: {}", inner),
             UpdateFolderPolicyError::NoPermission => f.write_str("The current user does not have permission to perform this action."),
             UpdateFolderPolicyError::TeamFolder => f.write_str("This action cannot be performed on a team shared folder."),
             _ => write!(f, "{:?}", *self),

--- a/src/generated/types/team.rs
+++ b/src/generated/types/team.rs
@@ -1181,9 +1181,9 @@ impl ::std::error::Error for BaseTeamFolderError {
 impl ::std::fmt::Display for BaseTeamFolderError {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match self {
-            BaseTeamFolderError::AccessError(inner) => write!(f, "{}", inner),
-            BaseTeamFolderError::StatusError(inner) => write!(f, "{}", inner),
-            BaseTeamFolderError::TeamSharedDropboxError(inner) => write!(f, "{}", inner),
+            BaseTeamFolderError::AccessError(inner) => write!(f, "BaseTeamFolderError: {}", inner),
+            BaseTeamFolderError::StatusError(inner) => write!(f, "BaseTeamFolderError: {}", inner),
+            BaseTeamFolderError::TeamSharedDropboxError(inner) => write!(f, "BaseTeamFolderError: {}", inner),
             _ => write!(f, "{:?}", *self),
         }
     }
@@ -19924,7 +19924,7 @@ impl ::std::fmt::Display for MembersSetProfilePhotoError {
             MembersSetProfilePhotoError::UserNotFound => f.write_str("No matching user found. The provided team_member_id, email, or external_id does not exist on this team."),
             MembersSetProfilePhotoError::UserNotInTeam => f.write_str("The user is not a member of the team."),
             MembersSetProfilePhotoError::SetProfileDisallowed => f.write_str("Modifying deleted users is not allowed."),
-            MembersSetProfilePhotoError::PhotoError(inner) => write!(f, "{}", inner),
+            MembersSetProfilePhotoError::PhotoError(inner) => write!(f, "MembersSetProfilePhotoError: {}", inner),
             _ => write!(f, "{:?}", *self),
         }
     }
@@ -24416,9 +24416,9 @@ impl ::std::error::Error for TeamFolderActivateError {
 impl ::std::fmt::Display for TeamFolderActivateError {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match self {
-            TeamFolderActivateError::AccessError(inner) => write!(f, "{}", inner),
-            TeamFolderActivateError::StatusError(inner) => write!(f, "{}", inner),
-            TeamFolderActivateError::TeamSharedDropboxError(inner) => write!(f, "{}", inner),
+            TeamFolderActivateError::AccessError(inner) => write!(f, "TeamFolderActivateError: {}", inner),
+            TeamFolderActivateError::StatusError(inner) => write!(f, "TeamFolderActivateError: {}", inner),
+            TeamFolderActivateError::TeamSharedDropboxError(inner) => write!(f, "TeamFolderActivateError: {}", inner),
             _ => write!(f, "{:?}", *self),
         }
     }
@@ -24662,9 +24662,9 @@ impl ::std::error::Error for TeamFolderArchiveError {
 impl ::std::fmt::Display for TeamFolderArchiveError {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match self {
-            TeamFolderArchiveError::AccessError(inner) => write!(f, "{}", inner),
-            TeamFolderArchiveError::StatusError(inner) => write!(f, "{}", inner),
-            TeamFolderArchiveError::TeamSharedDropboxError(inner) => write!(f, "{}", inner),
+            TeamFolderArchiveError::AccessError(inner) => write!(f, "TeamFolderArchiveError: {}", inner),
+            TeamFolderArchiveError::StatusError(inner) => write!(f, "TeamFolderArchiveError: {}", inner),
+            TeamFolderArchiveError::TeamSharedDropboxError(inner) => write!(f, "TeamFolderArchiveError: {}", inner),
             _ => write!(f, "{:?}", *self),
         }
     }
@@ -26147,9 +26147,9 @@ impl ::std::error::Error for TeamFolderPermanentlyDeleteError {
 impl ::std::fmt::Display for TeamFolderPermanentlyDeleteError {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match self {
-            TeamFolderPermanentlyDeleteError::AccessError(inner) => write!(f, "{}", inner),
-            TeamFolderPermanentlyDeleteError::StatusError(inner) => write!(f, "{}", inner),
-            TeamFolderPermanentlyDeleteError::TeamSharedDropboxError(inner) => write!(f, "{}", inner),
+            TeamFolderPermanentlyDeleteError::AccessError(inner) => write!(f, "TeamFolderPermanentlyDeleteError: {}", inner),
+            TeamFolderPermanentlyDeleteError::StatusError(inner) => write!(f, "TeamFolderPermanentlyDeleteError: {}", inner),
+            TeamFolderPermanentlyDeleteError::TeamSharedDropboxError(inner) => write!(f, "TeamFolderPermanentlyDeleteError: {}", inner),
             _ => write!(f, "{:?}", *self),
         }
     }
@@ -26415,9 +26415,9 @@ impl ::std::error::Error for TeamFolderRenameError {
 impl ::std::fmt::Display for TeamFolderRenameError {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match self {
-            TeamFolderRenameError::AccessError(inner) => write!(f, "{}", inner),
-            TeamFolderRenameError::StatusError(inner) => write!(f, "{}", inner),
-            TeamFolderRenameError::TeamSharedDropboxError(inner) => write!(f, "{}", inner),
+            TeamFolderRenameError::AccessError(inner) => write!(f, "TeamFolderRenameError: {}", inner),
+            TeamFolderRenameError::StatusError(inner) => write!(f, "TeamFolderRenameError: {}", inner),
+            TeamFolderRenameError::TeamSharedDropboxError(inner) => write!(f, "TeamFolderRenameError: {}", inner),
             TeamFolderRenameError::InvalidFolderName => f.write_str("The provided folder name cannot be used."),
             TeamFolderRenameError::FolderNameAlreadyUsed => f.write_str("There is already a team folder with the same name."),
             TeamFolderRenameError::FolderNameReserved => f.write_str("The provided name cannot be used because it is reserved."),
@@ -26847,9 +26847,9 @@ impl ::std::error::Error for TeamFolderUpdateSyncSettingsError {
 impl ::std::fmt::Display for TeamFolderUpdateSyncSettingsError {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match self {
-            TeamFolderUpdateSyncSettingsError::AccessError(inner) => write!(f, "{}", inner),
-            TeamFolderUpdateSyncSettingsError::StatusError(inner) => write!(f, "{}", inner),
-            TeamFolderUpdateSyncSettingsError::TeamSharedDropboxError(inner) => write!(f, "{}", inner),
+            TeamFolderUpdateSyncSettingsError::AccessError(inner) => write!(f, "TeamFolderUpdateSyncSettingsError: {}", inner),
+            TeamFolderUpdateSyncSettingsError::StatusError(inner) => write!(f, "TeamFolderUpdateSyncSettingsError: {}", inner),
+            TeamFolderUpdateSyncSettingsError::TeamSharedDropboxError(inner) => write!(f, "TeamFolderUpdateSyncSettingsError: {}", inner),
             TeamFolderUpdateSyncSettingsError::SyncSettingsError(inner) => write!(f, "An error occurred setting the sync settings: {}", inner),
             _ => write!(f, "{:?}", *self),
         }


### PR DESCRIPTION
Otherwise, with nested errors, you can end up with unhelpful errors like this (example printed by `anyhow`):

```
Error: failed to get metadata for "/temp/spoopadoop"

Caused by:
    0: Dropbox API endpoint returned an error: There is nothing at the given path.
    1: There is nothing at the given path.
    2: There is nothing at the given path.
```

instead, with this change, you get:
```
Error: failed to get metadata for "/temp/spoopadoop"

Caused by:
    0: Dropbox API endpoint returned an error: GetMetadataError: There is nothing at the given path.
    1: GetMetadataError: There is nothing at the given path.
    2: There is nothing at the given path.
```
which is less repetitive and gives a better indication of what actually went wrong.

<!--
Thank you for your pull request. Please provide a description below.
-->

## **Checklist**

**General Contributing**
<!-- Change [ ] to [x] if you have: -->
- [x] I have read the Code of Conduct and signed the [CLA](https://opensource.dropbox.com/cla/).
- [x] I have added an entry to the `RELEASE_NOTES.md` file, or believe it's not necessary for this change.

**Validation**
<!-- Describe which tests cover the changes you've made, and any additional manual validation you
     did to ensure the correctness of this change. Does this change warrant addition of new tests?
     Does this change have performance implications? Etc. -->
This affects display of errors only; no other behavior change. Display impls are not a fixed format and changes to them shouldn't break things.