### PR TITLE
add deprecated and unstable attributes to struct fields and enum variants

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,6 +1,7 @@
 # unreleased changes
 * API spec update 2026-06-05
     * technically a breaking change, as dropbox_sdk::types::sharing::RelinquishAccessError::GroupAccess was removed, but this is very minor
+* Annotate struct fields and enum variants as deprecated or preview, where appropriate.
 
 # v0.20.0
 2026-05-12

--- a/generator/rust.stoneg.py
+++ b/generator/rust.stoneg.py
@@ -159,6 +159,10 @@ class RustBackend(RustHelperBackend):
                 name = self.field_name(field)
                 typ = self._rust_type(field.data_type)
                 self._emit_doc(field.doc)
+                if field.deprecated:
+                    self.emit(f'#[deprecated]')
+                if field.preview:
+                    self._emit_preview_attr(field)
                 self.emit(f'pub {name}: {typ},')
         self.emit()
 
@@ -197,6 +201,10 @@ class RustBackend(RustHelperBackend):
             for subtype in struct.get_enumerated_subtypes():
                 name = self.enum_variant_name(subtype)
                 typ = self._rust_type(subtype.data_type)
+                if subtype.deprecated:
+                    self.emit(f'#[deprecated]')
+                if subtype.preview:
+                    self._emit_preview_attr(subtype)
                 self.emit(f'{name}({typ}),')
             if struct.is_catch_all():
                 self._emit_other_variant()
@@ -219,6 +227,10 @@ class RustBackend(RustHelperBackend):
                     # Handle the 'Other' variant at the end.
                     continue
                 self._emit_doc(field.doc)
+                if field.deprecated:
+                    self.emit(f'#[deprecated]')
+                if field.preview:
+                    self._emit_preview_attr(field)
                 variant_name = self.enum_variant_name(field)
                 if isinstance(field.data_type, ir.Void):
                     self.emit(f'{variant_name},')
@@ -294,12 +306,7 @@ class RustBackend(RustHelperBackend):
         self._emit_doc(fn.doc)
 
         if fn.attrs.get('is_preview'):
-            if fn.doc:
-                self.emit('///')
-            self.emit('/// # Stability')
-            self.emit('/// *PREVIEW*: This function may change or disappear without notice.')
-            self.emit('#[cfg(feature = "unstable")]')
-            self.emit('#[cfg_attr(docsrs, doc(cfg(feature = "unstable")))]')
+            self._emit_preview_attr(fn)
 
         if fn.deprecated:
             if fn.deprecated.by:
@@ -388,6 +395,14 @@ class RustBackend(RustHelperBackend):
                 ' out of date.',
                 prefix='/// ', width=100)
         self.emit('Other,')
+
+    def _emit_preview_attr(self, thing: ir.Field | ir.ApiRoute) -> None:
+        if thing.doc:
+            self.emit('///')
+        self.emit('/// # Stability')
+        self.emit('/// *PREVIEW*: This function may change or disappear without notice.')
+        self.emit('#[cfg(feature = "unstable")]')
+        self.emit('#[cfg_attr(docsrs, doc(cfg(feature = "unstable")))]')
 
     # Serialization
 

--- a/generator/rust.stoneg.py
+++ b/generator/rust.stoneg.py
@@ -483,28 +483,29 @@ class RustBackend(RustHelperBackend):
                     with self.block(f'let result = {type_name}', delim=('{', '};')):
                         for field in struct.all_fields:
                             field_name = self.field_name(field)
+                            attr = '#[allow(deprecated)] ' if field.deprecated else ''
                             if isinstance(field.data_type, ir.Nullable):
                                 # None -> field is not present
                                 # Some(None) -> field is present with null value
                                 # Some(Some(x)) -> field is present and non-null
                                 # First two are equivalent here, hence Option::flatten().
-                                self.emit(f'{field_name}: field_{field_name}.and_then(Option::flatten),')
+                                self.emit(f'{attr}{field_name}: field_{field_name}.and_then(Option::flatten),')
                             elif field.has_default:
                                 default_value = self._default_value(field)
                                 if isinstance(field.data_type, ir.String) \
                                         and not field.default:
-                                    self.emit(f'{field_name}: field_{field_name}.unwrap_or_default(),')
+                                    self.emit(f'{attr}{field_name}: field_{field_name}.unwrap_or_default(),')
                                 elif (ir.is_primitive_type(ir.unwrap_aliases(field.data_type)[0])
                                         # Also, as a rough but effective heuristic, consider values
                                         # that have no parentheses in them to be "trivial", and
                                         # don't enclose them in a closure. This avoids running
                                         # afoul of the clippy::unnecessary_lazy_evaluations lint.
                                         or not "(" in default_value):
-                                    self.emit(f'{field_name}: field_{field_name}.unwrap_or({default_value}),')
+                                    self.emit(f'{attr}{field_name}: field_{field_name}.unwrap_or({default_value}),')
                                 else:
-                                    self.emit(f'{field_name}: field_{field_name}.unwrap_or_else(|| {default_value}),')
+                                    self.emit(f'{attr}{field_name}: field_{field_name}.unwrap_or_else(|| {default_value}),')
                             else:
-                                self.emit(f'{field_name}: field_{field_name}.ok_or_else(|| '
+                                self.emit(f'{attr}{field_name}: field_{field_name}.ok_or_else(|| '
                                           f'::serde::de::Error::missing_field("{field.name}"))?,')
                     if optional:
                         self.emit('Ok(Some(result))')
@@ -519,6 +520,8 @@ class RustBackend(RustHelperBackend):
                         access='pub(crate)'):
                     self.emit('use serde::ser::SerializeStruct;')
                     for field in struct.all_fields:
+                        if field.deprecated:
+                            self.emit('#[allow(deprecated)]')
                         if ir.is_nullable_type(field.data_type):
                             # note: Stone requires a field can't be nullable and also have a
                             # non-null default
@@ -673,6 +676,8 @@ class RustBackend(RustHelperBackend):
                                     continue
                                 variant_name = self.enum_variant_name(field)
                                 ultimate_type = ir.unwrap(field.data_type)[0]
+                                if field.deprecated:
+                                    self.emit('#[allow(deprecated)]')
                                 if isinstance(field.data_type, ir.Void):
                                     self.emit(f'"{field.name}" => {type_name}::{variant_name},')
                                 elif isinstance(ultimate_type, ir.Struct) \
@@ -733,6 +738,8 @@ class RustBackend(RustHelperBackend):
                         if field.catch_all:
                             # Handle the 'Other' variant at the end.
                             continue
+                        if field.deprecated:
+                            self.emit('#[allow(deprecated)]')
                         variant_name = self.enum_variant_name(field)
                         if isinstance(field.data_type, ir.Void):
                             with self.block(f'{type_name}::{variant_name} =>'):
@@ -803,7 +810,8 @@ class RustBackend(RustHelperBackend):
                 with self.block('Self'):
                     for field in parent.all_fields:
                         field_name = self.field_name(field)
-                        self.emit(f'{field_name}: subtype.{field_name},')
+                        attr = '#[allow(deprecated)] ' if field.deprecated else ''
+                        self.emit(f'{attr}{field_name}: subtype.{field_name},')
 
     # "extends" for polymorphic structs means it's one of the supertype's variants, so we can
     # convert from the subtype to the supertype.
@@ -951,7 +959,8 @@ class RustBackend(RustHelperBackend):
                     for field in struct.all_fields:
                         name = self.field_name(field)
                         value = self._default_value(field)
-                        self.emit(f'{name}: {value},')
+                        attr = '#[allow(deprecated)] ' if field.deprecated else ''
+                        self.emit(f'{attr}{name}: {value},')
 
     @contextmanager
     def _impl_struct(self, struct: ir.Struct) -> Iterator[None]:
@@ -970,13 +979,15 @@ class RustBackend(RustHelperBackend):
                     'Self',
                     access='pub'):
                 with self.block(struct_name):
-                    for field in struct.all_required_fields:
-                        # shorthand assignment
-                        self.emit(f'{self.field_name(field)},')
-                    for field in struct.all_optional_fields:
+                    for field in struct.all_fields:
                         name = self.field_name(field)
-                        value = self._default_value(field)
-                        self.emit(f'{name}: {value},')
+                        attr = '#[allow(deprecated)] ' if field.deprecated else ''
+                        if field in struct.all_required_fields:
+                            # shorthand assignment
+                            self.emit(f'{attr}{name},')
+                        if field in struct.all_optional_fields:
+                            value = self._default_value(field)
+                            self.emit(f'{attr}{name}: {value},')
             first = False
 
         for field in struct.all_optional_fields:
@@ -996,6 +1007,9 @@ class RustBackend(RustHelperBackend):
                 field_type = field.data_type
                 value = 'value'
 
+            if field.deprecated:
+                self.emit('#[deprecated]')
+                self.emit('#[allow(deprecated)]')
             with self.emit_rust_function_def(
                     f'with_{field_name}',
                     ['mut self', f'value: {self._rust_type(field_type)}'],
@@ -1121,7 +1135,8 @@ class RustBackend(RustHelperBackend):
                 any_skipped = False
                 for variant in variants:
                     variant_name = self.enum_variant_name(variant)
-                    var_exp = f'{type_name}::{variant_name}'
+                    attr = '#[allow(deprecated)] ' if variant.deprecated else ''
+                    var_exp = f'{attr}{type_name}::{variant_name}'
                     msg = ''
                     args = ''
                     if variant.doc:

--- a/generator/test.stoneg.py
+++ b/generator/test.stoneg.py
@@ -6,7 +6,7 @@ import re
 import string
 import sys
 from _ast import Module
-from contextlib import contextmanager
+from contextlib import contextmanager, nullcontext
 from typing import Any, Dict, Iterator, Optional, Protocol
 
 try:
@@ -180,6 +180,8 @@ class TestBackend(RustHelperBackend):
                     '{".tag": "other"',
                     '{".tag": "dropbox-sdk-rust-bogus-test-variant"')
 
