### PR TITLE
correct dep versions for -Z minimal-versions

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,18 +15,18 @@ readme = "README.md"
 rust-version = "1.85.0" # Feb 20, 2025
 
 [dependencies]
-async-lock = "3.3.0"
+async-lock = "3"
 base64 = "0.22"
-bytes = "1.6.0"
+bytes = "1"
 log = "0.4"
 ring = "0.17"
-serde = { version = "1.0", features = ["derive"] }
-serde_json = "1.0"
-thiserror = "2.0"
-url = "2.1"
+serde = { version = "1", features = ["derive"] }
+serde_json = "1.0.25"
+thiserror = "2"
+url = "2"
 
 [dependencies.futures]
-version = "0.3.30"
+version = "0.3"
 default-features = false
 features = ["std"]
 
@@ -37,23 +37,23 @@ default-features = false
 features = ["http2", "rustls", "stream"]
 
 [dependencies.ureq]
-version = "3.0.4"
+version = "3"
 optional = true
 default-features = false
 features = ["rustls"]
 
 [dev-dependencies]
 env_logger = "0.11"
-chrono = "0.4"
+chrono = "0.4.31"
 parallel_reader = "0.1"
-threadpool = "1.8"
+threadpool = "1.4"
 
 [dev-dependencies.tokio]
-version = "1.37.0"
+version = "1"
 features = ["rt-multi-thread", "macros", "io-std"]
 
 [dev-dependencies.tokio-util]
-version = "0.7.10"
+version = "0.7"
 default-features = false
 features = ["compat"]
 


### PR DESCRIPTION
I made the versions as general as possible, only specifying specific versions where necessary to allow a `cargo test --all-features` to complete after running `cargo update -Z minimal-versions`.

Only chrono, serde_json, and threadpool needed extra tightening to avoid build failures with their semver minimal versions.

It will print a lot of warnings while building (around serde Deserialize impls) but everything works with minimal versions.

<!--
Thank you for your pull request. Please provide a description below.
-->

## **Checklist**

**General Contributing**
<!-- Change [ ] to [x] if you have: -->
- [x] I have read the Code of Conduct and signed the [CLA](https://opensource.dropbox.com/cla/).
- [x] I have added an entry to the `RELEASE_NOTES.md` file, or believe it's not necessary for this change.

**Validation**
<!-- Describe which tests cover the changes you've made, and any additional manual validation you
     did to ensure the correctness of this change. Does this change warrant addition of new tests?
     Does this change have performance implications? Etc. -->
see change description