### PR TITLE
raise MSRV to 1.84

### DIFF
--- a/.github/workflows/cargo-test.yml
+++ b/.github/workflows/cargo-test.yml
@@ -39,16 +39,10 @@ jobs:
         run: if [[ ! -z `git status --porcelain=v1` ]]; then echo "::error::Workspace is dirty after running generator. Did you remember to check in the generated files?"; exit 1; fi
 
       - name: Install MSRV toolchain
-        run: rustup install 1.75.0 --profile minimal
-
-      # remove this once our MSRV is >= 1.84, which has the MSRV-aware resolver
-      - name: fix deps for old rustc
-        run: |
-          rustup run 1.75.0 cargo update litemap --precise 0.7.4
-          rustup run 1.75.0 cargo update zerofrom --precise 0.1.5
+        run: rustup install 1.84.0 --profile minimal
 
       - name: Run cargo test
-        run: rustup run 1.75.0 cargo test --all-features
+        run: rustup run 1.84.0 cargo test --all-features
 
       - name: Run clippy
         run: rustup run nightly cargo clippy --all-targets --all-features -- --deny warnings

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,8 +12,8 @@ readme = "README.md"
 
 [package.metadata]
 # Keep this at least 1 year old.
-# 1.75 is required for "-> impl Trait"
-msrv = "1.75.0" # Dec 28, 2023
+# 1.84 is required for the MSRV-aware dependency resolver
+msrv = "1.84.0" # Jan 9, 2025
 
 [dependencies]
 async-lock = "3.3.0"

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,3 +1,7 @@
+# unreleased (v0.19.2)
+xxxx-yy-zz
+* MSRV raised to 1.84.0
+
 # v0.19.1
 2025-03-14
 * ureq (default non-async HTTP client impl) updated from major version 2 to 3.

--- a/clippy.toml
+++ b/clippy.toml
@@ -2,4 +2,4 @@
 doc-valid-idents = ["OAuth2"]
 
 # Don't warn about things that can't be used in this version.
-msrv = "1.75.0"
+msrv = "1.84.0"


### PR DESCRIPTION
This should fix the current CI issue.

The code should still build with a rustc as far back as 1.75.0, but the lack of a MSRV-aware resolver means an increasinly large number of dependencies have to be manually pinned to old versions, and figuring it out is a huge pain.

This change should not be incorporated in a released version until at least Jan 9 2026 so as to keep the MSRV >= 1 year old.

<!--
Thank you for your pull request. Please provide a description below.
-->

## **Checklist**

**General Contributing**
<!-- Change [ ] to [x] if you have: -->
- [x] I have read the Code of Conduct and signed the [CLA](https://opensource.dropbox.com/cla/).
- [x] I have added an entry to the `RELEASE_NOTES.md` file, or believe it's not necessary for this change.

**Validation**
<!-- Describe which tests cover the changes you've made, and any additional manual validation you
     did to ensure the correctness of this change. Does this change warrant addition of new tests?
     Does this change have performance implications? Etc. -->
Ran the Github CI.