+            if test_value.is_deprecated():
+                self.emit('#[allow(deprecated)] // deprecated variant')
             with self._test_fn(type_name + test_value.test_suffix()):
                 self.emit(f'let json = r#"{json}"#;')
                 self.emit(f'let x = ::serde_json::from_str::<::dropbox_sdk::types::{ns_name}::{rsname}>(json).unwrap();')
@@ -207,6 +209,8 @@ class TestBackend(RustHelperBackend):
     def _emit_closed_union_test(self, ns: ir.ApiNamespace, typ: ir.Struct | ir.Union) -> None:
         ns_name = self.namespace_name(ns)
         type_name = self.struct_name(typ)
+        if any(v.deprecated for v in self.get_enum_variants(typ)):
+            self.emit('#[allow(deprecated)] // some variants are deprecated')
         with self._test_fn("ClosedUnion_" + type_name):
             self.emit('// This test ensures that an exhaustive match compiles.')
             self.emit(f'let x: Option<::dropbox_sdk::types::{ns_name}::{self.enum_name(typ)}> = None;')
@@ -215,7 +219,8 @@ class TestBackend(RustHelperBackend):
                 var_exps = []
                 for variant in self.get_enum_variants(typ):
                     v_name = self.enum_variant_name(variant)
-                    var_exp = f'::dropbox_sdk::types::{ns_name}::{type_name}::{v_name}'
+                    note = '/* deprecated */ ' if variant.deprecated else ''
+                    var_exp = f'{note}::dropbox_sdk::types::{ns_name}::{type_name}::{v_name}'
                     if not ir.is_void_type(variant.data_type):
                         var_exp += '(_)'
                     var_exps += [var_exp]
@@ -327,12 +332,14 @@ class TestField(object):
             test_value: TestStruct | TestUnion | TestPolymorphicStruct,
             stone_type: ir.DataType,
             option: bool,
+            deprecated: bool,
     ) -> None:
         self.name = name
         self.value = python_value
         self.test_value = test_value
         self.typ = stone_type
         self.option = option
+        self.deprecated = deprecated
 
     def emit_assert(self, codegen: RustHelperBackend, expression_path: str) -> None:
         extra = ('.' + self.name) if self.name else ''
@@ -375,6 +382,10 @@ class TestValue(object):
         # Not all types can round-trip back from Rust to JSON.
         return True
 
+    def is_deprecated(self) -> bool:
+        # only appropriate for enum variants
+        return False
+
     def test_suffix(self) -> str:
         return ""
 
@@ -411,10 +422,12 @@ class TestStruct(TestValue):
                     field.default if field.has_default else None,
                     field.data_type,
                     rust_generator,
-                    reference_impls)
+                    reference_impls,
+                    field.deprecated)
             else:
                 field_value = make_test_field(
-                        field.name, field.data_type, rust_generator, reference_impls, no_optional_fields)
+                        field.name, field.data_type, rust_generator, reference_impls,
+                        no_optional_fields, field.deprecated)
                 if field_value is None:
                     raise RuntimeError(f'Error: incomplete type generated: {stone_type.name}')
                 try:
@@ -425,7 +438,8 @@ class TestStruct(TestValue):
 
     def emit_asserts(self, codegen: RustHelperBackend, expression_path: str) -> None:
         for field in self.fields:
-            field.emit_assert(codegen, expression_path)
+            with codegen.block('#[allow(deprecated)]') if field.deprecated else nullcontext():
+                field.emit_assert(codegen, expression_path)
 
     def test_suffix(self) -> str:
         if self._no_optional_fields:
@@ -476,6 +490,9 @@ class TestUnion(TestValue):
             or (isinstance(self._stone_type, ir.Union) and not self._stone_type.closed)
 
     def emit_asserts(self, codegen: RustHelperBackend, expression_path: str) -> None:
+        if self._variant.deprecated:
+            codegen.emit('#[allow(deprecated)]')
+
         if expression_path[0] == '(' and expression_path[-1] == ')':
             expression_path = expression_path[1:-1]  # strip off superfluous parens
 
@@ -494,6 +511,9 @@ class TestUnion(TestValue):
 
     def is_serializable(self) -> bool:
         return not self._variant.catch_all
+
+    def is_deprecated(self) -> bool:
+        return self._variant.deprecated
 
     def test_suffix(self) -> str:
         suf = "_" + self._rust_variant_name
@@ -561,6 +581,7 @@ def test_field_with_value(
         stone_type: ir.DataType,
         rust_generator: RustHelperBackend,
         reference_impls: Dict[str, Module],
+        deprecated: bool = False,
 ) -> TestField:
     typ, option = ir.unwrap_nullable(stone_type)
     inner = None
@@ -583,7 +604,8 @@ def test_field_with_value(
         value,
         inner,
         typ,
-        option)
+        option,
+        deprecated)
 
 
 # Make a TestField with an arbitrary value that satisfies constraints. If no_optional_fields is True
@@ -594,6 +616,7 @@ def make_test_field(
         rust_generator: RustHelperBackend,
         reference_impls: Dict[str, Module],
         no_optional_fields: bool = False,
+        deprecated: bool = False,
 ) -> TestField:
     rust_name = rust_generator.field_name_raw(field_name) if field_name is not None else None
     typ, option = ir.unwrap_nullable(stone_type)
@@ -611,11 +634,17 @@ def make_test_field(
         # Pick the first tag.
         # We could generate tests for them all, but it would lead to a huge explosion of tests, and
         # the types themselves are tested elsewhere.
-        if len(typ.fields) == 0:
-            # there must be a parent type; go for it
-            variant = typ.all_fields[0]
+        # Skip over deprecated variants to make the tests better for detecting compat breakage.
+        fields = list(filter(lambda f: not f.deprecated and not f.catch_all, typ.fields))
+        if len(fields) == 0:
+            if len(typ.fields) == 0:
+                # there must be a parent type; go for it
+                variant = typ.all_fields[0]
+            else:
+                # okay so all variants are deprecated; I guess just go for it
+                variant = typ.fields[0]
         else:
-            variant = typ.fields[0]
+            variant = fields[0]
         inner = TestUnion(rust_generator, typ, reference_impls, variant, no_optional_fields)
         value = inner.value
     elif ir.is_list_type(typ):
@@ -641,7 +670,7 @@ def make_test_field(
         value = bytes([0, 1, 2, 3, 4, 5])
     elif not ir.is_void_type(typ):
         raise RuntimeError(f'Error: unhandled field type of {field_name}: {typ}')
-    return TestField(rust_name, value, inner, typ, option)
+    return TestField(rust_name, value, inner, typ, option, deprecated)
 
 
 class Unregex(object):

--- a/src/generated/types/files.rs
+++ b/src/generated/types/files.rs
@@ -262,7 +262,7 @@ impl AlphaGetMetadataArg {
             include_deleted: false,
             include_has_explicit_shared_members: false,
             include_property_groups: None,
-            include_property_templates: None,
+            #[allow(deprecated)] include_property_templates: None,
         }
     }
 
@@ -289,6 +289,8 @@ impl AlphaGetMetadataArg {
         self
     }
 
+    #[deprecated]
+    #[allow(deprecated)]
     pub fn with_include_property_templates(
         mut self,
         value: Vec<crate::types::file_properties::TemplateId>,
@@ -376,7 +378,7 @@ impl AlphaGetMetadataArg {
             include_deleted: field_include_deleted.unwrap_or(false),
             include_has_explicit_shared_members: field_include_has_explicit_shared_members.unwrap_or(false),
             include_property_groups: field_include_property_groups.and_then(Option::flatten),
-            include_property_templates: field_include_property_templates.and_then(Option::flatten),
+            #[allow(deprecated)] include_property_templates: field_include_property_templates.and_then(Option::flatten),
         };
         Ok(Some(result))
     }
@@ -399,6 +401,7 @@ impl AlphaGetMetadataArg {
         if let Some(val) = &self.include_property_groups {
             s.serialize_field("include_property_groups", val)?;
         }
+        #[allow(deprecated)]
         if let Some(val) = &self.include_property_templates {
             s.serialize_field("include_property_templates", val)?;
         }
@@ -2271,6 +2274,7 @@ impl<'de> ::serde::de::Deserialize<'de> for DeleteBatchError {
                     _ => return Err(de::Error::missing_field(".tag"))
                 };
                 let value = match tag {
+                    #[allow(deprecated)]
                     "too_many_write_operations" => DeleteBatchError::TooManyWriteOperations,
                     _ => DeleteBatchError::Other,
                 };
@@ -2289,6 +2293,7 @@ impl ::serde::ser::Serialize for DeleteBatchError {
         // union serializer
         use serde::ser::SerializeStruct;
         match self {
+            #[allow(deprecated)]
             DeleteBatchError::TooManyWriteOperations => {
                 // unit
                 let mut s = serializer.serialize_struct("DeleteBatchError", 1)?;
@@ -2984,7 +2989,7 @@ impl DeletedMetadata {
             name,
             path_lower: None,
             path_display: None,
-            parent_shared_folder_id: None,
+            #[allow(deprecated)] parent_shared_folder_id: None,
             preview_url: None,
         }
     }
@@ -2999,6 +3004,8 @@ impl DeletedMetadata {
         self
     }
 
+    #[deprecated]
+    #[allow(deprecated)]
     pub fn with_parent_shared_folder_id(
         mut self,
         value: crate::types::common::SharedFolderId,
@@ -3081,7 +3088,7 @@ impl DeletedMetadata {
             name: field_name.ok_or_else(|| ::serde::de::Error::missing_field("name"))?,
             path_lower: field_path_lower.and_then(Option::flatten),
             path_display: field_path_display.and_then(Option::flatten),
-            parent_shared_folder_id: field_parent_shared_folder_id.and_then(Option::flatten),
+            #[allow(deprecated)] parent_shared_folder_id: field_parent_shared_folder_id.and_then(Option::flatten),
             preview_url: field_preview_url.and_then(Option::flatten),
         };
         Ok(Some(result))
@@ -3099,6 +3106,7 @@ impl DeletedMetadata {
         if let Some(val) = &self.path_display {
             s.serialize_field("path_display", val)?;
         }
+        #[allow(deprecated)]
         if let Some(val) = &self.parent_shared_folder_id {
             s.serialize_field("parent_shared_folder_id", val)?;
         }
@@ -3262,10 +3270,12 @@ impl DownloadArg {
     pub fn new(path: ReadPath) -> Self {
         DownloadArg {
             path,
-            rev: None,
+            #[allow(deprecated)] rev: None,
         }
     }
 
+    #[deprecated]
+    #[allow(deprecated)]
     pub fn with_rev(mut self, value: Rev) -> Self {
         self.rev = Some(value);
         self
@@ -3314,7 +3324,7 @@ impl DownloadArg {
         }
         let result = DownloadArg {
             path: field_path.ok_or_else(|| ::serde::de::Error::missing_field("path"))?,
-            rev: field_rev.and_then(Option::flatten),
+            #[allow(deprecated)] rev: field_rev.and_then(Option::flatten),
         };
         Ok(Some(result))
     }
@@ -3325,6 +3335,7 @@ impl DownloadArg {
     ) -> Result<(), S::Error> {
         use serde::ser::SerializeStruct;
         s.serialize_field("path", &self.path)?;
+        #[allow(deprecated)]
         if let Some(val) = &self.rev {
             s.serialize_field("rev", val)?;
         }
@@ -4839,7 +4850,7 @@ impl FileMetadata {
             size,
             path_lower: None,
             path_display: None,
-            parent_shared_folder_id: None,
+            #[allow(deprecated)] parent_shared_folder_id: None,
             preview_url: None,
             media_info: None,
             symlink_info: None,
@@ -4863,6 +4874,8 @@ impl FileMetadata {
         self
     }
 
+    #[deprecated]
+    #[allow(deprecated)]
     pub fn with_parent_shared_folder_id(
         mut self,
         value: crate::types::common::SharedFolderId,
@@ -5110,7 +5123,7 @@ impl FileMetadata {
             size: field_size.ok_or_else(|| ::serde::de::Error::missing_field("size"))?,
             path_lower: field_path_lower.and_then(Option::flatten),
             path_display: field_path_display.and_then(Option::flatten),
-            parent_shared_folder_id: field_parent_shared_folder_id.and_then(Option::flatten),
+            #[allow(deprecated)] parent_shared_folder_id: field_parent_shared_folder_id.and_then(Option::flatten),
             preview_url: field_preview_url.and_then(Option::flatten),
             media_info: field_media_info.and_then(Option::flatten),
             symlink_info: field_symlink_info.and_then(Option::flatten),
@@ -5142,6 +5155,7 @@ impl FileMetadata {
         if let Some(val) = &self.path_display {
             s.serialize_field("path_display", val)?;
         }
+        #[allow(deprecated)]
         if let Some(val) = &self.parent_shared_folder_id {
             s.serialize_field("parent_shared_folder_id", val)?;
         }
@@ -5499,9 +5513,9 @@ impl FolderMetadata {
             id,
             path_lower: None,
             path_display: None,
-            parent_shared_folder_id: None,
+            #[allow(deprecated)] parent_shared_folder_id: None,
             preview_url: None,
-            shared_folder_id: None,
+            #[allow(deprecated)] shared_folder_id: None,
             sharing_info: None,
             property_groups: None,
         }
@@ -5517,6 +5531,8 @@ impl FolderMetadata {
         self
     }
 
+    #[deprecated]
+    #[allow(deprecated)]
     pub fn with_parent_shared_folder_id(
         mut self,
         value: crate::types::common::SharedFolderId,
@@ -5530,6 +5546,8 @@ impl FolderMetadata {
         self
     }
 
+    #[deprecated]
+    #[allow(deprecated)]
     pub fn with_shared_folder_id(mut self, value: crate::types::common::SharedFolderId) -> Self {
         self.shared_folder_id = Some(value);
         self
@@ -5650,9 +5668,9 @@ impl FolderMetadata {
             id: field_id.ok_or_else(|| ::serde::de::Error::missing_field("id"))?,
             path_lower: field_path_lower.and_then(Option::flatten),
             path_display: field_path_display.and_then(Option::flatten),
-            parent_shared_folder_id: field_parent_shared_folder_id.and_then(Option::flatten),
+            #[allow(deprecated)] parent_shared_folder_id: field_parent_shared_folder_id.and_then(Option::flatten),
             preview_url: field_preview_url.and_then(Option::flatten),
-            shared_folder_id: field_shared_folder_id.and_then(Option::flatten),
+            #[allow(deprecated)] shared_folder_id: field_shared_folder_id.and_then(Option::flatten),
             sharing_info: field_sharing_info.and_then(Option::flatten),
             property_groups: field_property_groups.and_then(Option::flatten),
         };
@@ -5672,12 +5690,14 @@ impl FolderMetadata {
         if let Some(val) = &self.path_display {
             s.serialize_field("path_display", val)?;
         }
+        #[allow(deprecated)]
         if let Some(val) = &self.parent_shared_folder_id {
             s.serialize_field("parent_shared_folder_id", val)?;
         }
         if let Some(val) = &self.preview_url {
             s.serialize_field("preview_url", val)?;
         }
+        #[allow(deprecated)]
         if let Some(val) = &self.shared_folder_id {
             s.serialize_field("shared_folder_id", val)?;
         }
@@ -7900,7 +7920,7 @@ impl ListFolderArg {
         ListFolderArg {
             path,
             recursive: false,
-            include_media_info: false,
+            #[allow(deprecated)] include_media_info: false,
             include_deleted: false,
             include_has_explicit_shared_members: false,
             include_mounted_folders: true,
@@ -7916,6 +7936,8 @@ impl ListFolderArg {
         self
     }
 
+    #[deprecated]
+    #[allow(deprecated)]
     pub fn with_include_media_info(mut self, value: bool) -> Self {
         self.include_media_info = value;
         self
@@ -8067,7 +8089,7 @@ impl ListFolderArg {
         let result = ListFolderArg {
             path: field_path.ok_or_else(|| ::serde::de::Error::missing_field("path"))?,
             recursive: field_recursive.unwrap_or(false),
-            include_media_info: field_include_media_info.unwrap_or(false),
+            #[allow(deprecated)] include_media_info: field_include_media_info.unwrap_or(false),
             include_deleted: field_include_deleted.unwrap_or(false),
             include_has_explicit_shared_members: field_include_has_explicit_shared_members.unwrap_or(false),
             include_mounted_folders: field_include_mounted_folders.unwrap_or(true),
@@ -8088,6 +8110,7 @@ impl ListFolderArg {
         if self.recursive {
             s.serialize_field("recursive", &self.recursive)?;
         }
+        #[allow(deprecated)]
         if self.include_media_info {
             s.serialize_field("include_media_info", &self.include_media_info)?;
         }
@@ -9932,7 +9955,7 @@ impl LockFileResult {
     pub fn new(metadata: Metadata, lock: FileLock) -> Self {
         LockFileResult {
             metadata,
-            lock,
+            #[allow(deprecated)] lock,
         }
     }
 }
@@ -9979,7 +10002,7 @@ impl LockFileResult {
         }
         let result = LockFileResult {
             metadata: field_metadata.ok_or_else(|| ::serde::de::Error::missing_field("metadata"))?,
-            lock: field_lock.ok_or_else(|| ::serde::de::Error::missing_field("lock"))?,
+            #[allow(deprecated)] lock: field_lock.ok_or_else(|| ::serde::de::Error::missing_field("lock"))?,
         };
         Ok(Some(result))
     }
@@ -9990,6 +10013,7 @@ impl LockFileResult {
     ) -> Result<(), S::Error> {
         use serde::ser::SerializeStruct;
         s.serialize_field("metadata", &self.metadata)?;
+        #[allow(deprecated)]
         s.serialize_field("lock", &self.lock)?;
         Ok(())
     }
@@ -12203,10 +12227,12 @@ impl PreviewArg {
     pub fn new(path: ReadPath) -> Self {
         PreviewArg {
             path,
-            rev: None,
+            #[allow(deprecated)] rev: None,
         }
     }
 
+    #[deprecated]
+    #[allow(deprecated)]
     pub fn with_rev(mut self, value: Rev) -> Self {
         self.rev = Some(value);
         self
@@ -12255,7 +12281,7 @@ impl PreviewArg {
         }
         let result = PreviewArg {
             path: field_path.ok_or_else(|| ::serde::de::Error::missing_field("path"))?,
-            rev: field_rev.and_then(Option::flatten),
+            #[allow(deprecated)] rev: field_rev.and_then(Option::flatten),
         };
         Ok(Some(result))
     }
@@ -12266,6 +12292,7 @@ impl PreviewArg {
     ) -> Result<(), S::Error> {
         use serde::ser::SerializeStruct;
         s.serialize_field("path", &self.path)?;
+        #[allow(deprecated)]
         if let Some(val) = &self.rev {
             s.serialize_field("rev", val)?;
         }
@@ -12532,12 +12559,14 @@ impl RelocationArg {
         RelocationArg {
             from_path,
             to_path,
-            allow_shared_folder: false,
+            #[allow(deprecated)] allow_shared_folder: false,
             autorename: false,
             allow_ownership_transfer: false,
         }
     }
 
+    #[deprecated]
+    #[allow(deprecated)]
     pub fn with_allow_shared_folder(mut self, value: bool) -> Self {
         self.allow_shared_folder = value;
         self
@@ -12621,7 +12650,7 @@ impl RelocationArg {
         let result = RelocationArg {
             from_path: field_from_path.ok_or_else(|| ::serde::de::Error::missing_field("from_path"))?,
             to_path: field_to_path.ok_or_else(|| ::serde::de::Error::missing_field("to_path"))?,
-            allow_shared_folder: field_allow_shared_folder.unwrap_or(false),
+            #[allow(deprecated)] allow_shared_folder: field_allow_shared_folder.unwrap_or(false),
             autorename: field_autorename.unwrap_or(false),
             allow_ownership_transfer: field_allow_ownership_transfer.unwrap_or(false),
         };
@@ -12635,6 +12664,7 @@ impl RelocationArg {
         use serde::ser::SerializeStruct;
         s.serialize_field("from_path", &self.from_path)?;
         s.serialize_field("to_path", &self.to_path)?;
+        #[allow(deprecated)]
         if self.allow_shared_folder {
             s.serialize_field("allow_shared_folder", &self.allow_shared_folder)?;
         }
@@ -12706,7 +12736,7 @@ impl RelocationBatchArg {
         RelocationBatchArg {
             entries,
             autorename: false,
-            allow_shared_folder: false,
+            #[allow(deprecated)] allow_shared_folder: false,
             allow_ownership_transfer: false,
         }
     }
@@ -12716,6 +12746,8 @@ impl RelocationBatchArg {
         self
     }
 
+    #[deprecated]
+    #[allow(deprecated)]
     pub fn with_allow_shared_folder(mut self, value: bool) -> Self {
         self.allow_shared_folder = value;
         self
@@ -12786,7 +12818,7 @@ impl RelocationBatchArg {
         let result = RelocationBatchArg {
             entries: field_entries.ok_or_else(|| ::serde::de::Error::missing_field("entries"))?,
             autorename: field_autorename.unwrap_or(false),
-            allow_shared_folder: field_allow_shared_folder.unwrap_or(false),
+            #[allow(deprecated)] allow_shared_folder: field_allow_shared_folder.unwrap_or(false),
             allow_ownership_transfer: field_allow_ownership_transfer.unwrap_or(false),
         };
         Ok(Some(result))
@@ -12801,6 +12833,7 @@ impl RelocationBatchArg {
         if self.autorename {
             s.serialize_field("autorename", &self.autorename)?;
         }
+        #[allow(deprecated)]
         if self.allow_shared_folder {
             s.serialize_field("allow_shared_folder", &self.allow_shared_folder)?;
         }
@@ -16852,7 +16885,7 @@ impl SearchV2Arg {
             query,
             options: None,
             match_field_options: None,
-            include_highlights: None,
+            #[allow(deprecated)] include_highlights: None,
         }
     }
 
@@ -16866,6 +16899,8 @@ impl SearchV2Arg {
         self
     }
 
+    #[deprecated]
+    #[allow(deprecated)]
     pub fn with_include_highlights(mut self, value: bool) -> Self {
         self.include_highlights = Some(value);
         self
@@ -16932,7 +16967,7 @@ impl SearchV2Arg {
             query: field_query.ok_or_else(|| ::serde::de::Error::missing_field("query"))?,
             options: field_options.and_then(Option::flatten),
             match_field_options: field_match_field_options.and_then(Option::flatten),
-            include_highlights: field_include_highlights.and_then(Option::flatten),
+            #[allow(deprecated)] include_highlights: field_include_highlights.and_then(Option::flatten),
         };
         Ok(Some(result))
     }
@@ -16949,6 +16984,7 @@ impl SearchV2Arg {
         if let Some(val) = &self.match_field_options {
             s.serialize_field("match_field_options", val)?;
         }
+        #[allow(deprecated)]
         if let Some(val) = &self.include_highlights {
             s.serialize_field("include_highlights", val)?;
         }
@@ -21235,6 +21271,7 @@ impl<'de> ::serde::de::Deserialize<'de> for UploadSessionFinishError {
                             _ => return Err(de::Error::unknown_field(tag, VARIANTS))
                         }
                     }
+                    #[allow(deprecated)]
                     "too_many_shared_folder_targets" => UploadSessionFinishError::TooManySharedFolderTargets,
                     "too_many_write_operations" => UploadSessionFinishError::TooManyWriteOperations,
                     "concurrent_session_data_not_allowed" => UploadSessionFinishError::ConcurrentSessionDataNotAllowed,
@@ -21291,6 +21328,7 @@ impl ::serde::ser::Serialize for UploadSessionFinishError {
                 s.serialize_field("properties_error", x)?;
                 s.end()
             }
+            #[allow(deprecated)]
             UploadSessionFinishError::TooManySharedFolderTargets => {
                 // unit
                 let mut s = serializer.serialize_struct("UploadSessionFinishError", 1)?;
@@ -21361,7 +21399,7 @@ impl ::std::fmt::Display for UploadSessionFinishError {
             UploadSessionFinishError::LookupFailed(inner) => write!(f, "The session arguments are incorrect; the value explains the reason: {}", inner),
             UploadSessionFinishError::Path(inner) => write!(f, "Unable to save the uploaded contents to a file. Data has already been appended to the upload session. Please retry with empty data body and updated offset: {}", inner),
             UploadSessionFinishError::PropertiesError(inner) => write!(f, "The supplied property group is invalid. The file has uploaded without property groups: {}", inner),
-            UploadSessionFinishError::TooManySharedFolderTargets => f.write_str("Field is deprecated. The batch request commits files into too many different shared folders. Please limit your batch request to files contained in a single shared folder."),
+            #[allow(deprecated)] UploadSessionFinishError::TooManySharedFolderTargets => f.write_str("Field is deprecated. The batch request commits files into too many different shared folders. Please limit your batch request to files contained in a single shared folder."),
             UploadSessionFinishError::TooManyWriteOperations => f.write_str("There are too many write operations happening in the user's Dropbox. You should retry uploading this file."),
             UploadSessionFinishError::ConcurrentSessionDataNotAllowed => f.write_str("Uploading data not allowed when finishing concurrent upload session."),
             UploadSessionFinishError::ConcurrentSessionNotClosed => f.write_str("Concurrent upload sessions need to be closed before finishing."),

--- a/src/generated/types/files.rs
+++ b/src/generated/types/files.rs
@@ -250,6 +250,7 @@ pub struct AlphaGetMetadataArg {
     pub include_property_groups: Option<crate::types::file_properties::TemplateFilterBase>,
     /// Field is deprecated. If set to a valid list of template IDs,
     /// [`FileMetadata::property_groups`](FileMetadata) is set for files with custom properties.
+    #[deprecated]
     pub include_property_templates: Option<Vec<crate::types::file_properties::TemplateId>>,
 }
 
@@ -2247,6 +2248,7 @@ pub enum DeleteBatchError {
     /// Field is deprecated. Use [`DeleteError::TooManyWriteOperations`].
     /// [`delete_batch()`](crate::files::delete_batch) now provides smaller granularity about which
     /// entry has failed because of this.
+    #[deprecated]
     TooManyWriteOperations,
     /// Catch-all used for unrecognized values returned from the server. Encountering this value
     /// typically indicates that this SDK version is out of date.
@@ -2970,6 +2972,7 @@ pub struct DeletedMetadata {
     /// Field is deprecated. Please use
     /// [`FileSharingInfo::parent_shared_folder_id`](FileSharingInfo) or
     /// [`FolderSharingInfo::parent_shared_folder_id`](FolderSharingInfo) instead.
+    #[deprecated]
     pub parent_shared_folder_id: Option<crate::types::common::SharedFolderId>,
     /// The preview URL of the file.
     pub preview_url: Option<String>,
@@ -3251,6 +3254,7 @@ pub struct DownloadArg {
     /// The path of the file to download.
     pub path: ReadPath,
     /// Field is deprecated. Please specify revision in `path` instead.
+    #[deprecated]
     pub rev: Option<Rev>,
 }
 
@@ -4781,6 +4785,7 @@ pub struct FileMetadata {
     /// Field is deprecated. Please use
     /// [`FileSharingInfo::parent_shared_folder_id`](FileSharingInfo) or
     /// [`FolderSharingInfo::parent_shared_folder_id`](FolderSharingInfo) instead.
+    #[deprecated]
     pub parent_shared_folder_id: Option<crate::types::common::SharedFolderId>,
     /// The preview URL of the file.
     pub preview_url: Option<String>,
@@ -5472,10 +5477,12 @@ pub struct FolderMetadata {
     /// Field is deprecated. Please use
     /// [`FileSharingInfo::parent_shared_folder_id`](FileSharingInfo) or
     /// [`FolderSharingInfo::parent_shared_folder_id`](FolderSharingInfo) instead.
+    #[deprecated]
     pub parent_shared_folder_id: Option<crate::types::common::SharedFolderId>,
     /// The preview URL of the file.
     pub preview_url: Option<String>,
     /// Field is deprecated. Please use `sharing_info` instead.
+    #[deprecated]
     pub shared_folder_id: Option<crate::types::common::SharedFolderId>,
     /// Set if the folder is contained in a shared folder or is a shared folder mount point.
     pub sharing_info: Option<FolderSharingInfo>,
@@ -7863,6 +7870,7 @@ pub struct ListFolderArg {
     pub recursive: bool,
     /// Field is deprecated. If true, [`FileMetadata::media_info`](FileMetadata) is set for photo
     /// and video. This parameter will no longer have an effect starting December 2, 2019.
+    #[deprecated]
     pub include_media_info: bool,
     /// If true, the results will include entries for files and folders that used to exist but were
     /// deleted.
@@ -9916,6 +9924,7 @@ pub struct LockFileResult {
     /// Metadata of the file.
     pub metadata: Metadata,
     /// Field is deprecated. The file lock state after the operation.
+    #[deprecated]
     pub lock: FileLock,
 }
 
@@ -12186,6 +12195,7 @@ pub struct PreviewArg {
     /// The path of the file to preview.
     pub path: ReadPath,
     /// Field is deprecated. Please specify revision in `path` instead.
+    #[deprecated]
     pub rev: Option<Rev>,
 }
 
@@ -12507,6 +12517,7 @@ pub struct RelocationArg {
     /// Path in the user's Dropbox that is the destination.
     pub to_path: WritePathOrId,
     /// Field is deprecated. This flag has no effect.
+    #[deprecated]
     pub allow_shared_folder: bool,
     /// If there's a conflict, have the Dropbox server try to autorename the file to avoid the
     /// conflict.
@@ -12683,6 +12694,7 @@ pub struct RelocationBatchArg {
     /// avoid the conflict.
     pub autorename: bool,
     /// Field is deprecated. This flag has no effect.
+    #[deprecated]
     pub allow_shared_folder: bool,
     /// Allow moves by owner even if it would result in an ownership transfer for the content being
     /// moved. This does not apply to copies.
@@ -16830,6 +16842,7 @@ pub struct SearchV2Arg {
     /// Options for search results match fields.
     pub match_field_options: Option<SearchMatchFieldOptions>,
     /// Field is deprecated. Deprecated and moved this option to SearchMatchFieldOptions.
+    #[deprecated]
     pub include_highlights: Option<bool>,
 }
 
@@ -21162,6 +21175,7 @@ pub enum UploadSessionFinishError {
     PropertiesError(crate::types::file_properties::InvalidPropertyGroupError),
     /// Field is deprecated. The batch request commits files into too many different shared folders.
     /// Please limit your batch request to files contained in a single shared folder.
+    #[deprecated]
     TooManySharedFolderTargets,
     /// There are too many write operations happening in the user's Dropbox. You should retry
     /// uploading this file.

--- a/src/generated/types/sharing.rs
+++ b/src/generated/types/sharing.rs
@@ -802,6 +802,7 @@ pub enum AddFolderMemberError {
     /// The current user does not have permission to perform this action.
     NoPermission,
     /// Field is deprecated. Invalid shared folder error will be returned as an access_error.
+    #[deprecated]
     InvalidSharedFolder,
     /// Catch-all used for unrecognized values returned from the server. Encountering this value
     /// typically indicates that this SDK version is out of date.
@@ -1933,6 +1934,7 @@ pub struct CreateSharedLinkArg {
     /// The path to share.
     pub path: String,
     /// Field is deprecated. None
+    #[deprecated]
     pub short_url: bool,
     /// If it's okay to share a path that does not yet exist, set this to either
     /// [`PendingUploadMode::File`] or [`PendingUploadMode::Folder`] to indicate whether to assume
@@ -2651,8 +2653,10 @@ pub enum FileAction {
     /// Relinquish one's own membership to the file.
     RelinquishMembership,
     /// Field is deprecated. Use create_view_link and create_edit_link instead.
+    #[deprecated]
     ShareLink,
     /// Field is deprecated. Use create_view_link and create_edit_link instead.
+    #[deprecated]
     CreateLink,
     /// Create a shared link to a file that only allows users to view the content.
     CreateViewLink,
@@ -3748,8 +3752,10 @@ pub enum FolderAction {
     /// Keep a copy of the contents upon leaving or being kicked from the folder.
     LeaveACopy,
     /// Field is deprecated. Use create_view_link and create_edit_link instead.
+    #[deprecated]
     ShareLink,
     /// Field is deprecated. Use create_view_link and create_edit_link instead.
+    #[deprecated]
     CreateLink,
     /// Create a shared link that only allows users to view the content.
     CreateViewLink,
@@ -5581,6 +5587,7 @@ pub struct GroupInfo {
     /// Who is allowed to manage the group.
     pub group_management_type: crate::types::team_common::GroupManagementType,
     /// Field is deprecated. The type of group.
+    #[deprecated]
     pub group_type: crate::types::team_common::GroupType,
     /// If the current user is a member of the group.
     pub is_member: bool,
@@ -5816,6 +5823,7 @@ pub struct GroupMembershipInfo {
     /// to the MemberActions in the request.
     pub permissions: Option<Vec<MemberPermission>>,
     /// Field is deprecated. Never set.
+    #[deprecated]
     pub initials: Option<String>,
     /// True if the member has access on a parent folder.
     pub is_inherited: bool,
@@ -6286,6 +6294,7 @@ pub struct InviteeMembershipInfo {
     /// to the MemberActions in the request.
     pub permissions: Option<Vec<MemberPermission>>,
     /// Field is deprecated. Never set.
+    #[deprecated]
     pub initials: Option<String>,
     /// True if the member has access on a parent folder.
     pub is_inherited: bool,
@@ -6862,8 +6871,10 @@ pub enum LinkAudience {
     NoOne,
     /// Field is deprecated. Use `require_password` instead. A link-specific password is required to
     /// access the link. Login is not required.
+    #[deprecated]
     Password,
     /// Field is deprecated. Link is accessible only by members of the content.
+    #[deprecated]
     Members,
     /// Catch-all used for unrecognized values returned from the server. Encountering this value
     /// typically indicates that this SDK version is out of date.
@@ -7546,8 +7557,10 @@ pub struct LinkPermissions {
     pub can_disallow_download: bool,
     /// Field is deprecated. Whether comments are enabled for the linked file. This takes the team
     /// commenting policy into account.
+    #[deprecated]
     pub allow_comments: bool,
     /// Field is deprecated. Whether the team has disabled commenting globally.
+    #[deprecated]
     pub team_restricts_comments: bool,
     /// The current visibility of the link after considering the shared links policies of the the
     /// team (in case the link's owner is part of a team) and the shared folder (in case the linked
@@ -11159,6 +11172,7 @@ pub struct MembershipInfo {
     /// to the MemberActions in the request.
     pub permissions: Option<Vec<MemberPermission>>,
     /// Field is deprecated. Never set.
+    #[deprecated]
     pub initials: Option<String>,
     /// True if the member has access on a parent folder.
     pub is_inherited: bool,
@@ -17018,6 +17032,7 @@ pub enum SharedFolderAccessError {
     /// The user does not exist or their account is disabled.
     InvalidMember,
     /// Field is deprecated. Never set.
+    #[deprecated]
     EmailUnverified,
     /// The shared folder is unmounted.
     Unmounted,
@@ -18461,6 +18476,7 @@ pub enum SharedLinkPolicy {
     /// Links can be shared with anyone.
     Anyone,
     /// Field is deprecated. Links can be shared with anyone on the same team as the owner.
+    #[deprecated]
     Team,
     /// Links can only be shared among members of the shared folder.
     Members,
@@ -18548,6 +18564,7 @@ pub struct SharedLinkSettings {
     /// level for an existing link is not supported.
     pub access: Option<RequestedLinkAccessLevel>,
     /// Field is deprecated. Use `audience` instead.  The requested access for this shared link.
+    #[deprecated]
     pub requested_visibility: Option<RequestedVisibility>,
     /// Boolean flag to allow or not download capabilities for shared links.
     pub allow_download: Option<bool>,
@@ -20097,6 +20114,7 @@ pub struct UpdateFilePolicyArg {
     /// actions the authenticated user can perform on the file.
     pub actions: Option<Vec<FileAction>>,
     /// Field is deprecated. Settings on the link for the file.
+    #[deprecated]
     pub link_settings: Option<LinkSettings>,
     /// The presence and seen state policy on the file.
     pub viewer_info_policy: Option<ViewerInfoPolicy>,
@@ -20967,6 +20985,7 @@ pub struct UserFileMembershipInfo {
     /// to the MemberActions in the request.
     pub permissions: Option<Vec<MemberPermission>>,
     /// Field is deprecated. Never set.
+    #[deprecated]
     pub initials: Option<String>,
     /// True if the member has access on a parent folder.
     pub is_inherited: bool,
@@ -21345,6 +21364,7 @@ pub struct UserMembershipInfo {
     /// to the MemberActions in the request.
     pub permissions: Option<Vec<MemberPermission>>,
     /// Field is deprecated. Never set.
+    #[deprecated]
     pub initials: Option<String>,
     /// True if the member has access on a parent folder.
     pub is_inherited: bool,

--- a/src/generated/types/sharing.rs
+++ b/src/generated/types/sharing.rs
@@ -861,6 +861,7 @@ impl<'de> ::serde::de::Deserialize<'de> for AddFolderMemberError {
                     "insufficient_plan" => AddFolderMemberError::InsufficientPlan,
                     "team_folder" => AddFolderMemberError::TeamFolder,
                     "no_permission" => AddFolderMemberError::NoPermission,
+                    #[allow(deprecated)]
                     "invalid_shared_folder" => AddFolderMemberError::InvalidSharedFolder,
                     _ => AddFolderMemberError::Other,
                 };
@@ -967,6 +968,7 @@ impl ::serde::ser::Serialize for AddFolderMemberError {
                 s.serialize_field(".tag", "no_permission")?;
                 s.end()
             }
+            #[allow(deprecated)]
             AddFolderMemberError::InvalidSharedFolder => {
                 // unit
                 let mut s = serializer.serialize_struct("AddFolderMemberError", 1)?;
@@ -1002,7 +1004,7 @@ impl ::std::fmt::Display for AddFolderMemberError {
             AddFolderMemberError::InsufficientPlan => f.write_str("The current user's account doesn't support this action. An example of this is when adding a read-only member. This action can only be performed by users that have upgraded to a Pro or Business plan."),
             AddFolderMemberError::TeamFolder => f.write_str("This action cannot be performed on a team shared folder."),
             AddFolderMemberError::NoPermission => f.write_str("The current user does not have permission to perform this action."),
-            AddFolderMemberError::InvalidSharedFolder => f.write_str("Field is deprecated. Invalid shared folder error will be returned as an access_error."),
+            #[allow(deprecated)] AddFolderMemberError::InvalidSharedFolder => f.write_str("Field is deprecated. Invalid shared folder error will be returned as an access_error."),
             _ => write!(f, "{:?}", *self),
         }
     }
@@ -1946,11 +1948,13 @@ impl CreateSharedLinkArg {
     pub fn new(path: String) -> Self {
         CreateSharedLinkArg {
             path,
-            short_url: false,
+            #[allow(deprecated)] short_url: false,
             pending_upload: None,
         }
     }
 
+    #[deprecated]
+    #[allow(deprecated)]
     pub fn with_short_url(mut self, value: bool) -> Self {
         self.short_url = value;
         self
@@ -2012,7 +2016,7 @@ impl CreateSharedLinkArg {
         }
         let result = CreateSharedLinkArg {
             path: field_path.ok_or_else(|| ::serde::de::Error::missing_field("path"))?,
-            short_url: field_short_url.unwrap_or(false),
+            #[allow(deprecated)] short_url: field_short_url.unwrap_or(false),
             pending_upload: field_pending_upload.and_then(Option::flatten),
         };
         Ok(Some(result))
@@ -2024,6 +2028,7 @@ impl CreateSharedLinkArg {
     ) -> Result<(), S::Error> {
         use serde::ser::SerializeStruct;
         s.serialize_field("path", &self.path)?;
+        #[allow(deprecated)]
         if self.short_url {
             s.serialize_field("short_url", &self.short_url)?;
         }
@@ -2691,7 +2696,9 @@ impl<'de> ::serde::de::Deserialize<'de> for FileAction {
                     "invite_editor" => FileAction::InviteEditor,
                     "unshare" => FileAction::Unshare,
                     "relinquish_membership" => FileAction::RelinquishMembership,
+                    #[allow(deprecated)]
                     "share_link" => FileAction::ShareLink,
+                    #[allow(deprecated)]
                     "create_link" => FileAction::CreateLink,
                     "create_view_link" => FileAction::CreateViewLink,
                     "create_edit_link" => FileAction::CreateEditLink,
@@ -2771,12 +2778,14 @@ impl ::serde::ser::Serialize for FileAction {
                 s.serialize_field(".tag", "relinquish_membership")?;
                 s.end()
             }
+            #[allow(deprecated)]
             FileAction::ShareLink => {
                 // unit
                 let mut s = serializer.serialize_struct("FileAction", 1)?;
                 s.serialize_field(".tag", "share_link")?;
                 s.end()
             }
+            #[allow(deprecated)]
             FileAction::CreateLink => {
                 // unit
                 let mut s = serializer.serialize_struct("FileAction", 1)?;
@@ -3795,7 +3804,9 @@ impl<'de> ::serde::de::Deserialize<'de> for FolderAction {
                     "unmount" => FolderAction::Unmount,
                     "unshare" => FolderAction::Unshare,
                     "leave_a_copy" => FolderAction::LeaveACopy,
+                    #[allow(deprecated)]
                     "share_link" => FolderAction::ShareLink,
+                    #[allow(deprecated)]
                     "create_link" => FolderAction::CreateLink,
                     "create_view_link" => FolderAction::CreateViewLink,
                     "create_edit_link" => FolderAction::CreateEditLink,
@@ -3898,12 +3909,14 @@ impl ::serde::ser::Serialize for FolderAction {
                 s.serialize_field(".tag", "leave_a_copy")?;
                 s.end()
             }
+            #[allow(deprecated)]
             FolderAction::ShareLink => {
                 // unit
                 let mut s = serializer.serialize_struct("FolderAction", 1)?;
                 s.serialize_field(".tag", "share_link")?;
                 s.end()
             }
+            #[allow(deprecated)]
             FolderAction::CreateLink => {
                 // unit
                 let mut s = serializer.serialize_struct("FolderAction", 1)?;
@@ -5615,7 +5628,7 @@ impl GroupInfo {
             group_name,
             group_id,
             group_management_type,
-            group_type,
+            #[allow(deprecated)] group_type,
             is_member,
             is_owner,
             same_team,
@@ -5738,7 +5751,7 @@ impl GroupInfo {
             group_name: field_group_name.ok_or_else(|| ::serde::de::Error::missing_field("group_name"))?,
             group_id: field_group_id.ok_or_else(|| ::serde::de::Error::missing_field("group_id"))?,
             group_management_type: field_group_management_type.ok_or_else(|| ::serde::de::Error::missing_field("group_management_type"))?,
-            group_type: field_group_type.ok_or_else(|| ::serde::de::Error::missing_field("group_type"))?,
+            #[allow(deprecated)] group_type: field_group_type.ok_or_else(|| ::serde::de::Error::missing_field("group_type"))?,
             is_member: field_is_member.ok_or_else(|| ::serde::de::Error::missing_field("is_member"))?,
             is_owner: field_is_owner.ok_or_else(|| ::serde::de::Error::missing_field("is_owner"))?,
             same_team: field_same_team.ok_or_else(|| ::serde::de::Error::missing_field("same_team"))?,
@@ -5756,6 +5769,7 @@ impl GroupInfo {
         s.serialize_field("group_name", &self.group_name)?;
         s.serialize_field("group_id", &self.group_id)?;
         s.serialize_field("group_management_type", &self.group_management_type)?;
+        #[allow(deprecated)]
         s.serialize_field("group_type", &self.group_type)?;
         s.serialize_field("is_member", &self.is_member)?;
         s.serialize_field("is_owner", &self.is_owner)?;
@@ -5835,7 +5849,7 @@ impl GroupMembershipInfo {
             access_type,
             group,
             permissions: None,
-            initials: None,
+            #[allow(deprecated)] initials: None,
             is_inherited: false,
         }
     }
@@ -5845,6 +5859,8 @@ impl GroupMembershipInfo {
         self
     }
 
+    #[deprecated]
+    #[allow(deprecated)]
     pub fn with_initials(mut self, value: String) -> Self {
         self.initials = Some(value);
         self
@@ -5924,7 +5940,7 @@ impl GroupMembershipInfo {
             access_type: field_access_type.ok_or_else(|| ::serde::de::Error::missing_field("access_type"))?,
             group: field_group.ok_or_else(|| ::serde::de::Error::missing_field("group"))?,
             permissions: field_permissions.and_then(Option::flatten),
-            initials: field_initials.and_then(Option::flatten),
+            #[allow(deprecated)] initials: field_initials.and_then(Option::flatten),
             is_inherited: field_is_inherited.unwrap_or(false),
         };
         Ok(Some(result))
@@ -5940,6 +5956,7 @@ impl GroupMembershipInfo {
         if let Some(val) = &self.permissions {
             s.serialize_field("permissions", val)?;
         }
+        #[allow(deprecated)]
         if let Some(val) = &self.initials {
             s.serialize_field("initials", val)?;
         }
@@ -5984,7 +6001,7 @@ impl From<GroupMembershipInfo> for MembershipInfo {
         Self {
             access_type: subtype.access_type,
             permissions: subtype.permissions,
-            initials: subtype.initials,
+            #[allow(deprecated)] initials: subtype.initials,
             is_inherited: subtype.is_inherited,
         }
     }
@@ -6308,7 +6325,7 @@ impl InviteeMembershipInfo {
             access_type,
             invitee,
             permissions: None,
-            initials: None,
+            #[allow(deprecated)] initials: None,
             is_inherited: false,
             user: None,
         }
@@ -6319,6 +6336,8 @@ impl InviteeMembershipInfo {
         self
     }
 
+    #[deprecated]
+    #[allow(deprecated)]
     pub fn with_initials(mut self, value: String) -> Self {
         self.initials = Some(value);
         self
@@ -6411,7 +6430,7 @@ impl InviteeMembershipInfo {
             access_type: field_access_type.ok_or_else(|| ::serde::de::Error::missing_field("access_type"))?,
             invitee: field_invitee.ok_or_else(|| ::serde::de::Error::missing_field("invitee"))?,
             permissions: field_permissions.and_then(Option::flatten),
-            initials: field_initials.and_then(Option::flatten),
+            #[allow(deprecated)] initials: field_initials.and_then(Option::flatten),
             is_inherited: field_is_inherited.unwrap_or(false),
             user: field_user.and_then(Option::flatten),
         };
@@ -6428,6 +6447,7 @@ impl InviteeMembershipInfo {
         if let Some(val) = &self.permissions {
             s.serialize_field("permissions", val)?;
         }
+        #[allow(deprecated)]
         if let Some(val) = &self.initials {
             s.serialize_field("initials", val)?;
         }
@@ -6475,7 +6495,7 @@ impl From<InviteeMembershipInfo> for MembershipInfo {
         Self {
             access_type: subtype.access_type,
             permissions: subtype.permissions,
-            initials: subtype.initials,
+            #[allow(deprecated)] initials: subtype.initials,
             is_inherited: subtype.is_inherited,
         }
     }
@@ -6900,7 +6920,9 @@ impl<'de> ::serde::de::Deserialize<'de> for LinkAudience {
                     "public" => LinkAudience::Public,
                     "team" => LinkAudience::Team,
                     "no_one" => LinkAudience::NoOne,
+                    #[allow(deprecated)]
                     "password" => LinkAudience::Password,
+                    #[allow(deprecated)]
                     "members" => LinkAudience::Members,
                     _ => LinkAudience::Other,
                 };
@@ -6941,12 +6963,14 @@ impl ::serde::ser::Serialize for LinkAudience {
                 s.serialize_field(".tag", "no_one")?;
                 s.end()
             }
+            #[allow(deprecated)]
             LinkAudience::Password => {
                 // unit
                 let mut s = serializer.serialize_struct("LinkAudience", 1)?;
                 s.serialize_field(".tag", "password")?;
                 s.end()
             }
+            #[allow(deprecated)]
             LinkAudience::Members => {
                 // unit
                 let mut s = serializer.serialize_struct("LinkAudience", 1)?;
@@ -7634,8 +7658,8 @@ impl LinkPermissions {
             allow_download,
             can_allow_download,
             can_disallow_download,
-            allow_comments,
-            team_restricts_comments,
+            #[allow(deprecated)] allow_comments,
+            #[allow(deprecated)] team_restricts_comments,
             resolved_visibility: None,
             requested_visibility: None,
             revoke_failure_reason: None,
@@ -7963,8 +7987,8 @@ impl LinkPermissions {
             allow_download: field_allow_download.ok_or_else(|| ::serde::de::Error::missing_field("allow_download"))?,
             can_allow_download: field_can_allow_download.ok_or_else(|| ::serde::de::Error::missing_field("can_allow_download"))?,
             can_disallow_download: field_can_disallow_download.ok_or_else(|| ::serde::de::Error::missing_field("can_disallow_download"))?,
-            allow_comments: field_allow_comments.ok_or_else(|| ::serde::de::Error::missing_field("allow_comments"))?,
-            team_restricts_comments: field_team_restricts_comments.ok_or_else(|| ::serde::de::Error::missing_field("team_restricts_comments"))?,
+            #[allow(deprecated)] allow_comments: field_allow_comments.ok_or_else(|| ::serde::de::Error::missing_field("allow_comments"))?,
+            #[allow(deprecated)] team_restricts_comments: field_team_restricts_comments.ok_or_else(|| ::serde::de::Error::missing_field("team_restricts_comments"))?,
             resolved_visibility: field_resolved_visibility.and_then(Option::flatten),
             requested_visibility: field_requested_visibility.and_then(Option::flatten),
             revoke_failure_reason: field_revoke_failure_reason.and_then(Option::flatten),
@@ -7996,7 +8020,9 @@ impl LinkPermissions {
         s.serialize_field("allow_download", &self.allow_download)?;
         s.serialize_field("can_allow_download", &self.can_allow_download)?;
         s.serialize_field("can_disallow_download", &self.can_disallow_download)?;
+        #[allow(deprecated)]
         s.serialize_field("allow_comments", &self.allow_comments)?;
+        #[allow(deprecated)]
         s.serialize_field("team_restricts_comments", &self.team_restricts_comments)?;
         if let Some(val) = &self.resolved_visibility {
             s.serialize_field("resolved_visibility", val)?;
@@ -11183,7 +11209,7 @@ impl MembershipInfo {
         MembershipInfo {
             access_type,
             permissions: None,
-            initials: None,
+            #[allow(deprecated)] initials: None,
             is_inherited: false,
         }
     }
@@ -11193,6 +11219,8 @@ impl MembershipInfo {
         self
     }
 
+    #[deprecated]
+    #[allow(deprecated)]
     pub fn with_initials(mut self, value: String) -> Self {
         self.initials = Some(value);
         self
@@ -11263,7 +11291,7 @@ impl MembershipInfo {
         let result = MembershipInfo {
             access_type: field_access_type.ok_or_else(|| ::serde::de::Error::missing_field("access_type"))?,
             permissions: field_permissions.and_then(Option::flatten),
-            initials: field_initials.and_then(Option::flatten),
+            #[allow(deprecated)] initials: field_initials.and_then(Option::flatten),
             is_inherited: field_is_inherited.unwrap_or(false),
         };
         Ok(Some(result))
@@ -11278,6 +11306,7 @@ impl MembershipInfo {
         if let Some(val) = &self.permissions {
             s.serialize_field("permissions", val)?;
         }
+        #[allow(deprecated)]
         if let Some(val) = &self.initials {
             s.serialize_field("initials", val)?;
         }
@@ -17060,6 +17089,7 @@ impl<'de> ::serde::de::Deserialize<'de> for SharedFolderAccessError {
                     "invalid_id" => SharedFolderAccessError::InvalidId,
                     "not_a_member" => SharedFolderAccessError::NotAMember,
                     "invalid_member" => SharedFolderAccessError::InvalidMember,
+                    #[allow(deprecated)]
                     "email_unverified" => SharedFolderAccessError::EmailUnverified,
                     "unmounted" => SharedFolderAccessError::Unmounted,
                     _ => SharedFolderAccessError::Other,
@@ -17101,6 +17131,7 @@ impl ::serde::ser::Serialize for SharedFolderAccessError {
                 s.serialize_field(".tag", "invalid_member")?;
                 s.end()
             }
+            #[allow(deprecated)]
             SharedFolderAccessError::EmailUnverified => {
                 // unit
                 let mut s = serializer.serialize_struct("SharedFolderAccessError", 1)?;
@@ -17127,7 +17158,7 @@ impl ::std::fmt::Display for SharedFolderAccessError {
             SharedFolderAccessError::InvalidId => f.write_str("This shared folder ID is invalid."),
             SharedFolderAccessError::NotAMember => f.write_str("The user is not a member of the shared folder thus cannot access it."),
             SharedFolderAccessError::InvalidMember => f.write_str("The user does not exist or their account is disabled."),
-            SharedFolderAccessError::EmailUnverified => f.write_str("Field is deprecated. Never set."),
+            #[allow(deprecated)] SharedFolderAccessError::EmailUnverified => f.write_str("Field is deprecated. Never set."),
             SharedFolderAccessError::Unmounted => f.write_str("The shared folder is unmounted."),
             _ => write!(f, "{:?}", *self),
         }
@@ -18502,6 +18533,7 @@ impl<'de> ::serde::de::Deserialize<'de> for SharedLinkPolicy {
                 };
                 let value = match tag {
                     "anyone" => SharedLinkPolicy::Anyone,
+                    #[allow(deprecated)]
                     "team" => SharedLinkPolicy::Team,
                     "members" => SharedLinkPolicy::Members,
                     _ => SharedLinkPolicy::Other,
@@ -18529,6 +18561,7 @@ impl ::serde::ser::Serialize for SharedLinkPolicy {
                 s.serialize_field(".tag", "anyone")?;
                 s.end()
             }
+            #[allow(deprecated)]
             SharedLinkPolicy::Team => {
                 // unit
                 let mut s = serializer.serialize_struct("SharedLinkPolicy", 1)?;
@@ -18596,6 +18629,8 @@ impl SharedLinkSettings {
         self
     }
 
+    #[deprecated]
+    #[allow(deprecated)]
     pub fn with_requested_visibility(mut self, value: RequestedVisibility) -> Self {
         self.requested_visibility = Some(value);
         self
@@ -18682,7 +18717,7 @@ impl SharedLinkSettings {
             expires: field_expires.and_then(Option::flatten),
             audience: field_audience.and_then(Option::flatten),
             access: field_access.and_then(Option::flatten),
-            requested_visibility: field_requested_visibility.and_then(Option::flatten),
+            #[allow(deprecated)] requested_visibility: field_requested_visibility.and_then(Option::flatten),
             allow_download: field_allow_download.and_then(Option::flatten),
         };
         Ok(result)
@@ -18708,6 +18743,7 @@ impl SharedLinkSettings {
         if let Some(val) = &self.access {
             s.serialize_field("access", val)?;
         }
+        #[allow(deprecated)]
         if let Some(val) = &self.requested_visibility {
             s.serialize_field("requested_visibility", val)?;
         }
@@ -20125,7 +20161,7 @@ impl UpdateFilePolicyArg {
         UpdateFilePolicyArg {
             file,
             actions: None,
-            link_settings: None,
+            #[allow(deprecated)] link_settings: None,
             viewer_info_policy: None,
         }
     }
@@ -20135,6 +20171,8 @@ impl UpdateFilePolicyArg {
         self
     }
 
+    #[deprecated]
+    #[allow(deprecated)]
     pub fn with_link_settings(mut self, value: LinkSettings) -> Self {
         self.link_settings = Some(value);
         self
@@ -20205,7 +20243,7 @@ impl UpdateFilePolicyArg {
         let result = UpdateFilePolicyArg {
             file: field_file.ok_or_else(|| ::serde::de::Error::missing_field("file"))?,
             actions: field_actions.and_then(Option::flatten),
-            link_settings: field_link_settings.and_then(Option::flatten),
+            #[allow(deprecated)] link_settings: field_link_settings.and_then(Option::flatten),
             viewer_info_policy: field_viewer_info_policy.and_then(Option::flatten),
         };
         Ok(Some(result))
@@ -20220,6 +20258,7 @@ impl UpdateFilePolicyArg {
         if let Some(val) = &self.actions {
             s.serialize_field("actions", val)?;
         }
+        #[allow(deprecated)]
         if let Some(val) = &self.link_settings {
             s.serialize_field("link_settings", val)?;
         }
@@ -21002,7 +21041,7 @@ impl UserFileMembershipInfo {
             access_type,
             user,
             permissions: None,
-            initials: None,
+            #[allow(deprecated)] initials: None,
             is_inherited: false,
             time_last_seen: None,
             platform_type: None,
@@ -21014,6 +21053,8 @@ impl UserFileMembershipInfo {
         self
     }
 
+    #[deprecated]
+    #[allow(deprecated)]
     pub fn with_initials(mut self, value: String) -> Self {
         self.initials = Some(value);
         self
@@ -21119,7 +21160,7 @@ impl UserFileMembershipInfo {
             access_type: field_access_type.ok_or_else(|| ::serde::de::Error::missing_field("access_type"))?,
             user: field_user.ok_or_else(|| ::serde::de::Error::missing_field("user"))?,
             permissions: field_permissions.and_then(Option::flatten),
-            initials: field_initials.and_then(Option::flatten),
+            #[allow(deprecated)] initials: field_initials.and_then(Option::flatten),
             is_inherited: field_is_inherited.unwrap_or(false),
             time_last_seen: field_time_last_seen.and_then(Option::flatten),
             platform_type: field_platform_type.and_then(Option::flatten),
@@ -21137,6 +21178,7 @@ impl UserFileMembershipInfo {
         if let Some(val) = &self.permissions {
             s.serialize_field("permissions", val)?;
         }
+        #[allow(deprecated)]
         if let Some(val) = &self.initials {
             s.serialize_field("initials", val)?;
         }
@@ -21188,7 +21230,7 @@ impl From<UserFileMembershipInfo> for UserMembershipInfo {
             access_type: subtype.access_type,
             user: subtype.user,
             permissions: subtype.permissions,
-            initials: subtype.initials,
+            #[allow(deprecated)] initials: subtype.initials,
             is_inherited: subtype.is_inherited,
         }
     }
@@ -21376,7 +21418,7 @@ impl UserMembershipInfo {
             access_type,
             user,
             permissions: None,
-            initials: None,
+            #[allow(deprecated)] initials: None,
             is_inherited: false,
         }
     }
@@ -21386,6 +21428,8 @@ impl UserMembershipInfo {
         self
     }
 
+    #[deprecated]
+    #[allow(deprecated)]
     pub fn with_initials(mut self, value: String) -> Self {
         self.initials = Some(value);
         self
@@ -21465,7 +21509,7 @@ impl UserMembershipInfo {
             access_type: field_access_type.ok_or_else(|| ::serde::de::Error::missing_field("access_type"))?,
             user: field_user.ok_or_else(|| ::serde::de::Error::missing_field("user"))?,
             permissions: field_permissions.and_then(Option::flatten),
-            initials: field_initials.and_then(Option::flatten),
+            #[allow(deprecated)] initials: field_initials.and_then(Option::flatten),
             is_inherited: field_is_inherited.unwrap_or(false),
         };
         Ok(Some(result))
@@ -21481,6 +21525,7 @@ impl UserMembershipInfo {
         if let Some(val) = &self.permissions {
             s.serialize_field("permissions", val)?;
         }
+        #[allow(deprecated)]
         if let Some(val) = &self.initials {
             s.serialize_field("initials", val)?;
         }
@@ -21525,7 +21570,7 @@ impl From<UserMembershipInfo> for MembershipInfo {
         Self {
             access_type: subtype.access_type,
             permissions: subtype.permissions,
-            initials: subtype.initials,
+            #[allow(deprecated)] initials: subtype.initials,
             is_inherited: subtype.is_inherited,
         }
     }

--- a/src/generated/types/team.rs
+++ b/src/generated/types/team.rs
@@ -283,6 +283,7 @@ pub enum AddSecondaryEmailResult {
     /// User already has the maximum number of secondary emails allowed.
     ReachedLimit(crate::types::common::EmailAddress),
     /// Field is deprecated. A transient error occurred. Please try again later.
+    #[deprecated]
     TransientError(crate::types::common::EmailAddress),
     /// An error occurred due to conflicting updates. Please try again later.
     TooManyUpdates(crate::types::common::EmailAddress),
@@ -6034,6 +6035,7 @@ pub struct GroupMembersChangeResult {
     /// Field is deprecated. For legacy purposes async_job_id will always return one space ' '.
     /// Formerly, it was an ID that was used to obtain the status of granting/revoking group-owned
     /// resources. It's no longer necessary because the async processing now happens automatically.
+    #[deprecated]
     pub async_job_id: crate::types::dbx_async::AsyncJobId,
 }
 
@@ -23025,6 +23027,7 @@ pub struct RevokeLinkedApiAppArg {
     pub team_member_id: String,
     /// Field is deprecated. This flag is not longer supported, the application dedicated folder (in
     /// case the application uses one) will be kept.
+    #[deprecated]
     pub keep_app_folder: bool,
 }
 
@@ -28761,6 +28764,7 @@ pub enum TeamMembershipType {
     Full,
     /// Field is deprecated. User does not have access to the shared quota and team admins have
     /// restricted administrative control.
+    #[deprecated]
     Limited,
 }
 
@@ -28819,6 +28823,7 @@ impl ::serde::ser::Serialize for TeamMembershipType {
 #[non_exhaustive] // structs may have more fields added in the future.
 pub struct TeamNamespacesListArg {
     /// Field is deprecated. Specifying a value here has no effect.
+    #[deprecated]
     pub limit: u32,
 }
 

--- a/src/generated/types/team.rs
+++ b/src/generated/types/team.rs
@@ -341,6 +341,7 @@ impl<'de> ::serde::de::Deserialize<'de> for AddSecondaryEmailResult {
                             _ => return Err(de::Error::unknown_field(tag, VARIANTS))
                         }
                     }
+                    #[allow(deprecated)]
                     "transient_error" => {
                         match map.next_key()? {
                             Some("transient_error") => AddSecondaryEmailResult::TransientError(map.next_value()?),
@@ -429,6 +430,7 @@ impl ::serde::ser::Serialize for AddSecondaryEmailResult {
                 s.serialize_field("reached_limit", x)?;
                 s.end()
             }
+            #[allow(deprecated)]
             AddSecondaryEmailResult::TransientError(x) => {
                 // primitive
                 let mut s = serializer.serialize_struct("AddSecondaryEmailResult", 2)?;
@@ -6046,7 +6048,7 @@ impl GroupMembersChangeResult {
     ) -> Self {
         GroupMembersChangeResult {
             group_info,
-            async_job_id,
+            #[allow(deprecated)] async_job_id,
         }
     }
 }
@@ -6093,7 +6095,7 @@ impl GroupMembersChangeResult {
         }
         let result = GroupMembersChangeResult {
             group_info: field_group_info.ok_or_else(|| ::serde::de::Error::missing_field("group_info"))?,
-            async_job_id: field_async_job_id.ok_or_else(|| ::serde::de::Error::missing_field("async_job_id"))?,
+            #[allow(deprecated)] async_job_id: field_async_job_id.ok_or_else(|| ::serde::de::Error::missing_field("async_job_id"))?,
         };
         Ok(Some(result))
     }
@@ -6104,6 +6106,7 @@ impl GroupMembersChangeResult {
     ) -> Result<(), S::Error> {
         use serde::ser::SerializeStruct;
         s.serialize_field("group_info", &self.group_info)?;
+        #[allow(deprecated)]
         s.serialize_field("async_job_id", &self.async_job_id)?;
         Ok(())
     }
@@ -23036,10 +23039,12 @@ impl RevokeLinkedApiAppArg {
         RevokeLinkedApiAppArg {
             app_id,
             team_member_id,
-            keep_app_folder: true,
+            #[allow(deprecated)] keep_app_folder: true,
         }
     }
 
+    #[deprecated]
+    #[allow(deprecated)]
     pub fn with_keep_app_folder(mut self, value: bool) -> Self {
         self.keep_app_folder = value;
         self
@@ -23097,7 +23102,7 @@ impl RevokeLinkedApiAppArg {
         let result = RevokeLinkedApiAppArg {
             app_id: field_app_id.ok_or_else(|| ::serde::de::Error::missing_field("app_id"))?,
             team_member_id: field_team_member_id.ok_or_else(|| ::serde::de::Error::missing_field("team_member_id"))?,
-            keep_app_folder: field_keep_app_folder.unwrap_or(true),
+            #[allow(deprecated)] keep_app_folder: field_keep_app_folder.unwrap_or(true),
         };
         Ok(Some(result))
     }
@@ -23109,6 +23114,7 @@ impl RevokeLinkedApiAppArg {
         use serde::ser::SerializeStruct;
         s.serialize_field("app_id", &self.app_id)?;
         s.serialize_field("team_member_id", &self.team_member_id)?;
+        #[allow(deprecated)]
         if !self.keep_app_folder {
             s.serialize_field("keep_app_folder", &self.keep_app_folder)?;
         }
@@ -28785,6 +28791,7 @@ impl<'de> ::serde::de::Deserialize<'de> for TeamMembershipType {
                 };
                 let value = match tag {
                     "full" => TeamMembershipType::Full,
+                    #[allow(deprecated)]
                     "limited" => TeamMembershipType::Limited,
                     _ => return Err(de::Error::unknown_variant(tag, VARIANTS))
                 };
@@ -28809,6 +28816,7 @@ impl ::serde::ser::Serialize for TeamMembershipType {
                 s.serialize_field(".tag", "full")?;
                 s.end()
             }
+            #[allow(deprecated)]
             TeamMembershipType::Limited => {
                 // unit
                 let mut s = serializer.serialize_struct("TeamMembershipType", 1)?;
@@ -28830,12 +28838,14 @@ pub struct TeamNamespacesListArg {
 impl Default for TeamNamespacesListArg {
     fn default() -> Self {
         TeamNamespacesListArg {
-            limit: 1000,
+            #[allow(deprecated)] limit: 1000,
         }
     }
 }
 
 impl TeamNamespacesListArg {
+    #[deprecated]
+    #[allow(deprecated)]
     pub fn with_limit(mut self, value: u32) -> Self {
         self.limit = value;
         self
@@ -28864,7 +28874,7 @@ impl TeamNamespacesListArg {
             }
         }
         let result = TeamNamespacesListArg {
-            limit: field_limit.unwrap_or(1000),
+            #[allow(deprecated)] limit: field_limit.unwrap_or(1000),
         };
         Ok(result)
     }
@@ -28874,6 +28884,7 @@ impl TeamNamespacesListArg {
         s: &mut S::SerializeStruct,
     ) -> Result<(), S::Error> {
         use serde::ser::SerializeStruct;
+        #[allow(deprecated)]
         if self.limit != 1000 {
             s.serialize_field("limit", &self.limit)?;
         }

--- a/tests/compatibility.rs
+++ b/tests/compatibility.rs
@@ -10,16 +10,18 @@
 fn test_extra_fields() {
     let json = r#"{
         ".tag": "deleted",
-        "name": "f",
+        "name": "spaghetti",
         "some extra field": "whatever",
         "some more": {"some": "complex", "other": "stuff"},
-        "parent_shared_folder_id": "spaghetti",
+        "path_lower": "/pasta/spaghetti",
+        "path_display": "/PASTA/spaghetti",
         "one more extra": "~~~~"
     }"#;
     let x = serde_json::from_str::<dropbox_sdk::files::Metadata>(json).unwrap();
     if let dropbox_sdk::files::Metadata::Deleted(d) = x {
-        assert_eq!("f", &d.name);
-        assert_eq!(Some("spaghetti"), d.parent_shared_folder_id.as_deref());
+        assert_eq!("spaghetti", d.name);
+        assert_eq!(Some("/pasta/spaghetti"), d.path_lower.as_deref());
+        assert_eq!(Some("/PASTA/spaghetti"), d.path_display.as_deref());
     } else {
         panic!("wrong variant");
     }


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description below.
-->

The most recent spec update added deprecation and preview annotations in several places. This change adds them to the Rust code as well.

## **Checklist**

**General Contributing**
<!-- Change [ ] to [x] if you have: -->
- [x] I have read the Code of Conduct and signed the [CLA](https://opensource.dropbox.com/cla/).
- [x] I have added an entry to the `RELEASE_NOTES.md` file, or believe it's not necessary for this change.

**Validation**
<!-- Describe which tests cover the changes you've made, and any additional manual validation you
     did to ensure the correctness of this change. Does this change warrant addition of new tests?
     Does this change have performance implications? Etc. -->
Generated tests updated correspondingly.